### PR TITLE
Implement default admin password configuration 

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,20 @@ http://localhost:8005
 
 ### Default Login
 
+On fresh installations, a default admin user is created:
 - Username: `admin`
-- Password: `admin123`
+- Password: `admin123` (default)
+
+**Customizing the Default Password:**
+
+You can set a custom default admin password for fresh installations using the `ADMIN_DEFAULT_PASSWORD` environment variable:
+
+```bash
+# Set in your .env file or as environment variable
+ADMIN_DEFAULT_PASSWORD=your_secure_password_here
+```
+
+**Note:** This only affects the initial admin user creation on fresh installations. It does not change passwords for existing users. Always change the default password after your first login.
 
 ## Backup and Restore
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -89,6 +89,9 @@ class Settings:  # App Info
         os.getenv("ALLOW_USER_REGISTRATION", "True").lower() == "true"
     )  # Default: enabled to avoid lockout scenarios
 
+    # Default Admin Password Configuration
+    ADMIN_DEFAULT_PASSWORD: str = os.getenv("ADMIN_DEFAULT_PASSWORD", "admin123")
+
     # SSO Configuration (Simple and Right-Sized)
     SSO_ENABLED: bool = os.getenv("SSO_ENABLED", "False").lower() == "true"
     SSO_PROVIDER_TYPE: str = os.getenv("SSO_PROVIDER_TYPE", "oidc")

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -173,11 +173,12 @@ def create_default_user():
 
         if admin_count == 0:
             # No admin users exist - create default admin
+            default_password = settings.ADMIN_DEFAULT_PASSWORD
             AuthService.create_user(
-                db, username="admin", password="admin123", is_superuser=True
+                db, username="admin", password=default_password, is_superuser=True
             )
             print("✅ Fresh installation detected - Default admin user created")
-            print("   Username: admin, Password: admin123")
+            print("   Username: admin")
             print("   🔐 Please change the default password after first login!")
         else:
             print(

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -12,6 +12,10 @@ TZ=America/New_York
 # SSL Configuration
 ENABLE_SSL=false
 
+# Default Admin Password Configuration
+# Set custom password for the default admin user (defaults to admin123 if not set)
+## ADMIN_DEFAULT_PASSWORD=your-custom-admin-password
+
 # GitHub SSO Configuration
 SSO_ENABLED=true
 SSO_PROVIDER_TYPE=github

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,12 +11,12 @@ services:
       - postgres_data-prod:/var/lib/postgresql/data
       - ./postgres/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
     ports:
-      - '5432:5432'
+      - "5432:5432"
     healthcheck:
       test:
         [
-          'CMD-SHELL',
-          'pg_isready -U ${DB_USER:-medapp} -d ${DB_NAME:-medical_records}',
+          "CMD-SHELL",
+          "pg_isready -U ${DB_USER:-medapp} -d ${DB_NAME:-medical_records}",
         ]
       interval: 60s
       timeout: 10s
@@ -55,6 +55,9 @@ services:
       SSO_REDIRECT_URI: ${SSO_REDIRECT_URI:-}
       SSO_ALLOWED_DOMAINS: ${SSO_ALLOWED_DOMAINS:-[]}
 
+      # Default Admin Password Configuration (optional - defaults to admin123 in app if not set)
+      #ADMIN_DEFAULT_PASSWORD: ${ADMIN_DEFAULT_PASSWORD:-}
+
       #PUID: ${PUID} # Enable if using bind mounts
       #PGID: ${PGID} # Enable if using bind mounts
     volumes:
@@ -68,7 +71,7 @@ services:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: ['CMD', 'curl', '-f', '-k', 'http://localhost:8000/health']
+      test: ["CMD", "curl", "-f", "-k", "http://localhost:8000/health"]
       interval: 120s
       timeout: 15s
       retries: 2


### PR DESCRIPTION
This pull request introduces a configurable default admin password for fresh installations, making it easier and more secure to set up the application in different environments. It also updates documentation and environment files to reflect this new option, and makes minor formatting improvements to the Docker Compose configuration.

**Default Admin Password Configuration:**

* Added `ADMIN_DEFAULT_PASSWORD` to the `Settings` class in `app/core/config.py`, allowing the default admin password to be set via an environment variable (defaults to `admin123` if not specified).
* Updated the default admin user creation logic in `app/core/database.py` to use the `ADMIN_DEFAULT_PASSWORD` setting instead of a hardcoded password, and improved the print statements to prompt users to change the default password.
* Documented the new `ADMIN_DEFAULT_PASSWORD` option in `docker/.env.example`, including usage instructions.
* Added commented-out support for the `ADMIN_DEFAULT_PASSWORD` environment variable in the `medapp` service section of `docker/docker-compose.yml`.

**Formatting and Consistency Improvements:**

* Standardized the formatting of port and healthcheck command definitions in `docker/docker-compose.yml` for consistency and readability. [[1]](diffhunk://#diff-423deb13b7c401b1a7f41ee91c77f722e11d2f317d6a66b546524e8a04cc8b03L14-R19) [[2]](diffhunk://#diff-423deb13b7c401b1a7f41ee91c77f722e11d2f317d6a66b546524e8a04cc8b03L71-R74)