### PR TITLE
Make active/inactive medications more distinctive

### DIFF
--- a/frontend/src/components/adapters/ResponsiveTable.js
+++ b/frontend/src/components/adapters/ResponsiveTable.js
@@ -324,6 +324,10 @@ export const ResponsiveTable = memo(({
           const rowKey = row.id || row.key || index;
           const isSelected = selectedRows.includes(rowKey);
           
+          // Check if row is inactive/stopped/finished/completed/on-hold (for medical context)
+          const isInactive = medicalContext !== 'general' &&
+            ['inactive', 'stopped', 'completed', 'cancelled', 'on-hold'].includes(row.status?.toLowerCase());
+
           return (
             <MantineTable.Tr
               key={rowKey}
@@ -331,9 +335,13 @@ export const ResponsiveTable = memo(({
               onDoubleClick={onRowDoubleClick ? (event) => onRowDoubleClick(row, index, event) : undefined}
               style={{
                 cursor: onRowClick || selectable ? 'pointer' : 'default',
-                backgroundColor: isSelected ? 'var(--mantine-color-blue-0)' : undefined
+                backgroundColor: isSelected ? 'var(--mantine-color-blue-0)' : undefined,
+                borderLeft: isInactive
+                  ? '4px solid var(--mantine-color-red-6)'
+                  : '4px solid var(--mantine-color-green-6)'
               }}
               data-selected={isSelected}
+              data-inactive={isInactive}
             >
               {visibleColumns.map((column) => {
                 const columnKey = column.key || column.dataIndex || column.name || column.accessor;
@@ -374,7 +382,11 @@ export const ResponsiveTable = memo(({
         {processedData.map((row, index) => {
           const rowKey = row.id || row.key || index;
           const isSelected = selectedRows.includes(rowKey);
-          
+
+          // Check if row is inactive/stopped/finished/completed/on-hold (for medical context)
+          const isInactive = medicalContext !== 'general' &&
+            ['inactive', 'stopped', 'completed', 'cancelled', 'on-hold'].includes(row.status?.toLowerCase());
+
           return (
             <Card
               key={rowKey}
@@ -382,11 +394,15 @@ export const ResponsiveTable = memo(({
               shadow="xs"
               p={compactMode ? "xs" : "sm"}
               onClick={(event) => handleRowClick(row, index, event)}
-              style={{ 
+              style={{
                 cursor: onRowClick || selectable ? 'pointer' : 'default',
-                borderColor: isSelected ? 'var(--mantine-color-blue-6)' : undefined
+                borderColor: isSelected ? 'var(--mantine-color-blue-6)' : undefined,
+                borderLeft: isInactive
+                  ? '4px solid var(--mantine-color-red-6)'
+                  : '4px solid var(--mantine-color-green-6)'
               }}
               data-selected={isSelected}
+              data-inactive={isInactive}
             >
               <Stack gap={compactMode ? "xs" : "sm"}>
                 {displayFields.map((field, fieldIndex) => {
@@ -597,28 +613,42 @@ export const ResponsiveTable = memo(({
       </MantineTable.Thead>
       {/* Render rows with print config (all columns) */}
       <MantineTable.Tbody>
-        {processedData.map((row, rowIndex) => (
-          <MantineTable.Tr key={row.id || rowIndex}>
-            {printTableConfig.visibleColumns.map((column, colIndex) => {
+        {processedData.map((row, rowIndex) => {
+          // Check if row is inactive/stopped/finished/completed/on-hold (for medical context)
+          const isInactive = medicalContext !== 'general' &&
+            ['inactive', 'stopped', 'completed', 'cancelled', 'on-hold'].includes(row.status?.toLowerCase());
+
+          return (
+            <MantineTable.Tr
+              key={row.id || rowIndex}
+              style={{
+                borderLeft: isInactive
+                  ? '4px solid var(--mantine-color-red-6)'
+                  : '4px solid var(--mantine-color-green-6)'
+              }}
+              data-inactive={isInactive}
+            >
+              {printTableConfig.visibleColumns.map((column, colIndex) => {
               const columnKey = getColumnKey(column);
               const cellValue = row[columnKey];
               const formatter = formatters?.[columnKey];
               const formattedValue = formatter ? formatter(cellValue, row) : (cellValue?.toString() || '');
 
-              return (
-                <MantineTable.Td key={columnKey || colIndex}>
-                  <Text size="xs">
-                    {typeof formattedValue === 'string' || typeof formattedValue === 'number' ? (
-                      formattedValue
-                    ) : (
-                      formattedValue
-                    )}
-                  </Text>
-                </MantineTable.Td>
-              );
-            })}
-          </MantineTable.Tr>
-        ))}
+                return (
+                  <MantineTable.Td key={columnKey || colIndex}>
+                    <Text size="xs">
+                      {typeof formattedValue === 'string' || typeof formattedValue === 'number' ? (
+                        formattedValue
+                      ) : (
+                        formattedValue
+                      )}
+                    </Text>
+                  </MantineTable.Td>
+                );
+              })}
+            </MantineTable.Tr>
+          );
+        })}
       </MantineTable.Tbody>
     </MantineTable>
   );

--- a/frontend/src/components/medical/medications/MedicationCard.js
+++ b/frontend/src/components/medical/medications/MedicationCard.js
@@ -25,13 +25,24 @@ const MedicationCard = ({
     return indication || 'No indication specified';
   };
 
+  // Check if medication is inactive/stopped/finished/completed/on-hold
+  const isInactive = ['inactive', 'stopped', 'completed', 'cancelled', 'on-hold'].includes(
+    medication.status?.toLowerCase()
+  );
+
   return (
     <Card
       withBorder
       shadow="sm"
       radius="md"
       h="100%"
-      style={{ display: 'flex', flexDirection: 'column' }}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        borderLeft: isInactive
+          ? '4px solid var(--mantine-color-red-6)'
+          : '4px solid var(--mantine-color-green-6)'
+      }}
     >
       <Stack gap="sm" style={{ flex: 1 }}>
         <Group justify="space-between" align="flex-start">

--- a/frontend/src/pages/medical/Medication.js
+++ b/frontend/src/pages/medical/Medication.js
@@ -497,6 +497,7 @@ const Medication = () => {
                 onDelete={handleDeleteMedication}
                 formatters={formatters}
                 dataType="medical"
+                medicalContext="medications"
                 responsive={responsive}
               />
             </Paper>


### PR DESCRIPTION
This pull request enhances the visual distinction of inactive or completed rows in medical-related tables and cards. It introduces a consistent left border color (red for inactive, green for active) to quickly indicate the status of items such as medications. Additionally, it passes a `medicalContext` prop to ensure context-aware rendering in the `ResponsiveTable`.

**Visual status indication improvements:**

* Added a colored left border (`red` for inactive statuses like "stopped", "completed", "on-hold", etc.; `green` otherwise) to each row in `ResponsiveTable` and to `MedicationCard` for clear, immediate feedback on item status. This is determined by checking the `status` field of each row or medication. [[1]](diffhunk://#diff-0d37d3d2889ec2cb6d708a2ef57057db7b0becd84983fca00f57c23946581135R327-R344) [[2]](diffhunk://#diff-0d37d3d2889ec2cb6d708a2ef57057db7b0becd84983fca00f57c23946581135R386-R389) [[3]](diffhunk://#diff-0d37d3d2889ec2cb6d708a2ef57057db7b0becd84983fca00f57c23946581135L387-R405) [[4]](diffhunk://#diff-0d37d3d2889ec2cb6d708a2ef57057db7b0becd84983fca00f57c23946581135L600-R630) [[5]](diffhunk://#diff-0d37d3d2889ec2cb6d708a2ef57057db7b0becd84983fca00f57c23946581135L621-R651) [[6]](diffhunk://#diff-3a3ce8bb9c777885aa0b4f06c759731ad6e73c37f5904892ee84f83dc6812dc6R28-R45)

* Added a `data-inactive` attribute to rows and cards for potential use in styling or testing. [[1]](diffhunk://#diff-0d37d3d2889ec2cb6d708a2ef57057db7b0becd84983fca00f57c23946581135R327-R344) [[2]](diffhunk://#diff-0d37d3d2889ec2cb6d708a2ef57057db7b0becd84983fca00f57c23946581135R386-R389) [[3]](diffhunk://#diff-0d37d3d2889ec2cb6d708a2ef57057db7b0becd84983fca00f57c23946581135L387-R405) [[4]](diffhunk://#diff-0d37d3d2889ec2cb6d708a2ef57057db7b0becd84983fca00f57c23946581135L600-R630)

**Context-aware rendering:**

* Passed a `medicalContext="medications"` prop to the `ResponsiveTable` in the medication page to enable the new status-based styling logic.