### PR TITLE
feat: add relationship to self functionality in patient management

### DIFF
--- a/alembic/migrations/versions/20251007_1609_a818ac170805_rename_relationship_to_family_to_.py
+++ b/alembic/migrations/versions/20251007_1609_a818ac170805_rename_relationship_to_family_to_.py
@@ -1,0 +1,28 @@
+"""rename relationship_to_family to relationship_to_self
+
+Revision ID: a818ac170805
+Revises: df53ab5473dd
+Create Date: 2025-10-07 16:09:10.652593
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a818ac170805'
+down_revision = 'df53ab5473dd'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Rename column from relationship_to_family to relationship_to_self
+    op.alter_column('patients', 'relationship_to_family',
+                    new_column_name='relationship_to_self')
+
+
+def downgrade() -> None:
+    # Rename column back from relationship_to_self to relationship_to_family
+    op.alter_column('patients', 'relationship_to_self',
+                    new_column_name='relationship_to_family')

--- a/app/api/v1/endpoints/patient_management.py
+++ b/app/api/v1/endpoints/patient_management.py
@@ -124,6 +124,7 @@ class PatientResponse(BaseModel):
     weight: Optional[float]
     address: Optional[str]
     physician_id: Optional[int]
+    relationship_to_self: Optional[str]
     owner_user_id: int
     is_self_record: bool
     privacy_level: str

--- a/app/models/enums.py
+++ b/app/models/enums.py
@@ -83,6 +83,27 @@ class SeverityLevel(Enum):
     LIFE_THREATENING = "life-threatening"
 
 
+class RelationshipToSelf(Enum):
+    """Relationship of patient record to the account owner"""
+    SELF = "self"
+    SPOUSE = "spouse"
+    PARTNER = "partner"
+    CHILD = "child"
+    SON = "son"
+    DAUGHTER = "daughter"
+    PARENT = "parent"
+    FATHER = "father"
+    MOTHER = "mother"
+    SIBLING = "sibling"
+    BROTHER = "brother"
+    SISTER = "sister"
+    GRANDPARENT = "grandparent"
+    GRANDCHILD = "grandchild"
+    OTHER_FAMILY = "other_family"
+    FRIEND = "friend"
+    OTHER = "other"
+
+
 class FamilyRelationship(Enum):
     """Family relationship types for family history"""
     FATHER = "father"
@@ -173,6 +194,11 @@ def get_all_severity_levels():
 def get_all_encounter_priorities():
     """Get all valid encounter priority levels"""
     return get_status_values(EncounterPriority)
+
+
+def get_all_relationship_to_self():
+    """Get all valid relationship to self values"""
+    return get_status_values(RelationshipToSelf)
 
 
 def get_all_family_relationships():

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -32,6 +32,7 @@ from .enums import (
     LabResultStatus,
     MedicationStatus,
     ProcedureStatus,
+    RelationshipToSelf,
     SeverityLevel,
     TreatmentStatus,
     get_all_allergy_statuses,
@@ -44,6 +45,7 @@ from .enums import (
     get_all_lab_result_statuses,
     get_all_medication_statuses,
     get_all_procedure_statuses,
+    get_all_relationship_to_self,
     get_all_severity_levels,
     get_all_treatment_statuses,
 )
@@ -142,9 +144,9 @@ class Patient(Base):
 
     # V2+: Family context (nullable for V1)
     family_id = Column(Integer, nullable=True)  # Will add FK constraint in V2
-    relationship_to_family = Column(
+    relationship_to_self = Column(
         String, nullable=True
-    )  # self, spouse, child, parent
+    )  # Use RelationshipToSelf enum: self, spouse, child, parent, etc.
 
     # V3+: Advanced permissions (nullable for V1/V2)
     privacy_level = Column(String, default="owner", nullable=False)

--- a/app/schemas/patient.py
+++ b/app/schemas/patient.py
@@ -29,6 +29,7 @@ class PatientBase(BaseModel):
         None  # in pounds (allows decimals for metric conversion precision)
     )
     physician_id: Optional[int] = None
+    relationship_to_self: Optional[str] = None  # Use RelationshipToSelf enum values
 
     @root_validator(pre=True)
     def convert_empty_strings_to_none(cls, values):
@@ -41,6 +42,7 @@ class PatientBase(BaseModel):
                 "height",
                 "weight",
                 "physician_id",
+                "relationship_to_self",
             ]:
                 if field in values and values[field] == "":
                     values[field] = None
@@ -100,7 +102,7 @@ class PatientBase(BaseModel):
         Raises:
             ValueError: If gender is not in allowed list
         """
-        if v is not None:
+        if v is not None and v != "":
             allowed_genders = ["M", "F", "MALE", "FEMALE", "OTHER", "U", "UNKNOWN"]
             if v.upper() not in allowed_genders:
                 raise ValueError(f"Gender must be one of: {', '.join(allowed_genders)}")
@@ -108,7 +110,7 @@ class PatientBase(BaseModel):
             # Normalize common values
             gender_map = {"MALE": "M", "FEMALE": "F", "UNKNOWN": "U"}
             return gender_map.get(v.upper(), v.upper())
-        return v
+        return None if v == "" else v
 
     @validator("birth_date")
     def validate_birth_date(cls, v):
@@ -290,6 +292,7 @@ class PatientUpdate(BaseModel):
     height: Optional[float] = None
     weight: Optional[float] = None
     physician_id: Optional[int] = None
+    relationship_to_self: Optional[str] = None
 
     @root_validator(pre=True)
     def convert_empty_strings_to_none(cls, values):
@@ -305,6 +308,7 @@ class PatientUpdate(BaseModel):
                 "height",
                 "weight",
                 "physician_id",
+                "relationship_to_self",
             ]:
                 if field in values and values[field] == "":
                     values[field] = None
@@ -441,6 +445,7 @@ class Patient(PatientBase):
                 "height",
                 "weight",
                 "physician_id",
+                "relationship_to_self",
             ]:
                 if field in values and values[field] == "":
                     values[field] = None

--- a/frontend/src/components/medical/MantinePatientForm.js
+++ b/frontend/src/components/medical/MantinePatientForm.js
@@ -20,6 +20,7 @@ import {
   convertForDisplay,
   convertForStorage,
 } from '../../utils/unitConversion';
+import { RELATIONSHIP_OPTIONS } from '../../constants/relationshipOptions';
 import PatientPhotoUpload from './PatientPhotoUpload';
 import patientApi from '../../services/api/patientApi';
 import logger from '../../services/logger';
@@ -248,25 +249,7 @@ const MantinePatientForm = ({
         value={formData.relationship_to_self}
         onChange={handleSelectChange('relationship_to_self')}
         disabled={saving}
-        data={[
-          { value: 'self', label: 'Self' },
-          { value: 'spouse', label: 'Spouse' },
-          { value: 'partner', label: 'Partner' },
-          { value: 'child', label: 'Child' },
-          { value: 'son', label: 'Son' },
-          { value: 'daughter', label: 'Daughter' },
-          { value: 'parent', label: 'Parent' },
-          { value: 'father', label: 'Father' },
-          { value: 'mother', label: 'Mother' },
-          { value: 'sibling', label: 'Sibling' },
-          { value: 'brother', label: 'Brother' },
-          { value: 'sister', label: 'Sister' },
-          { value: 'grandparent', label: 'Grandparent' },
-          { value: 'grandchild', label: 'Grandchild' },
-          { value: 'other_family', label: 'Other Family' },
-          { value: 'friend', label: 'Friend' },
-          { value: 'other', label: 'Other' },
-        ]}
+        data={RELATIONSHIP_OPTIONS}
         description="How is this person related to you?"
         clearable
         searchable

--- a/frontend/src/components/medical/MantinePatientForm.js
+++ b/frontend/src/components/medical/MantinePatientForm.js
@@ -241,6 +241,37 @@ const MantinePatientForm = ({
         </Grid.Col>
       </Grid>
 
+      {/* Relationship to You */}
+      <Select
+        label="Relationship to You"
+        placeholder="Select relationship (optional)"
+        value={formData.relationship_to_self}
+        onChange={handleSelectChange('relationship_to_self')}
+        disabled={saving}
+        data={[
+          { value: 'self', label: 'Self' },
+          { value: 'spouse', label: 'Spouse' },
+          { value: 'partner', label: 'Partner' },
+          { value: 'child', label: 'Child' },
+          { value: 'son', label: 'Son' },
+          { value: 'daughter', label: 'Daughter' },
+          { value: 'parent', label: 'Parent' },
+          { value: 'father', label: 'Father' },
+          { value: 'mother', label: 'Mother' },
+          { value: 'sibling', label: 'Sibling' },
+          { value: 'brother', label: 'Brother' },
+          { value: 'sister', label: 'Sister' },
+          { value: 'grandparent', label: 'Grandparent' },
+          { value: 'grandchild', label: 'Grandchild' },
+          { value: 'other_family', label: 'Other Family' },
+          { value: 'friend', label: 'Friend' },
+          { value: 'other', label: 'Other' },
+        ]}
+        description="How is this person related to you?"
+        clearable
+        searchable
+      />
+
       {/* Address */}
       <Textarea
         label="Address"

--- a/frontend/src/components/medical/PatientForm.js
+++ b/frontend/src/components/medical/PatientForm.js
@@ -63,6 +63,7 @@ const PatientForm = ({
     address: '',
     physician_id: null,
     is_self_record: false,
+    relationship_to_self: '',
   });
 
   const isEditing = !!patient;
@@ -86,6 +87,7 @@ const PatientForm = ({
         address: patient.address || '',
         physician_id: patient.physician_id || null,
         is_self_record: patient.is_self_record || false,
+        relationship_to_self: patient.relationship_to_self || '',
       });
     }
   }, [patient]);
@@ -207,6 +209,27 @@ const PatientForm = ({
     { value: 'Prefer not to say', label: 'Prefer not to say' },
   ];
 
+  const relationshipOptions = [
+    { value: '', label: 'Select relationship (optional)' },
+    { value: 'self', label: 'Self' },
+    { value: 'spouse', label: 'Spouse' },
+    { value: 'partner', label: 'Partner' },
+    { value: 'child', label: 'Child' },
+    { value: 'son', label: 'Son' },
+    { value: 'daughter', label: 'Daughter' },
+    { value: 'parent', label: 'Parent' },
+    { value: 'father', label: 'Father' },
+    { value: 'mother', label: 'Mother' },
+    { value: 'sibling', label: 'Sibling' },
+    { value: 'brother', label: 'Brother' },
+    { value: 'sister', label: 'Sister' },
+    { value: 'grandparent', label: 'Grandparent' },
+    { value: 'grandchild', label: 'Grandchild' },
+    { value: 'other_family', label: 'Other Family' },
+    { value: 'friend', label: 'Friend' },
+    { value: 'other', label: 'Other' },
+  ];
+
   return (
     <Box component="form" onSubmit={handleSubmit}>
       <Stack gap="md">
@@ -299,6 +322,19 @@ const PatientForm = ({
                 clearable
               />
             </Group>
+
+            <Select
+              label="Relationship to You"
+              placeholder="Select relationship (optional)"
+              description="How is this person related to you?"
+              data={relationshipOptions}
+              value={formData.relationship_to_self}
+              onChange={value =>
+                setFormData({ ...formData, relationship_to_self: value })
+              }
+              disabled={loading}
+              clearable
+            />
           </Stack>
         </div>
 

--- a/frontend/src/components/medical/PatientForm.js
+++ b/frontend/src/components/medical/PatientForm.js
@@ -39,6 +39,7 @@ import {
   convertForDisplay,
   convertForStorage,
 } from '../../utils/unitConversion';
+import { RELATIONSHIP_OPTIONS } from '../../constants/relationshipOptions';
 
 const PatientForm = ({
   patient = null,
@@ -209,26 +210,6 @@ const PatientForm = ({
     { value: 'Prefer not to say', label: 'Prefer not to say' },
   ];
 
-  const relationshipOptions = [
-    { value: '', label: 'Select relationship (optional)' },
-    { value: 'self', label: 'Self' },
-    { value: 'spouse', label: 'Spouse' },
-    { value: 'partner', label: 'Partner' },
-    { value: 'child', label: 'Child' },
-    { value: 'son', label: 'Son' },
-    { value: 'daughter', label: 'Daughter' },
-    { value: 'parent', label: 'Parent' },
-    { value: 'father', label: 'Father' },
-    { value: 'mother', label: 'Mother' },
-    { value: 'sibling', label: 'Sibling' },
-    { value: 'brother', label: 'Brother' },
-    { value: 'sister', label: 'Sister' },
-    { value: 'grandparent', label: 'Grandparent' },
-    { value: 'grandchild', label: 'Grandchild' },
-    { value: 'other_family', label: 'Other Family' },
-    { value: 'friend', label: 'Friend' },
-    { value: 'other', label: 'Other' },
-  ];
 
   return (
     <Box component="form" onSubmit={handleSubmit}>
@@ -327,7 +308,7 @@ const PatientForm = ({
               label="Relationship to You"
               placeholder="Select relationship (optional)"
               description="How is this person related to you?"
-              data={relationshipOptions}
+              data={RELATIONSHIP_OPTIONS}
               value={formData.relationship_to_self}
               onChange={value =>
                 setFormData({ ...formData, relationship_to_self: value })

--- a/frontend/src/components/medical/PatientSelector.js
+++ b/frontend/src/components/medical/PatientSelector.js
@@ -572,6 +572,21 @@ const PatientSelector = ({ onPatientChange, currentPatientId, loading: externalL
   };
 
   /**
+   * Format relationship label for display
+   */
+  const formatRelationshipLabel = (relationship) => {
+    if (!relationship) return null;
+
+    // Convert snake_case to Title Case
+    const formatted = relationship
+      .split('_')
+      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(' ');
+
+    return `(${formatted})`;
+  };
+
+  /**
    * Get patient photo URL or null if no photo
    */
   const getPatientPhoto = (patient) => {
@@ -621,6 +636,11 @@ const PatientSelector = ({ onPatientChange, currentPatientId, loading: externalL
         <div style={{ flex: 1 }}>
           <Text size="sm" fw={500}>
             {formatPatientName(patient)}
+            {patient.relationship_to_self && (
+              <Text span c="dimmed" ml="xs" fw={400}>
+                {formatRelationshipLabel(patient.relationship_to_self)}
+              </Text>
+            )}
           </Text>
           <Text size="xs" c="dimmed">
             {patient.birth_date} • {patient.privacy_level}
@@ -682,9 +702,16 @@ const PatientSelector = ({ onPatientChange, currentPatientId, loading: externalL
           color="blue"
           radius="xl"
         />
-        <Text fw={500} size="sm" style={{ flex: 1 }}>
-          {formatPatientName(activePatient)}
-        </Text>
+        <div style={{ flex: 1 }}>
+          <Text fw={500} size="sm">
+            {formatPatientName(activePatient)}
+            {activePatient.relationship_to_self && (
+              <Text span c="dimmed" ml="xs">
+                {formatRelationshipLabel(activePatient.relationship_to_self)}
+              </Text>
+            )}
+          </Text>
+        </div>
         {getPatientBadge(activePatient)}
         
         {/* Loading indicator */}
@@ -741,6 +768,11 @@ const PatientSelector = ({ onPatientChange, currentPatientId, loading: externalL
                   <div>
                     <Text size="sm" fw={patient.id === activePatient?.id ? 600 : 500}>
                       {formatPatientName(patient)}
+                      {patient.relationship_to_self && (
+                        <Text span c="dimmed" ml="xs" fw={400}>
+                          {formatRelationshipLabel(patient.relationship_to_self)}
+                        </Text>
+                      )}
                     </Text>
                     <Text size="xs" c="dimmed">
                       {patient.birth_date}
@@ -835,6 +867,11 @@ const PatientSelector = ({ onPatientChange, currentPatientId, loading: externalL
               <div style={{ flex: 1 }}>
                 <Text fw={500} size="lg">
                   {formatPatientName(activePatient)}
+                  {activePatient.relationship_to_self && (
+                    <Text span c="dimmed" ml="xs" fw={400} size="md">
+                      {formatRelationshipLabel(activePatient.relationship_to_self)}
+                    </Text>
+                  )}
                 </Text>
                 <Text size="sm" c="dimmed">
                   Born: {activePatient.birth_date}

--- a/frontend/src/components/medical/PatientSelector.js
+++ b/frontend/src/components/medical/PatientSelector.js
@@ -45,6 +45,7 @@ import { useDisclosure } from '@mantine/hooks';
 import { toast } from 'react-toastify';
 import { useAuth } from '../../contexts/AuthContext';
 import { usePatientList, useCacheManager } from '../../hooks/useGlobalData';
+import { formatRelationshipLabel } from '../../constants/relationshipOptions';
 import patientApi from '../../services/api/patientApi';
 import patientSharingApi from '../../services/api/patientSharingApi';
 import logger from '../../services/logger';
@@ -572,21 +573,6 @@ const PatientSelector = ({ onPatientChange, currentPatientId, loading: externalL
   };
 
   /**
-   * Format relationship label for display
-   */
-  const formatRelationshipLabel = (relationship) => {
-    if (!relationship) return null;
-
-    // Convert snake_case to Title Case
-    const formatted = relationship
-      .split('_')
-      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(' ');
-
-    return `(${formatted})`;
-  };
-
-  /**
    * Get patient photo URL or null if no photo
    */
   const getPatientPhoto = (patient) => {
@@ -638,7 +624,7 @@ const PatientSelector = ({ onPatientChange, currentPatientId, loading: externalL
             {formatPatientName(patient)}
             {patient.relationship_to_self && (
               <Text span c="dimmed" ml="xs" fw={400}>
-                {formatRelationshipLabel(patient.relationship_to_self)}
+                ({formatRelationshipLabel(patient.relationship_to_self)})
               </Text>
             )}
           </Text>
@@ -707,7 +693,7 @@ const PatientSelector = ({ onPatientChange, currentPatientId, loading: externalL
             {formatPatientName(activePatient)}
             {activePatient.relationship_to_self && (
               <Text span c="dimmed" ml="xs">
-                {formatRelationshipLabel(activePatient.relationship_to_self)}
+                ({formatRelationshipLabel(activePatient.relationship_to_self)})
               </Text>
             )}
           </Text>
@@ -770,7 +756,7 @@ const PatientSelector = ({ onPatientChange, currentPatientId, loading: externalL
                       {formatPatientName(patient)}
                       {patient.relationship_to_self && (
                         <Text span c="dimmed" ml="xs" fw={400}>
-                          {formatRelationshipLabel(patient.relationship_to_self)}
+                          ({formatRelationshipLabel(patient.relationship_to_self)})
                         </Text>
                       )}
                     </Text>
@@ -869,7 +855,7 @@ const PatientSelector = ({ onPatientChange, currentPatientId, loading: externalL
                   {formatPatientName(activePatient)}
                   {activePatient.relationship_to_self && (
                     <Text span c="dimmed" ml="xs" fw={400} size="md">
-                      {formatRelationshipLabel(activePatient.relationship_to_self)}
+                      ({formatRelationshipLabel(activePatient.relationship_to_self)})
                     </Text>
                   )}
                 </Text>

--- a/frontend/src/constants/relationshipOptions.js
+++ b/frontend/src/constants/relationshipOptions.js
@@ -1,0 +1,59 @@
+/**
+ * Relationship to Self Options
+ *
+ * Defines the available relationship types for patient records.
+ * This should match the RelationshipToSelf enum in the backend.
+ */
+
+export const RELATIONSHIP_OPTIONS = [
+  { value: '', label: 'Select relationship (optional)' },
+  { value: 'self', label: 'Self' },
+  { value: 'spouse', label: 'Spouse' },
+  { value: 'partner', label: 'Partner' },
+  { value: 'child', label: 'Child' },
+  { value: 'son', label: 'Son' },
+  { value: 'daughter', label: 'Daughter' },
+  { value: 'parent', label: 'Parent' },
+  { value: 'father', label: 'Father' },
+  { value: 'mother', label: 'Mother' },
+  { value: 'sibling', label: 'Sibling' },
+  { value: 'brother', label: 'Brother' },
+  { value: 'sister', label: 'Sister' },
+  { value: 'grandparent', label: 'Grandparent' },
+  { value: 'grandchild', label: 'Grandchild' },
+  { value: 'other_family', label: 'Other Family' },
+  { value: 'friend', label: 'Friend' },
+  { value: 'other', label: 'Other' },
+];
+
+/**
+ * Format relationship value for display
+ * Converts snake_case to Title Case
+ *
+ * @param {string} relationship - The relationship value (e.g., 'other_family')
+ * @returns {string|null} - Formatted label (e.g., 'Other Family') or null if empty
+ */
+export const formatRelationshipLabel = (relationship) => {
+  if (!relationship) return null;
+
+  // Convert snake_case to Title Case
+  const formatted = relationship
+    .split('_')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+
+  return formatted;
+};
+
+/**
+ * Get relationship label from value
+ *
+ * @param {string} value - The relationship value
+ * @returns {string|null} - The display label or null if not found
+ */
+export const getRelationshipLabel = (value) => {
+  if (!value) return null;
+
+  const option = RELATIONSHIP_OPTIONS.find(opt => opt.value === value);
+  return option ? option.label : formatRelationshipLabel(value);
+};

--- a/frontend/src/pages/medical/Patient-Info.js
+++ b/frontend/src/pages/medical/Patient-Info.js
@@ -78,6 +78,7 @@ const PatientInfo = () => {
     height: '',
     weight: '',
     physician_id: '',
+    relationship_to_self: '',
   });
   const [error, setError] = useState('');
 
@@ -141,6 +142,7 @@ const PatientInfo = () => {
       height: '',
       weight: '',
       physician_id: '',
+      relationship_to_self: '',
     });
   }, []);
 
@@ -157,6 +159,7 @@ const PatientInfo = () => {
       height: patient.height || '',
       weight: patient.weight || '',
       physician_id: patient.physician_id || '',
+      relationship_to_self: patient.relationship_to_self || '',
     });
   }, []);
 
@@ -172,7 +175,8 @@ const PatientInfo = () => {
     }
     setShowModal(true);
     setError('');
-  }, [patientData, resetSubmission, populateFormData, resetFormData]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [patientData, resetSubmission]);
 
   // Check for edit mode from URL parameter
   useEffect(() => {
@@ -207,7 +211,8 @@ const PatientInfo = () => {
       setPatientExists(false);
       resetFormData();
     }
-  }, [patientData, patientError, populateFormData, resetFormData]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [patientData, patientError]);
 
   // Handle global error state
   useEffect(() => {
@@ -455,6 +460,17 @@ const PatientInfo = () => {
                       <span>{getGenderDisplay(patientData.gender)}</span>
                     </div>
                   </div>
+                  {patientData.relationship_to_self && (
+                    <div className="detail-group full-width">
+                      <label>Relationship to You:</label>
+                      <span>
+                        {patientData.relationship_to_self
+                          .split('_')
+                          .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+                          .join(' ')}
+                      </span>
+                    </div>
+                  )}
                   <div className="detail-group full-width">
                     <label>Address:</label>
                     <span>{patientData.address || 'Not provided'}</span>


### PR DESCRIPTION
This pull request introduces a new field, `relationship_to_self`, to the patient data model, replacing the previous `relationship_to_family` field. This change improves clarity in representing the relationship between the patient and the account owner throughout the backend, API, and frontend. The update includes a database migration, schema and model updates, enum definitions, and UI enhancements to support selecting and displaying this relationship.

**Backend changes:**

* Added a new `RelationshipToSelf` enum in `app/models/enums.py` with all possible relationship values, and utility function `get_all_relationship_to_self()` for retrieving valid options. [[1]](diffhunk://#diff-ea1be5f8dde15c3569942ff8dff0fa54349aaac251cc6e6e5544380e43e2f7aaR86-R106) [[2]](diffhunk://#diff-ea1be5f8dde15c3569942ff8dff0fa54349aaac251cc6e6e5544380e43e2f7aaR199-R203)
* Updated the database schema: renamed the column `relationship_to_family` to `relationship_to_self` in the `patients` table via Alembic migration. [[1]](diffhunk://#diff-c0b75e1ab6a99a787630262dff0030399bf06029ca45df985ccb66eae0cf0a8dR1-R28) [[2]](diffhunk://#diff-6136b7719b4607d189578925ce8b2785a6304e57812f17d99ebbb90a11fe4867L145-R149)
* Updated Pydantic schemas (`PatientBase`, `PatientUpdate`, and response/validator logic) to include the new `relationship_to_self` field and handle empty string normalization. [[1]](diffhunk://#diff-572788b83f8c556f25bdcaddae96c87d4fca1d0fc0a2a5e50f14b362aa69c680R32) [[2]](diffhunk://#diff-572788b83f8c556f25bdcaddae96c87d4fca1d0fc0a2a5e50f14b362aa69c680R45) [[3]](diffhunk://#diff-572788b83f8c556f25bdcaddae96c87d4fca1d0fc0a2a5e50f14b362aa69c680R295) [[4]](diffhunk://#diff-572788b83f8c556f25bdcaddae96c87d4fca1d0fc0a2a5e50f14b362aa69c680R311) [[5]](diffhunk://#diff-572788b83f8c556f25bdcaddae96c87d4fca1d0fc0a2a5e50f14b362aa69c680R448)

**Frontend changes:**

* Added "Relationship to You" select input to patient forms (`MantinePatientForm.js`, `PatientForm.js`), allowing users to specify the relationship using the new options. [[1]](diffhunk://#diff-0029ff13a6ea770285a52af1318b59987dbdb4992063bcfb15314c5bcf9d2842R244-R274) [[2]](diffhunk://#diff-8efb159c2315276149ff039e85af6272311649de2d379640b244c6abc2c76d8cR212-R232) [[3]](diffhunk://#diff-8efb159c2315276149ff039e85af6272311649de2d379640b244c6abc2c76d8cR325-R337)
* Updated patient info and selector components to display the relationship in a user-friendly format wherever patient details are shown. [[1]](diffhunk://#diff-cef67f65458db4108931fb70c85ceb8c759e17c9c5e8b5290815939b636f6c7fR639-R643) [[2]](diffhunk://#diff-cef67f65458db4108931fb70c85ceb8c759e17c9c5e8b5290815939b636f6c7fL685-R714) [[3]](diffhunk://#diff-cef67f65458db4108931fb70c85ceb8c759e17c9c5e8b5290815939b636f6c7fR771-R775) [[4]](diffhunk://#diff-cef67f65458db4108931fb70c85ceb8c759e17c9c5e8b5290815939b636f6c7fR870-R874) [[5]](diffhunk://#diff-1e38020d7395053d82bf19fda93553189bc538a124829123f4c0ea8a2fb46569R463-R473)
* Ensured form state and data population logic includes the new field for both creation and editing of patient records. [[1]](diffhunk://#diff-8efb159c2315276149ff039e85af6272311649de2d379640b244c6abc2c76d8cR66) [[2]](diffhunk://#diff-8efb159c2315276149ff039e85af6272311649de2d379640b244c6abc2c76d8cR90) [[3]](diffhunk://#diff-1e38020d7395053d82bf19fda93553189bc538a124829123f4c0ea8a2fb46569R81) [[4]](diffhunk://#diff-1e38020d7395053d82bf19fda93553189bc538a124829123f4c0ea8a2fb46569R145) [[5]](diffhunk://#diff-1e38020d7395053d82bf19fda93553189bc538a124829123f4c0ea8a2fb46569R162)

These changes collectively provide better support for capturing and displaying the relationship between the patient and the account owner, improving data accuracy and user experience.