### PR TITLE
Enhance Vitals functionality and UI for better user interaction

### DIFF
--- a/frontend/src/constants/vitalFilters.js
+++ b/frontend/src/constants/vitalFilters.js
@@ -1,0 +1,24 @@
+/**
+ * Constants for vital signs filtering types
+ * Used to prevent typos and maintain consistency across vitals filtering
+ */
+
+export const VITAL_FILTER_TYPES = {
+  ALL: 'all',
+  WITH_BLOOD_PRESSURE: 'with_bp',
+  WITH_HEART_RATE: 'with_heart_rate',
+  WITH_TEMPERATURE: 'with_temperature',
+  WITH_WEIGHT: 'with_weight',
+  WITH_VITALS: 'with_vitals',
+  COMPLETE: 'complete',
+};
+
+export const VITAL_FILTER_LABELS = {
+  [VITAL_FILTER_TYPES.ALL]: 'All Records',
+  [VITAL_FILTER_TYPES.WITH_BLOOD_PRESSURE]: 'With Blood Pressure',
+  [VITAL_FILTER_TYPES.WITH_HEART_RATE]: 'With Heart Rate',
+  [VITAL_FILTER_TYPES.WITH_TEMPERATURE]: 'With Temperature',
+  [VITAL_FILTER_TYPES.WITH_WEIGHT]: 'With Weight',
+  [VITAL_FILTER_TYPES.WITH_VITALS]: 'With Core Vitals',
+  [VITAL_FILTER_TYPES.COMPLETE]: 'Complete Records',
+};

--- a/frontend/src/utils/medicalPageConfigs.js
+++ b/frontend/src/utils/medicalPageConfigs.js
@@ -971,6 +971,8 @@ export const medicalPageConfigs = {
       categoryOptions: [
         { value: 'all', label: 'All Records' },
         { value: 'with_bp', label: 'With Blood Pressure' },
+        { value: 'with_heart_rate', label: 'With Heart Rate' },
+        { value: 'with_temperature', label: 'With Temperature' },
         { value: 'with_weight', label: 'With Weight' },
         { value: 'with_vitals', label: 'With Core Vitals' },
         { value: 'complete', label: 'Complete Records' },
@@ -980,6 +982,10 @@ export const medicalPageConfigs = {
           switch (filterValue) {
             case 'with_bp':
               return item.systolic_bp != null && item.diastolic_bp != null;
+            case 'with_heart_rate':
+              return item.heart_rate != null;
+            case 'with_temperature':
+              return item.temperature != null;
             case 'with_weight':
               return item.weight != null;
             case 'with_vitals':


### PR DESCRIPTION
This pull request enhances both backend and frontend handling of patient vital signs, focusing on improving BMI calculation robustness and providing a more interactive filtering experience for vitals in the UI. The backend now attempts to calculate BMI from the latest weight and height if not directly available, while the frontend introduces filter constants, clickable stat cards for filtering, and clearer filter feedback for users.

**Backend improvements for BMI calculation:**

- The `get_vitals_stats` method in `app/crud/vitals.py` now attempts to calculate BMI from the latest weight and height if no BMI is stored, including validation for reasonable medical ranges (weight: 50–1000 lbs, height: 24–96 inches). [[1]](diffhunk://#diff-7f1e67ef5db1937e5ff51a76f899dafbf9e1d189205a701c158b74d5048ee0aeL124-R124) [[2]](diffhunk://#diff-7f1e67ef5db1937e5ff51a76f899dafbf9e1d189205a701c158b74d5048ee0aeR133-R154)

**Frontend filtering and interaction enhancements:**

*Filtering constants and configuration:*

- Added `VITAL_FILTER_TYPES` and `VITAL_FILTER_LABELS` constants in `frontend/src/constants/vitalFilters.js` to standardize filter keys and labels across the application.
- Updated `medicalPageConfigs.js` to include new filter options for heart rate and temperature, and added corresponding filter logic to support these new types. [[1]](diffhunk://#diff-1883bea589ffd8ccbd105ae1de1bda91b514008b72ab1fd9067c6d2976e73f2cR974-R975) [[2]](diffhunk://#diff-1883bea589ffd8ccbd105ae1de1bda91b514008b72ab1fd9067c6d2976e73f2cR985-R988)

*Vitals page UI improvements:*

- Updated `STATS_CONFIGS` in `frontend/src/pages/medical/Vitals.js` to associate each stat with a filter type and description, enabling stat cards to act as filter triggers. [[1]](diffhunk://#diff-d84c5e5431e47100153096c83f1e542df9e5182bd76e6efa0455140317cd6278R53-R55) [[2]](diffhunk://#diff-d84c5e5431e47100153096c83f1e542df9e5182bd76e6efa0455140317cd6278R67-R68) [[3]](diffhunk://#diff-d84c5e5431e47100153096c83f1e542df9e5182bd76e6efa0455140317cd6278R84-R85) [[4]](diffhunk://#diff-d84c5e5431e47100153096c83f1e542df9e5182bd76e6efa0455140317cd6278R101-R102) [[5]](diffhunk://#diff-d84c5e5431e47100153096c83f1e542df9e5182bd76e6efa0455140317cd6278R112-R113) [[6]](diffhunk://#diff-d84c5e5431e47100153096c83f1e542df9e5182bd76e6efa0455140317cd6278R123-R124)
- Added interactive behavior to stat cards: clicking (or keyboard activating) a card filters the vitals table below by the corresponding vital type, with visual feedback for active filters and improved accessibility. [[1]](diffhunk://#diff-d84c5e5431e47100153096c83f1e542df9e5182bd76e6efa0455140317cd6278R229-R241) [[2]](diffhunk://#diff-d84c5e5431e47100153096c83f1e542df9e5182bd76e6efa0455140317cd6278R345-R388)
- Displays a badge above the stats cards when a filter is active, allowing users to easily clear the filter with a single click. [[1]](diffhunk://#diff-d84c5e5431e47100153096c83f1e542df9e5182bd76e6efa0455140317cd6278R549-R564) [[2]](diffhunk://#diff-d84c5e5431e47100153096c83f1e542df9e5182bd76e6efa0455140317cd6278R575-R576)
- Updated the health summary subtitle to indicate that cards are clickable for filtering.