### PR TITLE
Feat: Implement trend tracking for lab test components

### DIFF
--- a/app/api/v1/endpoints/lab_test_component.py
+++ b/app/api/v1/endpoints/lab_test_component.py
@@ -1,4 +1,6 @@
 from typing import Any, Dict, List, Optional
+from datetime import datetime
+from datetime import date as date_type
 
 from fastapi import (
     APIRouter,
@@ -37,6 +39,10 @@ from app.schemas.lab_test_component import (
     LabTestComponentResponse,
     LabTestComponentUpdate,
     LabTestComponentWithLabResult,
+    LabTestComponentTrendResponse,
+    LabTestComponentTrendDataPoint,
+    LabTestComponentTrendStatistics,
+    LabResultBasicForTrend,
 )
 from app.core.logging_config import get_logger
 
@@ -461,3 +467,226 @@ def get_abbreviation_suggestions(
         abbreviations = lab_test_component.get_unique_abbreviations(db, limit=limit)
 
     return abbreviations
+
+
+# Helper function for trend statistics
+def calculate_trend_statistics(components: List[Any]) -> LabTestComponentTrendStatistics:
+    """Calculate statistics for trend data."""
+    if not components:
+        return LabTestComponentTrendStatistics(
+            count=0,
+            normal_count=0,
+            abnormal_count=0,
+            trend_direction="stable"
+        )
+
+    values = [c.value for c in components]
+
+    # Basic stats
+    count = len(values)
+    latest = values[0] if values else None
+    average = sum(values) / count if count > 0 else None
+    minimum = min(values) if values else None
+    maximum = max(values) if values else None
+
+    # Trend direction (compare first half vs second half)
+    trend = "stable"
+    if count >= 4:
+        mid = count // 2
+        first_half_avg = sum(values[:mid]) / mid
+        second_half_avg = sum(values[mid:]) / (count - mid)
+
+        # Only calculate percentage if first_half_avg is meaningful
+        # Use absolute threshold to avoid division by zero and unstable percentages
+        if abs(first_half_avg) > 0.01:
+            change_percent = ((second_half_avg - first_half_avg) / abs(first_half_avg)) * 100
+
+            if change_percent > 5:
+                trend = "increasing"
+            elif change_percent < -5:
+                trend = "decreasing"
+        elif abs(second_half_avg - first_half_avg) > 0.01:
+            # For near-zero values, use absolute difference instead of percentage
+            if second_half_avg > first_half_avg:
+                trend = "increasing"
+            elif second_half_avg < first_half_avg:
+                trend = "decreasing"
+
+    # Time in range (count normal vs abnormal)
+    normal_count = sum(1 for c in components if c.status == "normal")
+    time_in_range_percent = (normal_count / count * 100) if count > 0 else None
+
+    # Standard deviation
+    if count > 1 and average is not None:
+        variance = sum((x - average) ** 2 for x in values) / count
+        std_dev = variance ** 0.5
+    else:
+        std_dev = None
+
+    return LabTestComponentTrendStatistics(
+        count=count,
+        latest=round(latest, 2) if latest is not None else None,
+        average=round(average, 2) if average is not None else None,
+        min=round(minimum, 2) if minimum is not None else None,
+        max=round(maximum, 2) if maximum is not None else None,
+        std_dev=round(std_dev, 2) if std_dev is not None else None,
+        trend_direction=trend,
+        time_in_range_percent=round(time_in_range_percent, 1) if time_in_range_percent is not None else None,
+        normal_count=normal_count,
+        abnormal_count=count - normal_count
+    )
+
+
+# Trend Tracking Endpoint
+@router.get("/patient/{patient_id}/trends/{test_name}", response_model=LabTestComponentTrendResponse)
+def get_lab_test_component_trends(
+    *,
+    request: Request,
+    patient_id: int,
+    test_name: str,
+    date_from: Optional[date_type] = Query(None, description="Start date (YYYY-MM-DD)"),
+    date_to: Optional[date_type] = Query(None, description="End date (YYYY-MM-DD)"),
+    limit: int = Query(100, ge=1, le=100, description="Max results (max 100)"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(deps.get_current_user),
+):
+    """
+    Get trend data for a specific test component across all lab results for a patient.
+    Returns historical values with statistics.
+
+    Decision: Uses exact test name matching (no fuzzy matching).
+    Decision: Uses lab_result.completed_date if available, otherwise created_at.
+    Decision: Shows warnings in response for unit mismatches or missing dates (handled client-side).
+    """
+
+    with handle_database_errors(request=request):
+        # Verify patient access
+        deps.verify_patient_access(patient_id, db, current_user)
+
+        # Validate and sanitize test_name
+        validated_test_name = validate_search_input(test_name)
+
+        # Get all test components for this patient and test name
+        components = lab_test_component.get_by_patient_and_test_name(
+            db,
+            patient_id=patient_id,
+            test_name=validated_test_name
+        )
+
+        # Helper function to get recorded date for a component
+        def get_recorded_date(component):
+            """Get the recorded date, preferring completed_date over created_at."""
+            return component.lab_result.completed_date if component.lab_result.completed_date else component.created_at.date()
+
+        # Apply date filtering if provided (FastAPI already parsed dates)
+        if date_from or date_to:
+            filtered_components = []
+            for component in components:
+                recorded_date = get_recorded_date(component)
+
+                if date_from and recorded_date < date_from:
+                    continue
+                if date_to and recorded_date > date_to:
+                    continue
+
+                filtered_components.append(component)
+
+            components = filtered_components
+
+        # Sort by date (most recent first)
+        components.sort(key=get_recorded_date, reverse=True)
+
+        # Apply limit
+        components = components[:limit]
+
+        # Detect unit mismatches
+        if components:
+            primary_unit = components[0].unit
+            units_found = set(c.unit for c in components if c.unit)
+            if len(units_found) > 1:
+                logger.warning(
+                    f"Unit mismatch detected in trend data for {test_name}",
+                    extra={
+                        "user_id": current_user.id,
+                        "patient_id": patient_id,
+                        "test_name": test_name,
+                        "primary_unit": primary_unit,
+                        "all_units": list(units_found),
+                        "component": "lab_test_component_trends"
+                    }
+                )
+
+        # Log the request
+        logger.info(
+            f"Trend data requested for patient {patient_id}, test: {test_name}",
+            extra={
+                "user_id": current_user.id,
+                "patient_id": patient_id,
+                "test_name": test_name,
+                "date_from": str(date_from) if date_from else None,
+                "date_to": str(date_to) if date_to else None,
+                "data_point_count": len(components),
+                "component": "lab_test_component_trends"
+            }
+        )
+
+        # Return empty response if no components found
+        if not components:
+            return LabTestComponentTrendResponse(
+                test_name=test_name,
+                unit="",
+                category=None,
+                data_points=[],
+                statistics=LabTestComponentTrendStatistics(
+                    count=0,
+                    normal_count=0,
+                    abnormal_count=0,
+                    trend_direction="stable"
+                ),
+                is_aggregated=False,
+                aggregation_period=None
+            )
+
+        # Calculate statistics
+        statistics = calculate_trend_statistics(components)
+
+        # Build data points with proper date handling
+        data_points = []
+        for component in components:
+            # Use completed_date if available
+            recorded_date = component.lab_result.completed_date if component.lab_result.completed_date else None
+
+            data_point = LabTestComponentTrendDataPoint(
+                id=component.id,
+                value=component.value,
+                unit=component.unit,
+                status=component.status,
+                ref_range_min=component.ref_range_min,
+                ref_range_max=component.ref_range_max,
+                ref_range_text=component.ref_range_text,
+                recorded_date=recorded_date,
+                created_at=component.created_at,
+                lab_result=LabResultBasicForTrend(
+                    id=component.lab_result.id,
+                    test_name=component.lab_result.test_name,
+                    completed_date=component.lab_result.completed_date
+                )
+            )
+            data_points.append(data_point)
+
+        # Get unit and category from most recent component
+        unit = components[0].unit
+        category = components[0].category
+
+        # Build response
+        response = LabTestComponentTrendResponse(
+            test_name=test_name,
+            unit=unit,
+            category=category,
+            data_points=data_points,
+            statistics=statistics,
+            is_aggregated=False,
+            aggregation_period=None
+        )
+
+        return response

--- a/app/crud/lab_test_component.py
+++ b/app/crud/lab_test_component.py
@@ -172,16 +172,17 @@ class CRUDLabTestComponent(CRUDBase[LabTestComponent, LabTestComponentCreate, La
     def get_by_patient_and_test_name(
         self, db: Session, *, patient_id: int, test_name: str
     ) -> List[LabTestComponent]:
-        """Get all test components for a patient by test name (across all lab results)"""
+        """Get all test components for a patient by exact test name (case-insensitive, across all lab results)"""
         return (
             db.query(self.model)
             .join(self.model.lab_result)
             .filter(
                 and_(
                     self.model.lab_result.has(patient_id=patient_id),
-                    self.model.test_name.ilike(f"%{test_name}%")
+                    self.model.test_name.ilike(test_name)  # Exact match, case-insensitive
                 )
             )
+            .options(joinedload(self.model.lab_result))  # Prevent N+1 queries
             .order_by(self.model.created_at.desc())
             .all()
         )

--- a/app/crud/lab_test_component.py
+++ b/app/crud/lab_test_component.py
@@ -170,10 +170,26 @@ class CRUDLabTestComponent(CRUDBase[LabTestComponent, LabTestComponentCreate, La
         )
 
     def get_by_patient_and_test_name(
-        self, db: Session, *, patient_id: int, test_name: str
+        self,
+        db: Session,
+        *,
+        patient_id: int,
+        test_name: str,
+        date_from: Optional[Any] = None,
+        date_to: Optional[Any] = None,
+        limit: Optional[int] = None
     ) -> List[LabTestComponent]:
-        """Get all test components for a patient by exact test name (case-insensitive, across all lab results)"""
-        return (
+        """
+        Get all test components for a patient by exact test name (case-insensitive, across all lab results).
+
+        Date filtering uses lab_result.completed_date if available, falls back to created_at.
+        This pushes filtering into the database query for better performance.
+        """
+        from app.models.models import LabResult
+        from sqlalchemy import case, func
+
+        # Build base query with join
+        query = (
             db.query(self.model)
             .join(self.model.lab_result)
             .filter(
@@ -182,10 +198,39 @@ class CRUDLabTestComponent(CRUDBase[LabTestComponent, LabTestComponentCreate, La
                     self.model.test_name.ilike(test_name)  # Exact match, case-insensitive
                 )
             )
-            .options(joinedload(self.model.lab_result))  # Prevent N+1 queries
-            .order_by(self.model.created_at.desc())
-            .all()
         )
+
+        # Apply date filters if provided
+        # Use COALESCE to prefer completed_date over created_at date
+        if date_from or date_to:
+            # Create a subquery that calculates the recorded date
+            recorded_date_expr = func.coalesce(
+                LabResult.completed_date,
+                func.date(self.model.created_at)
+            )
+
+            if date_from:
+                query = query.filter(recorded_date_expr >= date_from)
+            if date_to:
+                query = query.filter(recorded_date_expr <= date_to)
+
+        # Add sorting - prefer completed_date, fall back to created_at
+        # Most recent first
+        query = query.order_by(
+            func.coalesce(
+                LabResult.completed_date,
+                func.date(self.model.created_at)
+            ).desc()
+        )
+
+        # Apply limit if provided
+        if limit:
+            query = query.limit(limit)
+
+        # Eager load lab_result to prevent N+1 queries
+        query = query.options(joinedload(self.model.lab_result))
+
+        return query.all()
 
     def bulk_create(
         self, db: Session, *, obj_in: LabTestComponentBulkCreate

--- a/app/schemas/lab_test_component.py
+++ b/app/schemas/lab_test_component.py
@@ -1,5 +1,5 @@
 import math
-from datetime import datetime
+from datetime import date, datetime
 from typing import List, Optional
 
 from pydantic import BaseModel, field_validator, model_validator
@@ -336,3 +336,59 @@ class LabTestComponentBulkResponse(BaseModel):
     errors: Optional[List[str]] = []
 
     model_config = {"from_attributes": True}
+
+
+# Trend tracking schemas
+
+class LabResultBasicForTrend(BaseModel):
+    """Minimal lab result info for trend data points"""
+
+    id: int
+    test_name: str
+    completed_date: Optional[date] = None
+
+    model_config = {"from_attributes": True}
+
+
+class LabTestComponentTrendDataPoint(BaseModel):
+    """Single data point in trend data"""
+
+    id: int
+    value: float
+    unit: str
+    status: Optional[str] = None
+    ref_range_min: Optional[float] = None
+    ref_range_max: Optional[float] = None
+    ref_range_text: Optional[str] = None
+    recorded_date: Optional[date] = None
+    created_at: datetime
+    lab_result: LabResultBasicForTrend
+
+    model_config = {"from_attributes": True}
+
+
+class LabTestComponentTrendStatistics(BaseModel):
+    """Statistics for trend data"""
+
+    count: int
+    latest: Optional[float] = None
+    average: Optional[float] = None
+    min: Optional[float] = None
+    max: Optional[float] = None
+    std_dev: Optional[float] = None
+    trend_direction: str  # "increasing", "decreasing", "stable"
+    time_in_range_percent: Optional[float] = None
+    normal_count: int
+    abnormal_count: int
+
+
+class LabTestComponentTrendResponse(BaseModel):
+    """Response for trend data request"""
+
+    test_name: str
+    unit: str
+    category: Optional[str] = None
+    data_points: List[LabTestComponentTrendDataPoint]
+    statistics: LabTestComponentTrendStatistics
+    is_aggregated: bool = False
+    aggregation_period: Optional[str] = None  # "month", "week", etc.

--- a/frontend/src/components/medical/labresults/LabResultViewModal.js
+++ b/frontend/src/components/medical/labresults/LabResultViewModal.js
@@ -41,7 +41,15 @@ const LabResultViewModal = ({
   isBlocking,
   onError
 }) => {
+  // Reset activeTab when modal opens with new labResult
   const [activeTab, setActiveTab] = useState('overview');
+
+  // Reset tab when labResult changes
+  React.useEffect(() => {
+    if (isOpen) {
+      setActiveTab('overview');
+    }
+  }, [isOpen, labResult?.id]);
 
   const handleError = (error, context) => {
     logger.error('lab_result_view_modal_error', {
@@ -230,6 +238,7 @@ const LabResultViewModal = ({
             <Tabs.Panel value="test-components">
               <Box mt="md">
                 <TestComponentsTab
+                  key={`test-components-${labResult.id}`}
                   labResultId={labResult.id}
                   isViewMode={false}
                   onError={handleError}

--- a/frontend/src/components/medical/labresults/TestComponentDisplay.tsx
+++ b/frontend/src/components/medical/labresults/TestComponentDisplay.tsx
@@ -21,7 +21,7 @@ import {
   Alert,
   Skeleton
 } from '@mantine/core';
-import { IconInfoCircle, IconEdit, IconTrash } from '@tabler/icons-react';
+import { IconInfoCircle, IconEdit, IconTrash, IconChartLine } from '@tabler/icons-react';
 import StatusBadge from '../StatusBadge';
 import { LabTestComponent } from '../../../services/api/labTestComponentApi';
 import logger from '../../../services/logger';
@@ -34,6 +34,7 @@ interface TestComponentDisplayProps {
   showActions?: boolean;
   onEdit?: (component: LabTestComponent) => void;
   onDelete?: (component: LabTestComponent) => void;
+  onTrendClick?: (testName: string) => void;
   onError?: (error: Error) => void;
 }
 
@@ -45,6 +46,7 @@ const TestComponentDisplay: React.FC<TestComponentDisplayProps> = ({
   showActions = false,
   onEdit,
   onDelete,
+  onTrendClick,
   onError
 }) => {
   const handleError = (error: Error, context: string) => {
@@ -109,8 +111,24 @@ const TestComponentDisplay: React.FC<TestComponentDisplayProps> = ({
     const statusColor = getStatusColor(component.status, component.value, component.ref_range_min, component.ref_range_max);
     const referenceRange = formatReferenceRange(component);
 
+    const handleCardClick = (e: React.MouseEvent) => {
+      // Don't trigger if clicking on action buttons
+      const target = e.target as HTMLElement;
+      if (target.closest('button')) {
+        return;
+      }
+      onTrendClick?.(component.test_name);
+    };
+
     return (
-      <Card withBorder shadow="sm" radius="md" p="md">
+      <Card
+        withBorder
+        shadow="sm"
+        radius="md"
+        p="md"
+        style={{ cursor: 'pointer' }}
+        onClick={handleCardClick}
+      >
         <Stack gap="sm">
           {/* Header */}
           <Group justify="space-between" align="flex-start">
@@ -122,19 +140,29 @@ const TestComponentDisplay: React.FC<TestComponentDisplayProps> = ({
                     {component.abbreviation}
                   </Badge>
                 )}
+                {/* Trend indicator badge */}
+                <Tooltip label="Click card to view historical trends">
+                  <Badge variant="light" color="blue" size="xs" leftSection={<IconChartLine size={10} />}>
+                    Trends
+                  </Badge>
+                </Tooltip>
               </Group>
               {component.test_code && (
                 <Text size="xs" c="dimmed">{component.test_code}</Text>
               )}
             </Stack>
 
+            {/* Edit/Delete - only show when actions enabled */}
             {showActions && (
               <Group gap={4}>
                 <Tooltip label="Edit test component">
                   <ActionIcon
                     variant="subtle"
                     size="sm"
-                    onClick={() => onEdit?.(component)}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onEdit?.(component);
+                    }}
                     aria-label={`Edit ${component.test_name}`}
                   >
                     <IconEdit size={14} />
@@ -145,7 +173,10 @@ const TestComponentDisplay: React.FC<TestComponentDisplayProps> = ({
                     variant="subtle"
                     color="red"
                     size="sm"
-                    onClick={() => onDelete?.(component)}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onDelete?.(component);
+                    }}
                     aria-label={`Delete ${component.test_name}`}
                   >
                     <IconTrash size={14} />

--- a/frontend/src/components/medical/labresults/TestComponentDisplay.tsx
+++ b/frontend/src/components/medical/labresults/TestComponentDisplay.tsx
@@ -120,6 +120,14 @@ const TestComponentDisplay: React.FC<TestComponentDisplayProps> = ({
       onTrendClick?.(component.test_name);
     };
 
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+      // Support Enter and Space keys for accessibility
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        onTrendClick?.(component.test_name);
+      }
+    };
+
     return (
       <Card
         withBorder
@@ -128,6 +136,10 @@ const TestComponentDisplay: React.FC<TestComponentDisplayProps> = ({
         p="md"
         style={{ cursor: 'pointer' }}
         onClick={handleCardClick}
+        onKeyDown={handleKeyDown}
+        tabIndex={0}
+        role="button"
+        aria-label={`View trends for ${component.test_name}`}
       >
         <Stack gap="sm">
           {/* Header */}

--- a/frontend/src/components/medical/labresults/TestComponentTrendChart.tsx
+++ b/frontend/src/components/medical/labresults/TestComponentTrendChart.tsx
@@ -1,0 +1,253 @@
+/**
+ * TestComponentTrendChart component
+ * Displays historical trend data as a line chart with reference ranges
+ * Uses Recharts for visualization
+ */
+
+import React, { useMemo } from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  ReferenceLine,
+  ReferenceArea,
+  Dot
+} from 'recharts';
+import { Paper, Stack, Text, Badge, Group, Box } from '@mantine/core';
+import { TrendResponse } from '../../../services/api/labTestComponentApi';
+
+interface TestComponentTrendChartProps {
+  trendData: TrendResponse;
+}
+
+const TestComponentTrendChart: React.FC<TestComponentTrendChartProps> = ({ trendData }) => {
+  const chartData = useMemo(() => {
+    return trendData.data_points.map((point) => {
+      // Use recorded_date if available, otherwise use created_at date
+      const dateStr = point.recorded_date || point.created_at.split('T')[0];
+
+      return {
+        date: dateStr,
+        value: point.value,
+        refMin: point.ref_range_min,
+        refMax: point.ref_range_max,
+        status: point.status,
+        testName: point.lab_result.test_name,
+        id: point.id
+      };
+    }).reverse(); // Reverse to show oldest first (left to right)
+  }, [trendData.data_points]);
+
+  // Get the most recent reference range for display
+  const referenceRange = useMemo(() => {
+    const latest = trendData.data_points[0]; // Already sorted most recent first
+    if (!latest) return null;
+
+    return {
+      min: latest.ref_range_min,
+      max: latest.ref_range_max,
+      text: latest.ref_range_text
+    };
+  }, [trendData.data_points]);
+
+  // Calculate Y-axis domain with padding
+  const yAxisDomain = useMemo(() => {
+    if (chartData.length === 0) return [0, 100];
+
+    const values = chartData.map(d => d.value);
+    const refMins = chartData.map(d => d.refMin).filter(v => v !== null && v !== undefined) as number[];
+    const refMaxs = chartData.map(d => d.refMax).filter(v => v !== null && v !== undefined) as number[];
+
+    const allValues = [...values, ...refMins, ...refMaxs];
+    const min = Math.min(...allValues);
+    const max = Math.max(...allValues);
+
+    // Add 10% padding
+    const padding = (max - min) * 0.1;
+    return [Math.max(0, min - padding), max + padding];
+  }, [chartData]);
+
+  // Custom dot to show status colors
+  const CustomDot = (props: any) => {
+    const { cx, cy, payload } = props;
+
+    let fill = '#228be6'; // Default blue
+
+    if (payload.status) {
+      switch (payload.status.toLowerCase()) {
+        case 'normal':
+          fill = '#40c057'; // Green
+          break;
+        case 'high':
+        case 'low':
+          fill = '#fd7e14'; // Orange
+          break;
+        case 'critical':
+          fill = '#fa5252'; // Red
+          break;
+        case 'abnormal':
+          fill = '#fab005'; // Yellow
+          break;
+      }
+    }
+
+    return <Dot cx={cx} cy={cy} r={4} fill={fill} stroke="#fff" strokeWidth={2} />;
+  };
+
+  // Custom tooltip
+  const CustomTooltip = ({ active, payload }: any) => {
+    if (!active || !payload || !payload.length) return null;
+
+    const data = payload[0].payload;
+
+    return (
+      <Paper withBorder p="sm" shadow="md" radius="md" bg="white">
+        <Stack gap="xs">
+          <Text size="sm" fw={600}>{data.date}</Text>
+          <Group gap="xs" align="baseline">
+            <Text size="lg" fw={700} c="blue">{data.value}</Text>
+            <Text size="sm" c="dimmed">{trendData.unit}</Text>
+          </Group>
+
+          {data.status && (
+            <Badge size="sm" variant="light">
+              {data.status}
+            </Badge>
+          )}
+
+          {(data.refMin !== null || data.refMax !== null) && (
+            <Text size="xs" c="dimmed">
+              Reference: {data.refMin ?? '?'} - {data.refMax ?? '?'} {trendData.unit}
+            </Text>
+          )}
+
+          <Text size="xs" c="dimmed">
+            Lab: {data.testName}
+          </Text>
+        </Stack>
+      </Paper>
+    );
+  };
+
+  if (chartData.length === 0) {
+    return (
+      <Paper withBorder p="xl" radius="md" bg="gray.0">
+        <Text size="sm" c="dimmed" ta="center">
+          No data points to display
+        </Text>
+      </Paper>
+    );
+  }
+
+  return (
+    <Stack gap="md">
+      {/* Reference Range Legend */}
+      {referenceRange && (referenceRange.min !== null || referenceRange.max !== null) && (
+        <Paper withBorder p="xs" radius="md" bg="gray.0">
+          <Group gap="xs">
+            <Text size="xs" fw={600}>Reference Range:</Text>
+            <Text size="xs">
+              {referenceRange.min ?? '?'} - {referenceRange.max ?? '?'} {trendData.unit}
+            </Text>
+            {referenceRange.text && (
+              <Text size="xs" c="dimmed">({referenceRange.text})</Text>
+            )}
+          </Group>
+        </Paper>
+      )}
+
+      {/* Chart */}
+      <Paper withBorder p="md" radius="md">
+        <ResponsiveContainer width="100%" height={400}>
+          <LineChart
+            data={chartData}
+            margin={{ top: 5, right: 30, left: 20, bottom: 5 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" stroke="#e9ecef" />
+
+            <XAxis
+              dataKey="date"
+              tick={{ fontSize: 12 }}
+              tickLine={{ stroke: '#adb5bd' }}
+              stroke="#adb5bd"
+              angle={-45}
+              textAnchor="end"
+              height={80}
+            />
+
+            <YAxis
+              domain={yAxisDomain}
+              tick={{ fontSize: 12 }}
+              tickLine={{ stroke: '#adb5bd' }}
+              stroke="#adb5bd"
+              label={{ value: trendData.unit, angle: -90, position: 'insideLeft', style: { fontSize: 12 } }}
+            />
+
+            <Tooltip content={<CustomTooltip />} />
+
+            <Legend
+              wrapperStyle={{ fontSize: 12, paddingTop: 10 }}
+              iconType="line"
+            />
+
+            {/* Reference range area */}
+            {referenceRange && referenceRange.min !== null && referenceRange.max !== null && (
+              <ReferenceArea
+                y1={referenceRange.min}
+                y2={referenceRange.max}
+                fill="#40c057"
+                fillOpacity={0.1}
+                label=""
+              />
+            )}
+
+            {/* Reference range lines */}
+            {referenceRange && referenceRange.min !== null && (
+              <ReferenceLine
+                y={referenceRange.min}
+                stroke="#40c057"
+                strokeDasharray="3 3"
+                label={{ value: 'Min', position: 'right', fontSize: 10, fill: '#40c057' }}
+              />
+            )}
+
+            {referenceRange && referenceRange.max !== null && (
+              <ReferenceLine
+                y={referenceRange.max}
+                stroke="#40c057"
+                strokeDasharray="3 3"
+                label={{ value: 'Max', position: 'right', fontSize: 10, fill: '#40c057' }}
+              />
+            )}
+
+            {/* Value line */}
+            <Line
+              type="monotone"
+              dataKey="value"
+              stroke="#228be6"
+              strokeWidth={2}
+              dot={<CustomDot />}
+              name={trendData.test_name}
+              connectNulls
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </Paper>
+
+      {/* Status Legend */}
+      <Group gap="sm" justify="center">
+        <Badge size="sm" variant="light" color="green">Normal</Badge>
+        <Badge size="sm" variant="light" color="orange">High/Low</Badge>
+        <Badge size="sm" variant="light" color="red">Critical</Badge>
+        <Badge size="sm" variant="light" color="yellow">Abnormal</Badge>
+      </Group>
+    </Stack>
+  );
+};
+
+export default TestComponentTrendChart;

--- a/frontend/src/components/medical/labresults/TestComponentTrendChart.tsx
+++ b/frontend/src/components/medical/labresults/TestComponentTrendChart.tsx
@@ -67,9 +67,16 @@ const TestComponentTrendChart: React.FC<TestComponentTrendChartProps> = ({ trend
     const min = Math.min(...allValues);
     const max = Math.max(...allValues);
 
-    // Add 10% padding
-    const padding = (max - min) * 0.1;
-    return [Math.max(0, min - padding), max + padding];
+    // Calculate padding - handle edge case where all values are identical
+    // Use 10% of the range, or a minimal fallback if range is zero
+    const range = max - min;
+    const padding = range > 0 ? range * 0.1 : Math.abs(max) * 0.1 || 1;
+
+    // Ensure we don't clamp to zero unconditionally
+    const lowerBound = min - padding;
+    const upperBound = max + padding;
+
+    return [lowerBound, upperBound];
   }, [chartData]);
 
   // Custom dot to show status colors

--- a/frontend/src/components/medical/labresults/TestComponentTrendTable.tsx
+++ b/frontend/src/components/medical/labresults/TestComponentTrendTable.tsx
@@ -1,0 +1,243 @@
+/**
+ * TestComponentTrendTable component
+ * Displays historical trend data as a sortable table
+ */
+
+import React, { useMemo, useState } from 'react';
+import {
+  Table,
+  Paper,
+  Stack,
+  Text,
+  Badge,
+  Group,
+  ScrollArea,
+  ActionIcon,
+  Tooltip,
+  Box
+} from '@mantine/core';
+import { IconArrowUp, IconArrowDown, IconArrowsSort } from '@tabler/icons-react';
+import { TrendResponse, TrendDataPoint } from '../../../services/api/labTestComponentApi';
+
+interface TestComponentTrendTableProps {
+  trendData: TrendResponse;
+}
+
+type SortField = 'date' | 'value' | 'status';
+type SortOrder = 'asc' | 'desc';
+
+const TestComponentTrendTable: React.FC<TestComponentTrendTableProps> = ({ trendData }) => {
+  const [sortField, setSortField] = useState<SortField>('date');
+  const [sortOrder, setSortOrder] = useState<SortOrder>('desc'); // Most recent first by default
+
+  const getStatusColor = (status: string | null | undefined): string => {
+    if (!status) return 'gray';
+
+    switch (status.toLowerCase()) {
+      case 'normal':
+        return 'green';
+      case 'high':
+      case 'low':
+        return 'orange';
+      case 'critical':
+        return 'red';
+      case 'abnormal':
+      case 'borderline':
+        return 'yellow';
+      default:
+        return 'gray';
+    }
+  };
+
+  const formatDate = (point: TrendDataPoint): string => {
+    const dateStr = point.recorded_date || point.created_at.split('T')[0];
+    try {
+      const date = new Date(dateStr);
+      return date.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric'
+      });
+    } catch {
+      return dateStr;
+    }
+  };
+
+  const formatReferenceRange = (point: TrendDataPoint): string => {
+    const { ref_range_min, ref_range_max, ref_range_text } = point;
+
+    if (ref_range_text) {
+      return ref_range_text;
+    }
+
+    if (ref_range_min !== null && ref_range_max !== null) {
+      return `${ref_range_min} - ${ref_range_max}`;
+    }
+
+    if (ref_range_min !== null) {
+      return `≥ ${ref_range_min}`;
+    }
+
+    if (ref_range_max !== null) {
+      return `≤ ${ref_range_max}`;
+    }
+
+    return 'Not specified';
+  };
+
+  const sortedData = useMemo(() => {
+    const data = [...trendData.data_points];
+
+    data.sort((a, b) => {
+      let comparison = 0;
+
+      switch (sortField) {
+        case 'date': {
+          const dateA = a.recorded_date || a.created_at;
+          const dateB = b.recorded_date || b.created_at;
+          comparison = dateA.localeCompare(dateB);
+          break;
+        }
+        case 'value':
+          comparison = a.value - b.value;
+          break;
+        case 'status': {
+          const statusA = a.status || '';
+          const statusB = b.status || '';
+          comparison = statusA.localeCompare(statusB);
+          break;
+        }
+      }
+
+      return sortOrder === 'asc' ? comparison : -comparison;
+    });
+
+    return data;
+  }, [trendData.data_points, sortField, sortOrder]);
+
+  const handleSort = (field: SortField) => {
+    if (sortField === field) {
+      // Toggle order if same field
+      setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc');
+    } else {
+      // New field, default to descending
+      setSortField(field);
+      setSortOrder('desc');
+    }
+  };
+
+  const SortIcon: React.FC<{ field: SortField }> = ({ field }) => {
+    if (sortField !== field) {
+      return <IconArrowsSort size={14} style={{ opacity: 0.5 }} />;
+    }
+
+    return sortOrder === 'asc' ? (
+      <IconArrowUp size={14} />
+    ) : (
+      <IconArrowDown size={14} />
+    );
+  };
+
+  if (trendData.data_points.length === 0) {
+    return (
+      <Paper withBorder p="xl" radius="md" bg="gray.0">
+        <Text size="sm" c="dimmed" ta="center">
+          No data points to display
+        </Text>
+      </Paper>
+    );
+  }
+
+  return (
+    <Stack gap="md">
+      <Group justify="space-between" align="center">
+        <Text size="sm" fw={600}>
+          Historical Data ({trendData.data_points.length} records)
+        </Text>
+        <Text size="xs" c="dimmed">
+          Click column headers to sort
+        </Text>
+      </Group>
+
+      <Paper withBorder radius="md">
+        <ScrollArea>
+          <Table striped highlightOnHover>
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>
+                  <Group gap="xs" style={{ cursor: 'pointer' }} onClick={() => handleSort('date')}>
+                    <Text size="xs" fw={600}>Date</Text>
+                    <SortIcon field="date" />
+                  </Group>
+                </Table.Th>
+                <Table.Th>
+                  <Group gap="xs" style={{ cursor: 'pointer' }} onClick={() => handleSort('value')}>
+                    <Text size="xs" fw={600}>Value</Text>
+                    <SortIcon field="value" />
+                  </Group>
+                </Table.Th>
+                <Table.Th>
+                  <Text size="xs" fw={600}>Unit</Text>
+                </Table.Th>
+                <Table.Th>
+                  <Group gap="xs" style={{ cursor: 'pointer' }} onClick={() => handleSort('status')}>
+                    <Text size="xs" fw={600}>Status</Text>
+                    <SortIcon field="status" />
+                  </Group>
+                </Table.Th>
+                <Table.Th>
+                  <Text size="xs" fw={600}>Reference Range</Text>
+                </Table.Th>
+                <Table.Th>
+                  <Text size="xs" fw={600}>Lab Result</Text>
+                </Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {sortedData.map((point) => (
+                <Table.Tr key={point.id}>
+                  <Table.Td>
+                    <Text size="sm">{formatDate(point)}</Text>
+                  </Table.Td>
+                  <Table.Td>
+                    <Text size="sm" fw={600}>{point.value}</Text>
+                  </Table.Td>
+                  <Table.Td>
+                    <Text size="sm" c="dimmed">{point.unit}</Text>
+                  </Table.Td>
+                  <Table.Td>
+                    {point.status ? (
+                      <Badge
+                        size="sm"
+                        variant="light"
+                        color={getStatusColor(point.status)}
+                      >
+                        {point.status}
+                      </Badge>
+                    ) : (
+                      <Text size="xs" c="dimmed">-</Text>
+                    )}
+                  </Table.Td>
+                  <Table.Td>
+                    <Text size="xs" c="dimmed">
+                      {formatReferenceRange(point)}
+                    </Text>
+                  </Table.Td>
+                  <Table.Td>
+                    <Tooltip label={`Lab Result ID: ${point.lab_result.id}`}>
+                      <Text size="xs" c="dimmed" lineClamp={1}>
+                        {point.lab_result.test_name}
+                      </Text>
+                    </Tooltip>
+                  </Table.Td>
+                </Table.Tr>
+              ))}
+            </Table.Tbody>
+          </Table>
+        </ScrollArea>
+      </Paper>
+    </Stack>
+  );
+};
+
+export default TestComponentTrendTable;

--- a/frontend/src/components/medical/labresults/TestComponentTrendsPanel.tsx
+++ b/frontend/src/components/medical/labresults/TestComponentTrendsPanel.tsx
@@ -1,0 +1,537 @@
+/**
+ * TestComponentTrendsPanel component
+ * Slide-out panel that displays historical trend data for a specific lab test component
+ * Shows chart, statistics, and historical data table
+ */
+
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  Drawer,
+  Stack,
+  Group,
+  Text,
+  Title,
+  Button,
+  Tabs,
+  Alert,
+  Paper,
+  Badge,
+  LoadingOverlay,
+  CloseButton,
+  Divider,
+  Box,
+  Skeleton,
+  ActionIcon,
+  Tooltip,
+  TextInput,
+  Select
+} from '@mantine/core';
+import {
+  IconTrendingUp,
+  IconTrendingDown,
+  IconMinus,
+  IconChartLine,
+  IconTable,
+  IconChartBar,
+  IconAlertCircle,
+  IconDownload,
+  IconCalendar,
+  IconRefresh,
+  IconX,
+  IconFilter
+} from '@tabler/icons-react';
+import { notifications } from '@mantine/notifications';
+import {
+  labTestComponentApi,
+  TrendResponse
+} from '../../../services/api/labTestComponentApi';
+import logger from '../../../services/logger';
+import TestComponentTrendChart from './TestComponentTrendChart';
+import TestComponentTrendTable from './TestComponentTrendTable';
+
+interface TestComponentTrendsPanelProps {
+  opened: boolean;
+  onClose: () => void;
+  testName: string | null;
+  patientId: number;
+}
+
+const TestComponentTrendsPanel: React.FC<TestComponentTrendsPanelProps> = ({
+  opened,
+  onClose,
+  testName,
+  patientId
+}) => {
+  const [trendData, setTrendData] = useState<TrendResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<string>('chart');
+  const [timeRange, setTimeRange] = useState<string>('all');
+
+  const getDateRangeFromSelection = (range: string): { dateFrom?: string; dateTo?: string } => {
+    const today = new Date();
+    const formatDate = (date: Date) => date.toISOString().split('T')[0];
+
+    if (range === 'all') {
+      return {};
+    }
+
+    const dateTo = formatDate(today);
+    let dateFrom: Date;
+
+    switch (range) {
+      case '3months':
+        dateFrom = new Date(today);
+        dateFrom.setMonth(today.getMonth() - 3);
+        return { dateFrom: formatDate(dateFrom), dateTo };
+      case '6months':
+        dateFrom = new Date(today);
+        dateFrom.setMonth(today.getMonth() - 6);
+        return { dateFrom: formatDate(dateFrom), dateTo };
+      case 'year':
+        dateFrom = new Date(today);
+        dateFrom.setFullYear(today.getFullYear() - 1);
+        return { dateFrom: formatDate(dateFrom), dateTo };
+      case '2years':
+        dateFrom = new Date(today);
+        dateFrom.setFullYear(today.getFullYear() - 2);
+        return { dateFrom: formatDate(dateFrom), dateTo };
+      case '5years':
+        dateFrom = new Date(today);
+        dateFrom.setFullYear(today.getFullYear() - 5);
+        return { dateFrom: formatDate(dateFrom), dateTo };
+      default:
+        return {};
+    }
+  };
+
+  const loadTrendData = useCallback(async () => {
+    if (!testName || !patientId) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const dateRange = getDateRangeFromSelection(timeRange);
+
+      const response = await labTestComponentApi.getTrendsByPatientAndTest(
+        patientId,
+        testName,
+        {
+          dateFrom: dateRange.dateFrom,
+          dateTo: dateRange.dateTo,
+          limit: 100
+        }
+      );
+
+      setTrendData(response);
+
+      logger.info('test_component_trends_loaded', {
+        message: 'Test component trends loaded successfully',
+        testName,
+        patientId,
+        timeRange,
+        dataPointCount: response.data_points.length,
+        component: 'TestComponentTrendsPanel'
+      });
+    } catch (error: any) {
+      const errorMessage = error?.message || 'Failed to load trend data';
+      setError(errorMessage);
+
+      logger.error('test_component_trends_error', {
+        message: 'Error loading test component trends',
+        testName,
+        patientId,
+        error: errorMessage,
+        component: 'TestComponentTrendsPanel'
+      });
+
+      notifications.show({
+        title: 'Error Loading Trends',
+        message: errorMessage,
+        color: 'red',
+        autoClose: 5000
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [testName, patientId, timeRange]);
+
+  useEffect(() => {
+    if (opened && testName) {
+      loadTrendData();
+    }
+  }, [opened, testName, loadTrendData]);
+
+  const getTrendIcon = () => {
+    if (!trendData) return <IconMinus size={18} />;
+
+    switch (trendData.statistics.trend_direction) {
+      case 'increasing':
+        return <IconTrendingUp size={18} />;
+      case 'decreasing':
+        return <IconTrendingDown size={18} />;
+      default:
+        return <IconMinus size={18} />;
+    }
+  };
+
+  const getTrendColor = () => {
+    if (!trendData) return 'gray';
+
+    switch (trendData.statistics.trend_direction) {
+      case 'increasing':
+        return 'blue';
+      case 'decreasing':
+        return 'orange';
+      default:
+        return 'gray';
+    }
+  };
+
+  const getTrendLabel = () => {
+    if (!trendData) return 'Stable';
+
+    switch (trendData.statistics.trend_direction) {
+      case 'increasing':
+        return 'Increasing';
+      case 'decreasing':
+        return 'Decreasing';
+      default:
+        return 'Stable';
+    }
+  };
+
+  const getTimeRangeLabel = (range: string): string => {
+    switch (range) {
+      case 'all':
+        return 'All Dates';
+      case '3months':
+        return 'Past 3 Months';
+      case '6months':
+        return 'Past 6 Months';
+      case 'year':
+        return 'Past Year';
+      case '2years':
+        return 'Past 2 Years';
+      case '5years':
+        return 'Past 5 Years';
+      default:
+        return 'All Dates';
+    }
+  };
+
+  const handleExport = () => {
+    if (!trendData) return;
+
+    try {
+      // Create CSV content
+      const headers = ['Date', 'Value', 'Unit', 'Status', 'Reference Range', 'Lab Result'];
+      const rows = trendData.data_points.map(point => {
+        const date = point.recorded_date || point.created_at.split('T')[0];
+        const refRange = point.ref_range_text ||
+          (point.ref_range_min !== null && point.ref_range_max !== null
+            ? `${point.ref_range_min} - ${point.ref_range_max}`
+            : 'Not specified');
+
+        return [
+          date,
+          point.value.toString(),
+          point.unit,
+          point.status || '',
+          refRange,
+          point.lab_result.test_name
+        ];
+      });
+
+      // Build CSV string
+      const csvContent = [
+        // Title row
+        [`Test Component Trend Data: ${trendData.test_name}`],
+        [`Export Date: ${new Date().toLocaleDateString()}`],
+        [''],
+        // Statistics
+        ['Summary Statistics'],
+        ['Count', trendData.statistics.count.toString()],
+        ['Latest', trendData.statistics.latest?.toFixed(2) || 'N/A'],
+        ['Average', trendData.statistics.average?.toFixed(2) || 'N/A'],
+        ['Min', trendData.statistics.min?.toFixed(2) || 'N/A'],
+        ['Max', trendData.statistics.max?.toFixed(2) || 'N/A'],
+        ['Std Dev', trendData.statistics.std_dev?.toFixed(2) || 'N/A'],
+        ['Trend Direction', trendData.statistics.trend_direction],
+        ['Normal Count', trendData.statistics.normal_count.toString()],
+        ['Abnormal Count', trendData.statistics.abnormal_count.toString()],
+        [''],
+        // Data table
+        headers,
+        ...rows
+      ].map(row => row.map(cell => `"${cell}"`).join(',')).join('\n');
+
+      // Create blob and download
+      const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+      const link = document.createElement('a');
+      const url = URL.createObjectURL(blob);
+
+      link.setAttribute('href', url);
+      link.setAttribute('download', `trend_${trendData.test_name.replace(/\s+/g, '_')}_${new Date().toISOString().split('T')[0]}.csv`);
+      link.style.visibility = 'hidden';
+
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+
+      logger.info('test_component_trends_exported', {
+        message: 'Trend data exported to CSV',
+        testName,
+        patientId,
+        dataPointCount: trendData.data_points.length,
+        component: 'TestComponentTrendsPanel'
+      });
+
+      notifications.show({
+        title: 'Export Successful',
+        message: `Exported ${trendData.data_points.length} data points to CSV`,
+        color: 'green',
+        autoClose: 3000
+      });
+    } catch (error: any) {
+      logger.error('test_component_trends_export_error', {
+        message: 'Error exporting trend data',
+        testName,
+        patientId,
+        error: error.message,
+        component: 'TestComponentTrendsPanel'
+      });
+
+      notifications.show({
+        title: 'Export Failed',
+        message: 'Failed to export data. Please try again.',
+        color: 'red',
+        autoClose: 5000
+      });
+    }
+  };
+
+  return (
+    <Drawer
+      opened={opened}
+      onClose={onClose}
+      position="right"
+      size="xl"
+      title={
+        <Group gap="sm">
+          <IconChartLine size={24} />
+          <div>
+            <Text fw={600} size="lg">Trend Analysis</Text>
+            {testName && <Text size="sm" c="dimmed">{testName}</Text>}
+          </div>
+        </Group>
+      }
+      overlayProps={{ opacity: 0.5, blur: 4 }}
+      zIndex={2500}
+    >
+      <Stack gap="md" style={{ position: 'relative', minHeight: '100%' }}>
+        <LoadingOverlay visible={loading} overlayProps={{ blur: 2 }} />
+
+        {/* Error State */}
+        {error && (
+          <Alert
+            icon={<IconAlertCircle size={16} />}
+            title="Error"
+            color="red"
+            withCloseButton
+            onClose={() => setError(null)}
+          >
+            {error}
+          </Alert>
+        )}
+
+        {/* Time Range Filter */}
+        {!loading && (
+          <Paper withBorder p="md" radius="md" bg="gray.0">
+            <Stack gap="md">
+              <Group justify="space-between" align="center">
+                <Group gap="xs">
+                  <IconFilter size={16} />
+                  <Text fw={600} size="sm">Time Range</Text>
+                </Group>
+              </Group>
+
+              <Select
+                label="Select Time Range"
+                placeholder="Choose time range"
+                value={timeRange}
+                onChange={(value) => setTimeRange(value || 'all')}
+                data={[
+                  { value: 'all', label: 'All Dates' },
+                  { value: '3months', label: 'Past 3 Months' },
+                  { value: '6months', label: 'Past 6 Months' },
+                  { value: 'year', label: 'Past Year' },
+                  { value: '2years', label: 'Past 2 Years' },
+                  { value: '5years', label: 'Past 5 Years' }
+                ]}
+                leftSection={<IconCalendar size={16} />}
+                size="md"
+                allowDeselect={false}
+                comboboxProps={{ withinPortal: true, zIndex: 3000 }}
+              />
+
+              {/* Show selected time range */}
+              {timeRange !== 'all' && (
+                <Paper withBorder p="sm" radius="sm" bg="blue.0">
+                  <Group gap="xs" justify="center">
+                    <Text size="sm" fw={600}>Showing:</Text>
+                    <Badge size="lg" variant="filled">
+                      {getTimeRangeLabel(timeRange)}
+                    </Badge>
+                  </Group>
+                </Paper>
+              )}
+            </Stack>
+          </Paper>
+        )}
+
+        {/* Statistics Summary */}
+        {trendData && !loading && (
+          <Paper withBorder p="md" radius="md">
+            <Stack gap="md">
+              <Group justify="space-between" align="center">
+                <Text fw={600} size="sm">Summary Statistics</Text>
+                <Group gap="xs">
+                  <Tooltip label="Refresh data">
+                    <ActionIcon variant="subtle" onClick={loadTrendData} size="sm">
+                      <IconRefresh size={16} />
+                    </ActionIcon>
+                  </Tooltip>
+                  <Tooltip label="Export to CSV">
+                    <ActionIcon variant="subtle" onClick={handleExport} size="sm">
+                      <IconDownload size={16} />
+                    </ActionIcon>
+                  </Tooltip>
+                </Group>
+              </Group>
+
+              <Divider />
+
+              <Group gap="xl">
+                <Box>
+                  <Text size="xs" c="dimmed">Latest</Text>
+                  <Group gap="xs" align="baseline">
+                    <Text fw={700} size="xl">
+                      {trendData.statistics.latest?.toFixed(2) ?? 'N/A'}
+                    </Text>
+                    <Text size="sm" c="dimmed">{trendData.unit}</Text>
+                  </Group>
+                </Box>
+
+                <Box>
+                  <Text size="xs" c="dimmed">Average</Text>
+                  <Group gap="xs" align="baseline">
+                    <Text fw={600} size="lg">
+                      {trendData.statistics.average?.toFixed(2) ?? 'N/A'}
+                    </Text>
+                    <Text size="sm" c="dimmed">{trendData.unit}</Text>
+                  </Group>
+                </Box>
+
+                <Box>
+                  <Text size="xs" c="dimmed">Range</Text>
+                  <Group gap="xs" align="baseline">
+                    <Text fw={600} size="sm">
+                      {trendData.statistics.min?.toFixed(2)} - {trendData.statistics.max?.toFixed(2)}
+                    </Text>
+                    <Text size="xs" c="dimmed">{trendData.unit}</Text>
+                  </Group>
+                </Box>
+              </Group>
+
+              <Group gap="md">
+                <Badge
+                  leftSection={getTrendIcon()}
+                  color={getTrendColor()}
+                  variant="light"
+                  size="lg"
+                >
+                  {getTrendLabel()}
+                </Badge>
+
+                <Badge variant="light" color="blue" size="lg">
+                  {trendData.statistics.count} data points
+                </Badge>
+
+                {trendData.statistics.time_in_range_percent !== null && trendData.statistics.time_in_range_percent !== undefined && (
+                  <Badge variant="light" color="green" size="lg">
+                    {trendData.statistics.time_in_range_percent.toFixed(1)}% in range
+                  </Badge>
+                )}
+              </Group>
+
+              <Group gap="sm">
+                <Text size="xs" c="dimmed">
+                  Normal: <Text span fw={600}>{trendData.statistics.normal_count}</Text>
+                </Text>
+                <Text size="xs" c="dimmed">•</Text>
+                <Text size="xs" c="dimmed">
+                  Abnormal: <Text span fw={600}>{trendData.statistics.abnormal_count}</Text>
+                </Text>
+                {trendData.statistics.std_dev !== null && trendData.statistics.std_dev !== undefined && (
+                  <>
+                    <Text size="xs" c="dimmed">•</Text>
+                    <Text size="xs" c="dimmed">
+                      Std Dev: <Text span fw={600}>{trendData.statistics.std_dev.toFixed(2)}</Text>
+                    </Text>
+                  </>
+                )}
+              </Group>
+            </Stack>
+          </Paper>
+        )}
+
+        {/* Tabs for Chart and Table Views */}
+        {trendData && !loading && (
+          <Tabs value={activeTab} onChange={(value) => setActiveTab(value || 'chart')}>
+            <Tabs.List>
+              <Tabs.Tab value="chart" leftSection={<IconChartLine size={16} />}>
+                Chart
+              </Tabs.Tab>
+              <Tabs.Tab value="table" leftSection={<IconTable size={16} />}>
+                Data Table
+              </Tabs.Tab>
+            </Tabs.List>
+
+            <Tabs.Panel value="chart" pt="md">
+              <TestComponentTrendChart trendData={trendData} />
+            </Tabs.Panel>
+
+            <Tabs.Panel value="table" pt="md">
+              <TestComponentTrendTable trendData={trendData} />
+            </Tabs.Panel>
+          </Tabs>
+        )}
+
+        {/* Empty State */}
+        {trendData && trendData.data_points.length === 0 && !loading && (
+          <Paper withBorder p="xl" radius="md" bg="gray.0">
+            <Stack align="center" gap="md">
+              <IconChartLine size={48} color="var(--mantine-color-gray-5)" />
+              <Title order={3} c="dimmed">No trend data available</Title>
+              <Text size="sm" c="dimmed" ta="center">
+                There are no historical data points for this test component.
+              </Text>
+            </Stack>
+          </Paper>
+        )}
+
+        {/* Loading Skeleton */}
+        {loading && !trendData && (
+          <Stack gap="md">
+            <Skeleton height={150} radius="md" />
+            <Skeleton height={300} radius="md" />
+          </Stack>
+        )}
+      </Stack>
+    </Drawer>
+  );
+};
+
+export default TestComponentTrendsPanel;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -7,9 +7,7 @@ import logger from './services/logger';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
+  <App />
 );
 
 // If you want to start measuring performance in your app, pass a function


### PR DESCRIPTION
This pull request introduces a new backend endpoint and supporting schemas for tracking and analyzing historical trends of lab test components for a patient. It also adds frontend UI enhancements to allow users to view trend data for individual test components. The backend changes include a new API endpoint, helper functions for trend statistics, and updates to database queries for performance and accuracy. The frontend changes add a clickable trend indicator badge and event handling to trigger trend views.

**Backend: Lab Test Component Trend Tracking**
- Added new GET endpoint `/patient/{patient_id}/trends/{test_name}` in `lab_test_component.py` to return historical trend data and statistics for a test component, including handling of date filtering, unit mismatches, and summary statistics.
- Implemented helper function `calculate_trend_statistics` to compute average, min, max, standard deviation, trend direction, and time-in-range statistics for trend data.
- Updated `get_by_patient_and_test_name` in `lab_test_component.py` to use exact case-insensitive matching and eager loading of related lab results for performance.
- Added new Pydantic schemas in `lab_test_component.py` for trend data points, statistics, and response structure.

**Frontend: Lab Test Component Trend UI**
- Added a clickable "Trends" badge to each test component card in `TestComponentDisplay.tsx`, with an event handler to trigger trend view logic. Prevented event propagation from action buttons (edit/delete) to avoid accidental trend view activation. [[1]](diffhunk://#diff-8d99fe9b30c59b94caa8c5d5c925df98b5ed9c148164377bc90b5f7680870478L24-R24) [[2]](diffhunk://#diff-8d99fe9b30c59b94caa8c5d5c925df98b5ed9c148164377bc90b5f7680870478R37) [[3]](diffhunk://#diff-8d99fe9b30c59b94caa8c5d5c925df98b5ed9c148164377bc90b5f7680870478R49) [[4]](diffhunk://#diff-8d99fe9b30c59b94caa8c5d5c925df98b5ed9c148164377bc90b5f7680870478R114-R131) [[5]](diffhunk://#diff-8d99fe9b30c59b94caa8c5d5c925df98b5ed9c148164377bc90b5f7680870478R143-R165) [[6]](diffhunk://#diff-8d99fe9b30c59b94caa8c5d5c925df98b5ed9c148164377bc90b5f7680870478L148-R179)
- Ensured that the active tab in `LabResultViewModal.js` resets to "overview" when a new lab result is opened, improving user experience. [[1]](diffhunk://#diff-6773746e801d4fbca315ac4a1bc2279c148507d77cebaea8b694dae0b0ac4aeeR44-R53) [[2]](diffhunk://#diff-6773746e801d4fbca315ac4a1bc2279c148507d77cebaea8b694dae0b0ac4aeeR241)