### PR TITLE
feat: add patient sharing button and modal to Invitation

### DIFF
--- a/frontend/src/components/dashboard/InvitationNotifications.js
+++ b/frontend/src/components/dashboard/InvitationNotifications.js
@@ -34,17 +34,20 @@ import { notifications } from '@mantine/notifications';
 import { useDisclosure } from '@mantine/hooks';
 import invitationApi from '../../services/api/invitationApi';
 import { InvitationManager } from '../invitations';
+import { PatientSharingModal } from '../medical';
 import { formatDateTime } from '../../utils/helpers';
-import { useCacheManager } from '../../hooks/useGlobalData';
+import { useCacheManager, useCurrentPatient } from '../../hooks/useGlobalData';
 
 const InvitationNotifications = () => {
   const { colorScheme } = useMantineColorScheme();
   const { invalidatePatientList } = useCacheManager();
+  const { patient: currentPatient } = useCurrentPatient();
   const [pendingInvitations, setPendingInvitations] = useState([]);
   const [loading, setLoading] = useState(true);
   const [lastUpdate, setLastUpdate] = useState(null);
   const [invitationManagerOpened, { open: openInvitationManager, close: closeInvitationManager }] = useDisclosure(false);
   const [confirmModalOpened, { open: openConfirmModal, close: closeConfirmModal }] = useDisclosure(false);
+  const [patientSharingOpened, { open: openPatientSharing, close: closePatientSharing }] = useDisclosure(false);
   const [selectedInvitation, setSelectedInvitation] = useState(null);
 
   const loadPendingInvitations = async () => {
@@ -318,6 +321,17 @@ const InvitationNotifications = () => {
             Manage All Invitations
           </Button>
         )}
+
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={openPatientSharing}
+          leftSection={<IconUserShare size="0.9rem" />}
+          mt="xs"
+          fullWidth
+        >
+          Share Patient
+        </Button>
       </Card>
 
       {/* Invitation Manager Modal */}
@@ -325,6 +339,14 @@ const InvitationNotifications = () => {
         opened={invitationManagerOpened}
         onClose={closeInvitationManager}
         onUpdate={handleInvitationUpdate}
+      />
+
+      {/* Patient Sharing Modal */}
+      <PatientSharingModal
+        opened={patientSharingOpened}
+        onClose={closePatientSharing}
+        patient={currentPatient}
+        onShareUpdate={handleInvitationUpdate}
       />
 
       {/* Confirmation Modal for Accepting Invitations */}


### PR DESCRIPTION
This pull request adds a new patient sharing feature to the `InvitationNotifications` component, making it easier for users to share patient information directly from the dashboard. The changes include integrating the `PatientSharingModal`, updating state management to support the modal, and adding a new button for sharing patients.

**Patient Sharing Feature:**

* Added the `PatientSharingModal` component and included it in the `InvitationNotifications` component to enable patient sharing functionality. [[1]](diffhunk://#diff-bc16e573f9041f7a07bcb161ecc62a951cdeec502e4101950d74aace6ca5af72R37-R50) [[2]](diffhunk://#diff-bc16e573f9041f7a07bcb161ecc62a951cdeec502e4101950d74aace6ca5af72R344-R351)
* Updated state management to track the open/close state of the patient sharing modal and to access the current patient using the `useCurrentPatient` hook.
* Added a "Share Patient" button to the dashboard card, which opens the patient sharing modal when clicked.