### PR TITLE
feat: vaccination history

### DIFF
--- a/alembic/migrations/versions/20260529_1200_43c1fba67419_add_standardized_vaccine_fk_to_immunizations.py
+++ b/alembic/migrations/versions/20260529_1200_43c1fba67419_add_standardized_vaccine_fk_to_immunizations.py
@@ -1,0 +1,53 @@
+"""Add standardized_vaccine_id FK to immunizations
+
+Revision ID: 43c1fba67419
+Revises: c1d2e3f4a5b6
+Create Date: 2026-05-29 12:00:00.000000
+
+Adds an optional foreign key from immunizations to standardized_vaccines so
+new records created via the autocomplete picker can be linked back to the
+library entry that was selected. Legacy records and free-text entries retain
+NULL here and fall back to name matching at read time.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "43c1fba67419"
+down_revision = "c1d2e3f4a5b6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "immunizations",
+        sa.Column("standardized_vaccine_id", sa.Integer(), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_immunizations_standardized_vaccine",
+        "immunizations",
+        "standardized_vaccines",
+        ["standardized_vaccine_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index(
+        "ix_immunizations_standardized_vaccine_id",
+        "immunizations",
+        ["standardized_vaccine_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_immunizations_standardized_vaccine_id",
+        table_name="immunizations",
+    )
+    op.drop_constraint(
+        "fk_immunizations_standardized_vaccine",
+        "immunizations",
+        type_="foreignkey",
+    )
+    op.drop_column("immunizations", "standardized_vaccine_id")

--- a/alembic/migrations/versions/20260529_1200_43c1fba67419_add_standardized_vaccine_fk_to_immunizations.py
+++ b/alembic/migrations/versions/20260529_1200_43c1fba67419_add_standardized_vaccine_fk_to_immunizations.py
@@ -34,7 +34,7 @@ def upgrade() -> None:
         ondelete="SET NULL",
     )
     op.create_index(
-        "ix_immunizations_standardized_vaccine_id",
+        "idx_immunizations_standardized_vaccine_id",
         "immunizations",
         ["standardized_vaccine_id"],
     )
@@ -42,7 +42,7 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_index(
-        "ix_immunizations_standardized_vaccine_id",
+        "idx_immunizations_standardized_vaccine_id",
         table_name="immunizations",
     )
     op.drop_constraint(

--- a/app/api/v1/endpoints/immunization.py
+++ b/app/api/v1/endpoints/immunization.py
@@ -353,14 +353,7 @@ def get_immunization_history(
         unmatched_count = 0
 
         for record in records:
-            components, matched = resolve_components(record, library_index)
-
-            # Determine is_combined: derive from the matched library entry
-            matched_vaccine = None
-            if record.standardized_vaccine_id is not None:
-                matched_vaccine = library_index["by_id"].get(record.standardized_vaccine_id)
-            if matched_vaccine is None and record.vaccine_name:
-                matched_vaccine = library_index["by_name"].get(record.vaccine_name.lower())
+            components, matched, matched_vaccine = resolve_components(record, library_index)
             is_combined = bool(matched_vaccine and matched_vaccine.is_combined)
 
             base = ImmunizationResponse.model_validate(record).model_dump()

--- a/app/api/v1/endpoints/immunization.py
+++ b/app/api/v1/endpoints/immunization.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+from datetime import date as date_type
 from typing import Any, List, Optional
 
 from fastapi import APIRouter, Depends, Query, Request
@@ -16,12 +18,16 @@ from app.core.logging.config import get_logger
 from app.core.logging.helpers import log_data_access
 from app.crud.immunization import immunization
 from app.models.activity_log import EntityType
+from app.models.clinical import Immunization
 from app.models.models import User
 from app.schemas.immunization import (
     ImmunizationCreate,
+    ImmunizationHistoryItem,
+    ImmunizationHistoryResponse,
     ImmunizationResponse,
     ImmunizationUpdate,
 )
+from app.services.vaccine_resolver import build_library_index, resolve_components
 
 router = APIRouter()
 
@@ -307,3 +313,86 @@ def get_patient_immunizations(
         )
 
         return immunizations
+
+
+@router.get(
+    "/patient/{patient_id}/history",
+    response_model=ImmunizationHistoryResponse,
+)
+def get_immunization_history(
+    *,
+    request: Request,
+    db: Session = Depends(deps.get_db),
+    patient_id: int = Depends(deps.verify_patient_access),
+    start_date: Optional[date_type] = Query(None),
+    end_date: Optional[date_type] = Query(None),
+    current_user_id: int = Depends(deps.get_current_user_id),
+) -> Any:
+    """Return immunizations for a patient enriched with disease components.
+
+    Combined vaccines are expanded via the StandardizedVaccine library so the
+    history can be presented either chronologically or grouped by disease. The
+    ``diseases_index`` is pre-aggregated server-side so the client doesn't
+    re-derive it on each render.
+    """
+    with handle_database_errors(request=request):
+        query = (
+            db.query(Immunization)
+            .filter(Immunization.patient_id == patient_id)
+        )
+        if start_date is not None:
+            query = query.filter(Immunization.date_administered >= start_date)
+        if end_date is not None:
+            query = query.filter(Immunization.date_administered <= end_date)
+        records = query.order_by(Immunization.date_administered.desc()).all()
+
+        library_index = build_library_index(db)
+
+        items: list[ImmunizationHistoryItem] = []
+        diseases_index: dict[str, list[int]] = defaultdict(list)
+        unmatched_count = 0
+
+        for record in records:
+            components, matched = resolve_components(record, library_index)
+
+            # Determine is_combined: derive from the matched library entry
+            matched_vaccine = None
+            if record.standardized_vaccine_id is not None:
+                matched_vaccine = library_index["by_id"].get(record.standardized_vaccine_id)
+            if matched_vaccine is None and record.vaccine_name:
+                matched_vaccine = library_index["by_name"].get(record.vaccine_name.lower())
+            is_combined = bool(matched_vaccine and matched_vaccine.is_combined)
+
+            base = ImmunizationResponse.model_validate(record).model_dump()
+            items.append(
+                ImmunizationHistoryItem(
+                    **base,
+                    components=components,
+                    is_combined=is_combined,
+                    is_library_matched=matched,
+                )
+            )
+
+            if matched:
+                for disease in components:
+                    diseases_index[disease].append(record.id)
+            else:
+                unmatched_count += 1
+
+        log_data_access(
+            logger,
+            request,
+            current_user_id,
+            "read",
+            "Immunization",
+            patient_id=patient_id,
+            count=len(items),
+            unmatched_count=unmatched_count,
+            event="immunization_history_read",
+        )
+
+        return ImmunizationHistoryResponse(
+            items=items,
+            diseases_index=dict(diseases_index),
+            unmatched_count=unmatched_count,
+        )

--- a/app/crud/immunization.py
+++ b/app/crud/immunization.py
@@ -26,6 +26,10 @@ class CRUDImmunization(
         # Convert Pydantic model to dict while preserving date objects
         obj_data = obj_in.model_dump()
 
+        # who_code is a virtual write-only field; Task 5 resolves it to FK.
+        # Dropping it here keeps the SQLAlchemy constructor happy until then.
+        obj_data.pop("standardized_vaccine_who_code", None)
+
         # Create the database object directly from the dict
         db_obj = self.model(**obj_data)
         db.add(db_obj)
@@ -43,6 +47,8 @@ class CRUDImmunization(
         """
         # Get the data as dict, excluding None values
         update_data = obj_in.model_dump(exclude_unset=True)
+
+        update_data.pop("standardized_vaccine_who_code", None)
 
         # Update the database object
         for field, value in update_data.items():

--- a/app/crud/immunization.py
+++ b/app/crud/immunization.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import Session
 
 from app.crud.base import CRUDBase
 from app.crud.base_tags import TagFilterMixin
+from app.crud.standardized_vaccine import get_vaccine_by_who_code
 from app.models.models import Immunization
 from app.schemas.immunization import ImmunizationCreate, ImmunizationUpdate
 
@@ -18,19 +19,20 @@ class CRUDImmunization(
     """
 
     def create(self, db: Session, *, obj_in: ImmunizationCreate) -> Immunization:
-        """
-        Create a new immunization record.
+        """Create a new immunization record.
 
-        Override base create method to properly handle date fields without jsonable_encoder.
+        If the payload includes a who_code, resolve it to the standardized
+        vaccine FK before insert. Unknown codes are silently dropped - the
+        record still saves with NULL FK, and the user is the source of truth
+        for whether the vaccine_name is real.
         """
-        # Convert Pydantic model to dict while preserving date objects
         obj_data = obj_in.model_dump()
+        who_code = obj_data.pop("standardized_vaccine_who_code", None)
+        if who_code:
+            vaccine = get_vaccine_by_who_code(db, who_code)
+            if vaccine:
+                obj_data["standardized_vaccine_id"] = vaccine.id
 
-        # who_code is a virtual write-only field; Task 5 resolves it to FK.
-        # Dropping it here keeps the SQLAlchemy constructor happy until then.
-        obj_data.pop("standardized_vaccine_who_code", None)
-
-        # Create the database object directly from the dict
         db_obj = self.model(**obj_data)
         db.add(db_obj)
         db.commit()
@@ -40,17 +42,24 @@ class CRUDImmunization(
     def update(
         self, db: Session, *, db_obj: Immunization, obj_in: ImmunizationUpdate
     ) -> Immunization:
-        """
-        Update an immunization record.
+        """Update an immunization record.
 
-        Override base update method to properly handle date fields without jsonable_encoder.
+        ``standardized_vaccine_who_code`` works as a virtual field: present and
+        resolvable -> set FK; present but unknown -> clear FK; explicit ``None``
+        -> clear FK; absent from payload -> preserve existing FK.
         """
-        # Get the data as dict, excluding None values
         update_data = obj_in.model_dump(exclude_unset=True)
 
-        update_data.pop("standardized_vaccine_who_code", None)
+        if "standardized_vaccine_who_code" in update_data:
+            who_code = update_data.pop("standardized_vaccine_who_code")
+            if who_code is None:
+                update_data["standardized_vaccine_id"] = None
+            else:
+                vaccine = get_vaccine_by_who_code(db, who_code)
+                update_data["standardized_vaccine_id"] = (
+                    vaccine.id if vaccine else None
+                )
 
-        # Update the database object
         for field, value in update_data.items():
             setattr(db_obj, field, value)
 

--- a/app/models/clinical.py
+++ b/app/models/clinical.py
@@ -280,7 +280,6 @@ class Immunization(Base):
         Integer,
         ForeignKey("standardized_vaccines.id", ondelete="SET NULL"),
         nullable=True,
-        index=True,
     )
 
     # Table Relationships
@@ -292,7 +291,10 @@ class Immunization(Base):
     )
 
     # Indexes for performance
-    __table_args__ = (Index("idx_immunizations_patient_id", "patient_id"),)
+    __table_args__ = (
+        Index("idx_immunizations_patient_id", "patient_id"),
+        Index("idx_immunizations_standardized_vaccine_id", "standardized_vaccine_id"),
+    )
 
 
 class StandardizedVaccine(Base):

--- a/app/models/clinical.py
+++ b/app/models/clinical.py
@@ -273,9 +273,23 @@ class Immunization(Base):
     # Tagging system
     tags = Column(JSON, nullable=True, default=list)
 
+    # Optional link to standardized vaccine library entry. Captured when the
+    # user picks from the Immunization form's autocomplete. Free-text entries
+    # leave this null; the history view falls back to name-based matching.
+    standardized_vaccine_id = Column(
+        Integer,
+        ForeignKey("standardized_vaccines.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
     # Table Relationships
     patient = orm_relationship("Patient", back_populates="immunizations")
     practitioner = orm_relationship("Practitioner", back_populates="immunizations")
+    standardized_vaccine = orm_relationship(
+        "StandardizedVaccine",
+        foreign_keys=[standardized_vaccine_id],
+    )
 
     # Indexes for performance
     __table_args__ = (Index("idx_immunizations_patient_id", "patient_id"),)

--- a/app/schemas/immunization.py
+++ b/app/schemas/immunization.py
@@ -103,8 +103,10 @@ class ImmunizationCreate(ImmunizationBase):
         max_length=100,
         description=(
             "WHO PCMT code of the standardized vaccine the user picked from the "
-            "autocomplete. Backend resolves this to standardized_vaccine_id; "
-            "ignored if not found in the library."
+            "autocomplete. The backend attempts to resolve it to "
+            "standardized_vaccine_id; if no matching library entry exists, the "
+            "record is saved with standardized_vaccine_id=NULL (the free-text "
+            "vaccine_name remains the source of truth)."
         ),
     )
 

--- a/app/schemas/immunization.py
+++ b/app/schemas/immunization.py
@@ -48,6 +48,11 @@ class ImmunizationBase(TaggedEntityMixin):
     practitioner_id: Optional[int] = Field(
         None, gt=0, description="ID of the administering practitioner"
     )
+    standardized_vaccine_id: Optional[int] = Field(
+        None,
+        gt=0,
+        description="FK to standardized_vaccines.id if this record is linked to the library",
+    )
 
     @field_validator("date_administered", mode="before")
     @classmethod
@@ -98,7 +103,15 @@ class ImmunizationBase(TaggedEntityMixin):
 
 
 class ImmunizationCreate(ImmunizationBase):
-    pass
+    standardized_vaccine_who_code: Optional[str] = Field(
+        None,
+        max_length=100,
+        description=(
+            "WHO PCMT code of the standardized vaccine the user picked from the "
+            "autocomplete. Backend resolves this to standardized_vaccine_id; "
+            "ignored if not found in the library."
+        ),
+    )
 
 
 class ImmunizationUpdate(BaseModel):
@@ -116,6 +129,14 @@ class ImmunizationUpdate(BaseModel):
     notes: Optional[str] = Field(None, max_length=5000)
     practitioner_id: Optional[int] = Field(None, gt=0)
     tags: Optional[List[str]] = None
+    standardized_vaccine_who_code: Optional[str] = Field(
+        None,
+        max_length=100,
+        description=(
+            "WHO PCMT code of the standardized vaccine the user picked. Pass "
+            "explicit null to clear the link (e.g., user converted to free-text)."
+        ),
+    )
 
     @field_validator("date_administered", mode="before")
     @classmethod
@@ -182,5 +203,32 @@ class ImmunizationSummary(BaseModel):
     dose_number: Optional[int]
     patient_name: Optional[str] = None
     practitioner_name: Optional[str] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ImmunizationHistoryItem(ImmunizationResponse):
+    components: List[str] = Field(
+        default_factory=list,
+        description="Disease components this immunization covers",
+    )
+    is_combined: bool = Field(
+        False, description="True if the linked vaccine is a combination vaccine"
+    )
+    is_library_matched: bool = Field(
+        False,
+        description="True if the record was successfully matched to a library entry",
+    )
+
+
+class ImmunizationHistoryResponse(BaseModel):
+    items: List[ImmunizationHistoryItem]
+    diseases_index: dict[str, List[int]] = Field(
+        default_factory=dict,
+        description="Mapping of disease name to immunization IDs covering that disease",
+    )
+    unmatched_count: int = Field(
+        0, ge=0, description="Number of records that could not be matched to the library"
+    )
 
     model_config = ConfigDict(from_attributes=True)

--- a/app/schemas/immunization.py
+++ b/app/schemas/immunization.py
@@ -1,5 +1,5 @@
 from datetime import date
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
 
@@ -47,11 +47,6 @@ class ImmunizationBase(TaggedEntityMixin):
     patient_id: int = Field(..., gt=0, description="ID of the patient")
     practitioner_id: Optional[int] = Field(
         None, gt=0, description="ID of the administering practitioner"
-    )
-    standardized_vaccine_id: Optional[int] = Field(
-        None,
-        gt=0,
-        description="FK to standardized_vaccines.id if this record is linked to the library",
     )
 
     @field_validator("date_administered", mode="before")
@@ -185,6 +180,11 @@ class ImmunizationUpdate(BaseModel):
 
 class ImmunizationResponse(ImmunizationBase):
     id: int
+    standardized_vaccine_id: Optional[int] = Field(
+        None,
+        gt=0,
+        description="FK to standardized_vaccines.id if this record is linked to the library",
+    )
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -223,12 +223,10 @@ class ImmunizationHistoryItem(ImmunizationResponse):
 
 class ImmunizationHistoryResponse(BaseModel):
     items: List[ImmunizationHistoryItem]
-    diseases_index: dict[str, List[int]] = Field(
+    diseases_index: Dict[str, List[int]] = Field(
         default_factory=dict,
         description="Mapping of disease name to immunization IDs covering that disease",
     )
     unmatched_count: int = Field(
         0, ge=0, description="Number of records that could not be matched to the library"
     )
-
-    model_config = ConfigDict(from_attributes=True)

--- a/app/services/vaccine_resolver.py
+++ b/app/services/vaccine_resolver.py
@@ -68,17 +68,21 @@ def _components_for(vaccine: StandardizedVaccine) -> list[str]:
 def resolve_components(
     immunization: Immunization,
     library_index: LibraryIndex,
-) -> tuple[list[str], bool]:
+) -> tuple[list[str], bool, StandardizedVaccine | None]:
     """Resolve an immunization to its disease components.
 
-    Returns ``(components, was_matched)``. Matching order:
+    Returns ``(components, was_matched, matched_vaccine)``. Matching order:
       1. FK lookup via ``standardized_vaccine_id``.
       2. Exact (case-insensitive) match on ``vaccine_name`` or a library
          entry's ``common_names``.
-      3. No match → empty list, ``was_matched=False``.
+      3. No match → ``([], False, None)``.
 
-    A combined vaccine with empty ``components`` is reported as unmatched so
-    the UI can flag the data issue rather than silently rendering nothing.
+    ``matched_vaccine`` is returned so callers needing additional fields on
+    the library entry (e.g., ``is_combined`` for response shaping) don't have
+    to repeat the lookup. A combined vaccine with empty ``components`` is
+    reported as ``([], False, vaccine)`` — the match exists but the data is
+    incomplete, so the caller can distinguish "no library entry" from
+    "library entry but missing components."
     """
     vaccine: StandardizedVaccine | None = None
 
@@ -89,9 +93,9 @@ def resolve_components(
         vaccine = library_index["by_name"].get(immunization.vaccine_name.lower())
 
     if vaccine is None:
-        return [], False
+        return [], False, None
 
     components = _components_for(vaccine)
     if not components:
-        return [], False
-    return components, True
+        return [], False, vaccine  # match exists but data incomplete
+    return components, True, vaccine

--- a/app/services/vaccine_resolver.py
+++ b/app/services/vaccine_resolver.py
@@ -28,18 +28,27 @@ class LibraryIndex(TypedDict):
 def build_library_index(db: Session) -> LibraryIndex:
     """Build O(1) id and lower-cased name lookups for the full vaccine library.
 
-    common_names are indexed alongside vaccine_name so brand-name records
-    ("Shingrix") still match their canonical library entry.
+    Canonical ``vaccine_name`` is indexed first; ``common_names`` are then
+    added via ``setdefault`` so a brand alias never displaces another
+    vaccine's canonical name, regardless of iteration order.
     """
     vaccines = db.query(StandardizedVaccine).all()
     by_id: dict[int, StandardizedVaccine] = {}
     by_name: dict[str, StandardizedVaccine] = {}
+
+    # Pass 1: canonical names (and id index). Canonical entries always win.
     for vaccine in vaccines:
         by_id[vaccine.id] = vaccine
-        by_name[vaccine.vaccine_name.lower()] = vaccine
+        if vaccine.vaccine_name:
+            by_name[vaccine.vaccine_name.lower()] = vaccine
+
+    # Pass 2: common-name aliases. setdefault ensures they cannot displace
+    # any canonical entry indexed in pass 1.
+    for vaccine in vaccines:
         for alt in vaccine.common_names or []:
             if alt:
                 by_name.setdefault(alt.lower(), vaccine)
+
     return {"by_id": by_id, "by_name": by_name}
 
 

--- a/app/services/vaccine_resolver.py
+++ b/app/services/vaccine_resolver.py
@@ -1,0 +1,88 @@
+"""
+Resolve immunization records to the disease components they cover.
+
+Used by the immunization history endpoint to expand combination vaccines
+(e.g., DTaP) into their components (Diphtheria, Tetanus, Pertussis) and to
+present a chronological history grouped by disease.
+
+The resolver is split into:
+- ``build_library_index`` — single DB read producing a lookup structure.
+- ``resolve_components`` — pure function operating on the pre-built index.
+
+This split keeps the per-record hot path free of I/O so it can be unit-tested
+in isolation and run in tight loops without surprise queries.
+"""
+
+from typing import TypedDict
+
+from sqlalchemy.orm import Session
+
+from app.models.clinical import Immunization, StandardizedVaccine
+
+
+class LibraryIndex(TypedDict):
+    by_id: dict[int, StandardizedVaccine]
+    by_name: dict[str, StandardizedVaccine]
+
+
+def build_library_index(db: Session) -> LibraryIndex:
+    """Build O(1) id and lower-cased name lookups for the full vaccine library.
+
+    common_names are indexed alongside vaccine_name so brand-name records
+    ("Shingrix") still match their canonical library entry.
+    """
+    vaccines = db.query(StandardizedVaccine).all()
+    by_id: dict[int, StandardizedVaccine] = {}
+    by_name: dict[str, StandardizedVaccine] = {}
+    for vaccine in vaccines:
+        by_id[vaccine.id] = vaccine
+        by_name[vaccine.vaccine_name.lower()] = vaccine
+        for alt in vaccine.common_names or []:
+            if alt:
+                by_name.setdefault(alt.lower(), vaccine)
+    return {"by_id": by_id, "by_name": by_name}
+
+
+def _components_for(vaccine: StandardizedVaccine) -> list[str]:
+    """Return the disease components covered by a vaccine.
+
+    Combined vaccines surface their stored components; single-disease vaccines
+    return their own canonical name. A combined vaccine with missing
+    components is treated as unmatched — the caller decides what to do.
+    """
+    if vaccine.is_combined:
+        components = vaccine.components or []
+        return list(components)
+    return [vaccine.vaccine_name]
+
+
+def resolve_components(
+    immunization: Immunization,
+    library_index: LibraryIndex,
+) -> tuple[list[str], bool]:
+    """Resolve an immunization to its disease components.
+
+    Returns ``(components, was_matched)``. Matching order:
+      1. FK lookup via ``standardized_vaccine_id``.
+      2. Exact (case-insensitive) match on ``vaccine_name`` or a library
+         entry's ``common_names``.
+      3. No match → empty list, ``was_matched=False``.
+
+    A combined vaccine with empty ``components`` is reported as unmatched so
+    the UI can flag the data issue rather than silently rendering nothing.
+    """
+    vaccine: StandardizedVaccine | None = None
+
+    if immunization.standardized_vaccine_id is not None:
+        vaccine = library_index["by_id"].get(immunization.standardized_vaccine_id)
+
+    if vaccine is None and immunization.vaccine_name:
+        vaccine = library_index["by_name"].get(immunization.vaccine_name.lower())
+
+    if vaccine is None:
+        return [], False
+
+    components = _components_for(vaccine)
+    if not components:
+        return [], False
+    return components, True

--- a/docs/developer-guide/02-api-reference.md
+++ b/docs/developer-guide/02-api-reference.md
@@ -1261,9 +1261,21 @@ Base path: `/api/v1/immunizations`
   "expiration_date": "2026-01-15",
   "site": "Left arm",
   "route": "Intramuscular",
-  "notes": "No adverse reactions"
+  "notes": "No adverse reactions",
+  "standardized_vaccine_who_code": "XM1NL1"
 }
 ```
+
+- **Optional fields**:
+  - `standardized_vaccine_who_code` (string): WHO PCMT code of the standardized vaccine the user picked from the autocomplete. The backend resolves this to `standardized_vaccine_id`. Unknown codes are silently ignored (the record saves with NULL FK).
+
+#### Update Immunization
+
+`PUT /immunizations/{immunization_id}`
+
+- **Purpose**: Update an existing immunization record. Accepts the same fields as Create (all optional on update).
+- **Optional fields**:
+  - `standardized_vaccine_who_code` (string or null): WHO PCMT code of the standardized vaccine the user picked from the autocomplete. The backend resolves this to `standardized_vaccine_id`. Unknown codes are silently ignored (the record saves with NULL FK). Pass explicit `null` to clear an existing link.
 
 #### List Immunizations
 
@@ -1274,6 +1286,63 @@ Base path: `/api/v1/immunizations`
 `GET /immunizations/patient/{patient_id}/upcoming`
 
 - **Purpose**: Get immunizations scheduled for the future
+
+#### Get Immunization History
+
+`GET /immunizations/patient/{patient_id}/history`
+
+- **Purpose**: Returns immunizations enriched with disease components, suitable for the History view in the UI. Combined vaccines (e.g., DTaP) are expanded via the StandardizedVaccine library so a single record can be surfaced under each disease it covers.
+- **Authentication**: Yes
+- **Query Parameters**:
+  - `start_date` (string, optional, ISO date): include records with `date_administered >= start_date`
+  - `end_date` (string, optional, ISO date): include records with `date_administered <= end_date`
+- **Success Response** (200):
+
+```json
+{
+  "items": [
+    {
+      "id": 12,
+      "patient_id": 42,
+      "vaccine_name": "DTaP",
+      "vaccine_trade_name": "Daptacel",
+      "date_administered": "2024-03-15",
+      "dose_number": 4,
+      "lot_number": "ABC123",
+      "ndc_number": null,
+      "manufacturer": null,
+      "site": null,
+      "route": null,
+      "expiration_date": null,
+      "location": null,
+      "notes": null,
+      "practitioner_id": null,
+      "tags": [],
+      "standardized_vaccine_id": 10,
+      "components": ["Diphtheria", "Tetanus", "Pertussis"],
+      "is_combined": true,
+      "is_library_matched": true
+    }
+  ],
+  "diseases_index": {
+    "Diphtheria": [12],
+    "Tetanus": [12],
+    "Pertussis": [12]
+  },
+  "unmatched_count": 0
+}
+```
+
+- **Response fields specific to this endpoint**:
+  - `components`: array of disease component names this immunization covers (empty for unmatched records)
+  - `is_combined`: true if the linked vaccine is a combination vaccine
+  - `is_library_matched`: true if the record was successfully matched to a library entry (either via `standardized_vaccine_id` FK or case-insensitive name match against `StandardizedVaccine.vaccine_name` or `common_names`)
+  - `diseases_index`: mapping of disease name → list of immunization IDs covering that disease (only populated for matched records)
+  - `unmatched_count`: number of records that could not be resolved to a library entry
+- **Status codes**:
+  - `200` — success (including empty result)
+  - `403` — patient access denied
+  - `404` — patient not found
 
 ### 6.5 Vitals
 

--- a/docs/developer-guide/03-database-schema.md
+++ b/docs/developer-guide/03-database-schema.md
@@ -590,19 +590,23 @@ JUNCTION TABLES (Many-to-Many)
 | location | String | | Where administered |
 | notes | Text | | Additional notes |
 | tags | JSONB | DEFAULT [] | User tags |
+| standardized_vaccine_id | Integer | FK(standardized_vaccines.id) ON DELETE SET NULL, NULLABLE | Optional link to the StandardizedVaccine library entry the user picked from the form autocomplete. NULL for free-text records or records created before the vaccine library was introduced. |
 | created_at | DateTime | NOT NULL | Record creation timestamp |
 | updated_at | DateTime | NOT NULL | Last modification timestamp |
 
 **Relationships**:
 - `patient`: Many-to-one with Patient
 - `practitioner`: Many-to-one with Practitioner
+- `standardized_vaccine`: Many-to-one with StandardizedVaccine (optional; SET NULL on parent delete)
 
 **Indexes**:
 - `idx_immunizations_patient_id` on patient_id
+- `idx_immunizations_standardized_vaccine_id` on standardized_vaccine_id
 
 **Business Rules**:
 - Vaccine name and administration date required
 - Lot number and expiration important for recall tracking
+- `standardized_vaccine_id` is optional; free-text `vaccine_name` is still accepted for entries not in the vaccine library
 
 ### procedures
 **Purpose**: Medical procedures performed on patient
@@ -1760,7 +1764,7 @@ JUNCTION TABLES (Many-to-Many)
 | updated_at | DateTime | NOT NULL | Last modification timestamp |
 
 **Relationships**:
-- None directly. `immunizations.vaccine_name` is intentionally not a foreign key — free-text entries are still permitted.
+- `immunizations`: One-to-many with Immunization via `immunizations.standardized_vaccine_id` (ON DELETE SET NULL). The link is optional — `immunizations.vaccine_name` remains free-text so entries not in this catalog are still permitted.
 
 **Indexes**:
 - `idx_standardized_vaccines_who_code` on who_code (UNIQUE)
@@ -2260,6 +2264,7 @@ def get_utc_now():
 
 **Immunizations**:
 - `idx_immunizations_patient_id` on patient_id
+- `idx_immunizations_standardized_vaccine_id` on standardized_vaccine_id
 
 **Procedures**:
 - `idx_procedures_patient_id` on patient_id

--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -359,11 +359,11 @@
       "vaccineInfo": "Impfstoffinformationen"
     },
     "tabs": {
-      "records": "Records",
-      "history": "History"
+      "records": "Einträge",
+      "history": "Verlauf"
     },
     "history": {
-      "noPatient": "Select a patient to view history."
+      "noPatient": "Wählen Sie einen Patienten aus, um den Verlauf anzuzeigen."
     }
   },
   "insurance": {

--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -357,6 +357,13 @@
       "title": "Impfungsdetails",
       "tradeName": "Handelsname",
       "vaccineInfo": "Impfstoffinformationen"
+    },
+    "tabs": {
+      "records": "Records",
+      "history": "History"
+    },
+    "history": {
+      "noPatient": "Select a patient to view history."
     }
   },
   "insurance": {

--- a/frontend/public/locales/de/medical.json
+++ b/frontend/public/locales/de/medical.json
@@ -394,6 +394,25 @@
       "searchPlaceholder": "Zum Suchen von Impfstoffen eingeben...",
       "combinedHint": "Kombinierter Impfstoff — Bestandteile: {{components}}",
       "matchedCommonName": "Treffer: {{name}}"
+    },
+    "history": {
+      "viewMode": {
+        "byDate": "By Date",
+        "byDisease": "By Disease"
+      },
+      "recordCount": "{{count}} vaccinations",
+      "recordCountSingular": "1 vaccination",
+      "dosesCount": "{{count}} doses",
+      "dosesCountSingular": "1 dose",
+      "doseLabel": "Dose {{n}}",
+      "lotLabel": "Lot {{lot}}",
+      "unlinkedTag": "Unlinked",
+      "emptyAll": "No vaccinations recorded yet.",
+      "emptyRange": "No vaccinations in this range.",
+      "dateRangePlaceholder": "Filter by date range",
+      "noDiseaseData": "No vaccinations are linked to the library. Switch to the By Date view to see all records, or edit a record and re-select a vaccine from the autocomplete to link it.",
+      "unmatchedTitle": "Some records aren't linked to the vaccine library",
+      "unmatchedBanner": "{{count}} records aren't linked. Edit a record and re-select from the autocomplete to link it."
     }
   },
   "injuries": {

--- a/frontend/public/locales/de/medical.json
+++ b/frontend/public/locales/de/medical.json
@@ -397,22 +397,22 @@
     },
     "history": {
       "viewMode": {
-        "byDate": "By Date",
-        "byDisease": "By Disease"
+        "byDate": "Nach Datum",
+        "byDisease": "Nach Krankheit"
       },
-      "recordCount": "{{count}} vaccinations",
-      "recordCountSingular": "1 vaccination",
-      "dosesCount": "{{count}} doses",
-      "dosesCountSingular": "1 dose",
-      "doseLabel": "Dose {{n}}",
-      "lotLabel": "Lot {{lot}}",
-      "unlinkedTag": "Unlinked",
-      "emptyAll": "No vaccinations recorded yet.",
-      "emptyRange": "No vaccinations in this range.",
-      "dateRangePlaceholder": "Filter by date range",
-      "noDiseaseData": "No vaccinations are linked to the library. Switch to the By Date view to see all records, or edit a record and re-select a vaccine from the autocomplete to link it.",
-      "unmatchedTitle": "Some records aren't linked to the vaccine library",
-      "unmatchedBanner": "{{count}} records aren't linked. Edit a record and re-select from the autocomplete to link it."
+      "recordCount": "{{count}} Impfungen",
+      "recordCountSingular": "1 Impfung",
+      "dosesCount": "{{count}} Dosen",
+      "dosesCountSingular": "1 Dosis",
+      "doseLabel": "Dosis {{n}}",
+      "lotLabel": "Charge {{lot}}",
+      "unlinkedTag": "Nicht verknüpft",
+      "emptyAll": "Noch keine Impfungen erfasst.",
+      "emptyRange": "Keine Impfungen in diesem Zeitraum.",
+      "dateRangePlaceholder": "Nach Zeitraum filtern",
+      "noDiseaseData": "Es sind keine Impfungen mit der Bibliothek verknüpft. Wechseln Sie zur Ansicht „Nach Datum“, um alle Einträge zu sehen, oder bearbeiten Sie einen Eintrag und wählen Sie erneut einen Impfstoff aus der automatischen Vervollständigung, um ihn zu verknüpfen.",
+      "unmatchedTitle": "Einige Einträge sind nicht mit der Impfstoffbibliothek verknüpft",
+      "unmatchedBanner": "{{count}} Einträge sind nicht verknüpft. Bearbeiten Sie einen Eintrag und wählen Sie ihn erneut aus der automatischen Vervollständigung, um ihn zu verknüpfen."
     }
   },
   "injuries": {

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -357,6 +357,13 @@
       "title": "Immunization Details",
       "tradeName": "Trade Name",
       "vaccineInfo": "Vaccine Information"
+    },
+    "tabs": {
+      "records": "Records",
+      "history": "History"
+    },
+    "history": {
+      "noPatient": "Select a patient to view history."
     }
   },
   "insurance": {

--- a/frontend/public/locales/en/medical.json
+++ b/frontend/public/locales/en/medical.json
@@ -394,6 +394,25 @@
       "searchPlaceholder": "Type to search vaccines...",
       "combinedHint": "Combined vaccine — components: {{components}}",
       "matchedCommonName": "matched: {{name}}"
+    },
+    "history": {
+      "viewMode": {
+        "byDate": "By Date",
+        "byDisease": "By Disease"
+      },
+      "recordCount": "{{count}} vaccinations",
+      "recordCountSingular": "1 vaccination",
+      "dosesCount": "{{count}} doses",
+      "dosesCountSingular": "1 dose",
+      "doseLabel": "Dose {{n}}",
+      "lotLabel": "Lot {{lot}}",
+      "unlinkedTag": "Unlinked",
+      "emptyAll": "No vaccinations recorded yet.",
+      "emptyRange": "No vaccinations in this range.",
+      "dateRangePlaceholder": "Filter by date range",
+      "noDiseaseData": "No vaccinations are linked to the library. Switch to the By Date view to see all records, or edit a record and re-select a vaccine from the autocomplete to link it.",
+      "unmatchedTitle": "Some records aren't linked to the vaccine library",
+      "unmatchedBanner": "{{count}} records aren't linked. Edit a record and re-select from the autocomplete to link it."
     }
   },
   "injuries": {

--- a/frontend/public/locales/es/common.json
+++ b/frontend/public/locales/es/common.json
@@ -359,11 +359,11 @@
       "vaccineInfo": "Información de la vacuna"
     },
     "tabs": {
-      "records": "Records",
-      "history": "History"
+      "records": "Registros",
+      "history": "Historial"
     },
     "history": {
-      "noPatient": "Select a patient to view history."
+      "noPatient": "Seleccione un paciente para ver el historial."
     }
   },
   "insurance": {

--- a/frontend/public/locales/es/common.json
+++ b/frontend/public/locales/es/common.json
@@ -357,6 +357,13 @@
       "title": "Detalles de la vacunación",
       "tradeName": "Nombre comercial",
       "vaccineInfo": "Información de la vacuna"
+    },
+    "tabs": {
+      "records": "Records",
+      "history": "History"
+    },
+    "history": {
+      "noPatient": "Select a patient to view history."
     }
   },
   "insurance": {

--- a/frontend/public/locales/es/medical.json
+++ b/frontend/public/locales/es/medical.json
@@ -394,6 +394,25 @@
       "searchPlaceholder": "Escribe para buscar vacunas...",
       "combinedHint": "Vacuna combinada — componentes: {{components}}",
       "matchedCommonName": "coincidencia: {{name}}"
+    },
+    "history": {
+      "viewMode": {
+        "byDate": "By Date",
+        "byDisease": "By Disease"
+      },
+      "recordCount": "{{count}} vaccinations",
+      "recordCountSingular": "1 vaccination",
+      "dosesCount": "{{count}} doses",
+      "dosesCountSingular": "1 dose",
+      "doseLabel": "Dose {{n}}",
+      "lotLabel": "Lot {{lot}}",
+      "unlinkedTag": "Unlinked",
+      "emptyAll": "No vaccinations recorded yet.",
+      "emptyRange": "No vaccinations in this range.",
+      "dateRangePlaceholder": "Filter by date range",
+      "noDiseaseData": "No vaccinations are linked to the library. Switch to the By Date view to see all records, or edit a record and re-select a vaccine from the autocomplete to link it.",
+      "unmatchedTitle": "Some records aren't linked to the vaccine library",
+      "unmatchedBanner": "{{count}} records aren't linked. Edit a record and re-select from the autocomplete to link it."
     }
   },
   "injuries": {

--- a/frontend/public/locales/es/medical.json
+++ b/frontend/public/locales/es/medical.json
@@ -397,22 +397,22 @@
     },
     "history": {
       "viewMode": {
-        "byDate": "By Date",
-        "byDisease": "By Disease"
+        "byDate": "Por fecha",
+        "byDisease": "Por enfermedad"
       },
-      "recordCount": "{{count}} vaccinations",
-      "recordCountSingular": "1 vaccination",
-      "dosesCount": "{{count}} doses",
-      "dosesCountSingular": "1 dose",
-      "doseLabel": "Dose {{n}}",
-      "lotLabel": "Lot {{lot}}",
-      "unlinkedTag": "Unlinked",
-      "emptyAll": "No vaccinations recorded yet.",
-      "emptyRange": "No vaccinations in this range.",
-      "dateRangePlaceholder": "Filter by date range",
-      "noDiseaseData": "No vaccinations are linked to the library. Switch to the By Date view to see all records, or edit a record and re-select a vaccine from the autocomplete to link it.",
-      "unmatchedTitle": "Some records aren't linked to the vaccine library",
-      "unmatchedBanner": "{{count}} records aren't linked. Edit a record and re-select from the autocomplete to link it."
+      "recordCount": "{{count}} vacunaciones",
+      "recordCountSingular": "1 vacunación",
+      "dosesCount": "{{count}} dosis",
+      "dosesCountSingular": "1 dosis",
+      "doseLabel": "Dosis {{n}}",
+      "lotLabel": "Lote {{lot}}",
+      "unlinkedTag": "Sin vincular",
+      "emptyAll": "No hay vacunaciones registradas todavía.",
+      "emptyRange": "No hay vacunaciones en este rango.",
+      "dateRangePlaceholder": "Filtrar por rango de fechas",
+      "noDiseaseData": "No hay vacunaciones vinculadas a la biblioteca. Cambie a la vista «Por fecha» para ver todos los registros, o edite un registro y vuelva a seleccionar una vacuna del autocompletado para vincularlo.",
+      "unmatchedTitle": "Algunos registros no están vinculados a la biblioteca de vacunas",
+      "unmatchedBanner": "{{count}} registros no están vinculados. Edite un registro y vuelva a seleccionarlo en el autocompletado para vincularlo."
     }
   },
   "injuries": {

--- a/frontend/public/locales/fr/common.json
+++ b/frontend/public/locales/fr/common.json
@@ -359,11 +359,11 @@
       "vaccineInfo": "Informations sur le vaccin"
     },
     "tabs": {
-      "records": "Records",
-      "history": "History"
+      "records": "Enregistrements",
+      "history": "Historique"
     },
     "history": {
-      "noPatient": "Select a patient to view history."
+      "noPatient": "Sélectionnez un patient pour afficher l'historique."
     }
   },
   "insurance": {

--- a/frontend/public/locales/fr/common.json
+++ b/frontend/public/locales/fr/common.json
@@ -357,6 +357,13 @@
       "title": "Détails de l'immunisation",
       "tradeName": "Nom commercial",
       "vaccineInfo": "Informations sur le vaccin"
+    },
+    "tabs": {
+      "records": "Records",
+      "history": "History"
+    },
+    "history": {
+      "noPatient": "Select a patient to view history."
     }
   },
   "insurance": {

--- a/frontend/public/locales/fr/medical.json
+++ b/frontend/public/locales/fr/medical.json
@@ -394,6 +394,25 @@
       "searchPlaceholder": "Tapez pour rechercher des vaccins...",
       "combinedHint": "Vaccin combiné — composants : {{components}}",
       "matchedCommonName": "correspondance : {{name}}"
+    },
+    "history": {
+      "viewMode": {
+        "byDate": "By Date",
+        "byDisease": "By Disease"
+      },
+      "recordCount": "{{count}} vaccinations",
+      "recordCountSingular": "1 vaccination",
+      "dosesCount": "{{count}} doses",
+      "dosesCountSingular": "1 dose",
+      "doseLabel": "Dose {{n}}",
+      "lotLabel": "Lot {{lot}}",
+      "unlinkedTag": "Unlinked",
+      "emptyAll": "No vaccinations recorded yet.",
+      "emptyRange": "No vaccinations in this range.",
+      "dateRangePlaceholder": "Filter by date range",
+      "noDiseaseData": "No vaccinations are linked to the library. Switch to the By Date view to see all records, or edit a record and re-select a vaccine from the autocomplete to link it.",
+      "unmatchedTitle": "Some records aren't linked to the vaccine library",
+      "unmatchedBanner": "{{count}} records aren't linked. Edit a record and re-select from the autocomplete to link it."
     }
   },
   "injuries": {

--- a/frontend/public/locales/fr/medical.json
+++ b/frontend/public/locales/fr/medical.json
@@ -397,8 +397,8 @@
     },
     "history": {
       "viewMode": {
-        "byDate": "By Date",
-        "byDisease": "By Disease"
+        "byDate": "Par date",
+        "byDisease": "Par maladie"
       },
       "recordCount": "{{count}} vaccinations",
       "recordCountSingular": "1 vaccination",
@@ -406,13 +406,13 @@
       "dosesCountSingular": "1 dose",
       "doseLabel": "Dose {{n}}",
       "lotLabel": "Lot {{lot}}",
-      "unlinkedTag": "Unlinked",
-      "emptyAll": "No vaccinations recorded yet.",
-      "emptyRange": "No vaccinations in this range.",
-      "dateRangePlaceholder": "Filter by date range",
-      "noDiseaseData": "No vaccinations are linked to the library. Switch to the By Date view to see all records, or edit a record and re-select a vaccine from the autocomplete to link it.",
-      "unmatchedTitle": "Some records aren't linked to the vaccine library",
-      "unmatchedBanner": "{{count}} records aren't linked. Edit a record and re-select from the autocomplete to link it."
+      "unlinkedTag": "Non lié",
+      "emptyAll": "Aucune vaccination enregistrée.",
+      "emptyRange": "Aucune vaccination dans cette plage.",
+      "dateRangePlaceholder": "Filtrer par plage de dates",
+      "noDiseaseData": "Aucune vaccination n'est liée à la bibliothèque. Passez à la vue « Par date » pour voir tous les enregistrements, ou modifiez un enregistrement et resélectionnez un vaccin dans l'autocomplétion pour le lier.",
+      "unmatchedTitle": "Certains enregistrements ne sont pas liés à la bibliothèque de vaccins",
+      "unmatchedBanner": "{{count}} enregistrements ne sont pas liés. Modifiez un enregistrement et resélectionnez-le dans l'autocomplétion pour le lier."
     }
   },
   "injuries": {

--- a/frontend/public/locales/it/common.json
+++ b/frontend/public/locales/it/common.json
@@ -357,6 +357,13 @@
       "title": "Dettagli vaccinazione",
       "tradeName": "Nome commerciale",
       "vaccineInfo": "Informazioni sul vaccino"
+    },
+    "tabs": {
+      "records": "Records",
+      "history": "History"
+    },
+    "history": {
+      "noPatient": "Select a patient to view history."
     }
   },
   "insurance": {

--- a/frontend/public/locales/it/common.json
+++ b/frontend/public/locales/it/common.json
@@ -359,11 +359,11 @@
       "vaccineInfo": "Informazioni sul vaccino"
     },
     "tabs": {
-      "records": "Records",
-      "history": "History"
+      "records": "Cartelle",
+      "history": "Cronologia"
     },
     "history": {
-      "noPatient": "Select a patient to view history."
+      "noPatient": "Seleziona un paziente per visualizzare la cronologia."
     }
   },
   "insurance": {

--- a/frontend/public/locales/it/medical.json
+++ b/frontend/public/locales/it/medical.json
@@ -397,22 +397,22 @@
     },
     "history": {
       "viewMode": {
-        "byDate": "By Date",
-        "byDisease": "By Disease"
+        "byDate": "Per data",
+        "byDisease": "Per malattia"
       },
-      "recordCount": "{{count}} vaccinations",
-      "recordCountSingular": "1 vaccination",
-      "dosesCount": "{{count}} doses",
+      "recordCount": "{{count}} vaccinazioni",
+      "recordCountSingular": "1 vaccinazione",
+      "dosesCount": "{{count}} dosi",
       "dosesCountSingular": "1 dose",
       "doseLabel": "Dose {{n}}",
-      "lotLabel": "Lot {{lot}}",
-      "unlinkedTag": "Unlinked",
-      "emptyAll": "No vaccinations recorded yet.",
-      "emptyRange": "No vaccinations in this range.",
-      "dateRangePlaceholder": "Filter by date range",
-      "noDiseaseData": "No vaccinations are linked to the library. Switch to the By Date view to see all records, or edit a record and re-select a vaccine from the autocomplete to link it.",
-      "unmatchedTitle": "Some records aren't linked to the vaccine library",
-      "unmatchedBanner": "{{count}} records aren't linked. Edit a record and re-select from the autocomplete to link it."
+      "lotLabel": "Lotto {{lot}}",
+      "unlinkedTag": "Non collegato",
+      "emptyAll": "Nessuna vaccinazione registrata.",
+      "emptyRange": "Nessuna vaccinazione in questo intervallo.",
+      "dateRangePlaceholder": "Filtra per intervallo di date",
+      "noDiseaseData": "Nessuna vaccinazione è collegata alla libreria. Passa alla vista «Per data» per vedere tutti i record, oppure modifica un record e riseleziona un vaccino dal completamento automatico per collegarlo.",
+      "unmatchedTitle": "Alcuni record non sono collegati alla libreria dei vaccini",
+      "unmatchedBanner": "{{count}} record non sono collegati. Modifica un record e riselezionalo dal completamento automatico per collegarlo."
     }
   },
   "injuries": {

--- a/frontend/public/locales/it/medical.json
+++ b/frontend/public/locales/it/medical.json
@@ -394,6 +394,25 @@
       "searchPlaceholder": "Digita per cercare vaccini...",
       "combinedHint": "Vaccino combinato — componenti: {{components}}",
       "matchedCommonName": "corrisponde: {{name}}"
+    },
+    "history": {
+      "viewMode": {
+        "byDate": "By Date",
+        "byDisease": "By Disease"
+      },
+      "recordCount": "{{count}} vaccinations",
+      "recordCountSingular": "1 vaccination",
+      "dosesCount": "{{count}} doses",
+      "dosesCountSingular": "1 dose",
+      "doseLabel": "Dose {{n}}",
+      "lotLabel": "Lot {{lot}}",
+      "unlinkedTag": "Unlinked",
+      "emptyAll": "No vaccinations recorded yet.",
+      "emptyRange": "No vaccinations in this range.",
+      "dateRangePlaceholder": "Filter by date range",
+      "noDiseaseData": "No vaccinations are linked to the library. Switch to the By Date view to see all records, or edit a record and re-select a vaccine from the autocomplete to link it.",
+      "unmatchedTitle": "Some records aren't linked to the vaccine library",
+      "unmatchedBanner": "{{count}} records aren't linked. Edit a record and re-select from the autocomplete to link it."
     }
   },
   "injuries": {

--- a/frontend/public/locales/nl/common.json
+++ b/frontend/public/locales/nl/common.json
@@ -360,10 +360,10 @@
     },
     "tabs": {
       "records": "Records",
-      "history": "History"
+      "history": "Geschiedenis"
     },
     "history": {
-      "noPatient": "Select a patient to view history."
+      "noPatient": "Selecteer een patiënt om de geschiedenis te bekijken."
     }
   },
   "insurance": {

--- a/frontend/public/locales/nl/common.json
+++ b/frontend/public/locales/nl/common.json
@@ -357,6 +357,13 @@
       "title": "Vaccinatiedetails",
       "tradeName": "Handelsnaam",
       "vaccineInfo": "Vaccininformatie"
+    },
+    "tabs": {
+      "records": "Records",
+      "history": "History"
+    },
+    "history": {
+      "noPatient": "Select a patient to view history."
     }
   },
   "insurance": {

--- a/frontend/public/locales/nl/medical.json
+++ b/frontend/public/locales/nl/medical.json
@@ -394,6 +394,25 @@
       "searchPlaceholder": "Typ om vaccins te zoeken...",
       "combinedHint": "Gecombineerd vaccin — componenten: {{components}}",
       "matchedCommonName": "gevonden: {{name}}"
+    },
+    "history": {
+      "viewMode": {
+        "byDate": "By Date",
+        "byDisease": "By Disease"
+      },
+      "recordCount": "{{count}} vaccinations",
+      "recordCountSingular": "1 vaccination",
+      "dosesCount": "{{count}} doses",
+      "dosesCountSingular": "1 dose",
+      "doseLabel": "Dose {{n}}",
+      "lotLabel": "Lot {{lot}}",
+      "unlinkedTag": "Unlinked",
+      "emptyAll": "No vaccinations recorded yet.",
+      "emptyRange": "No vaccinations in this range.",
+      "dateRangePlaceholder": "Filter by date range",
+      "noDiseaseData": "No vaccinations are linked to the library. Switch to the By Date view to see all records, or edit a record and re-select a vaccine from the autocomplete to link it.",
+      "unmatchedTitle": "Some records aren't linked to the vaccine library",
+      "unmatchedBanner": "{{count}} records aren't linked. Edit a record and re-select from the autocomplete to link it."
     }
   },
   "injuries": {

--- a/frontend/public/locales/nl/medical.json
+++ b/frontend/public/locales/nl/medical.json
@@ -397,22 +397,22 @@
     },
     "history": {
       "viewMode": {
-        "byDate": "By Date",
-        "byDisease": "By Disease"
+        "byDate": "Op datum",
+        "byDisease": "Op ziekte"
       },
-      "recordCount": "{{count}} vaccinations",
-      "recordCountSingular": "1 vaccination",
+      "recordCount": "{{count}} vaccinaties",
+      "recordCountSingular": "1 vaccinatie",
       "dosesCount": "{{count}} doses",
-      "dosesCountSingular": "1 dose",
-      "doseLabel": "Dose {{n}}",
-      "lotLabel": "Lot {{lot}}",
-      "unlinkedTag": "Unlinked",
-      "emptyAll": "No vaccinations recorded yet.",
-      "emptyRange": "No vaccinations in this range.",
-      "dateRangePlaceholder": "Filter by date range",
-      "noDiseaseData": "No vaccinations are linked to the library. Switch to the By Date view to see all records, or edit a record and re-select a vaccine from the autocomplete to link it.",
-      "unmatchedTitle": "Some records aren't linked to the vaccine library",
-      "unmatchedBanner": "{{count}} records aren't linked. Edit a record and re-select from the autocomplete to link it."
+      "dosesCountSingular": "1 dosis",
+      "doseLabel": "Dosis {{n}}",
+      "lotLabel": "Charge {{lot}}",
+      "unlinkedTag": "Niet gekoppeld",
+      "emptyAll": "Nog geen vaccinaties geregistreerd.",
+      "emptyRange": "Geen vaccinaties in deze periode.",
+      "dateRangePlaceholder": "Filter op periode",
+      "noDiseaseData": "Er zijn geen vaccinaties gekoppeld aan de bibliotheek. Schakel over naar de weergave 'Op datum' om alle records te zien, of bewerk een record en selecteer opnieuw een vaccin uit de autocomplete om het te koppelen.",
+      "unmatchedTitle": "Sommige records zijn niet gekoppeld aan de vaccinbibliotheek",
+      "unmatchedBanner": "{{count}} records zijn niet gekoppeld. Bewerk een record en selecteer het opnieuw uit de autocomplete om het te koppelen."
     }
   },
   "injuries": {

--- a/frontend/public/locales/pl/common.json
+++ b/frontend/public/locales/pl/common.json
@@ -357,6 +357,13 @@
       "title": "Szczegóły szczepienia",
       "tradeName": "Nazwa handlowa",
       "vaccineInfo": "Informacje o szczepionce"
+    },
+    "tabs": {
+      "records": "Records",
+      "history": "History"
+    },
+    "history": {
+      "noPatient": "Select a patient to view history."
     }
   },
   "insurance": {

--- a/frontend/public/locales/pl/common.json
+++ b/frontend/public/locales/pl/common.json
@@ -359,11 +359,11 @@
       "vaccineInfo": "Informacje o szczepionce"
     },
     "tabs": {
-      "records": "Records",
-      "history": "History"
+      "records": "Wpisy",
+      "history": "Historia"
     },
     "history": {
-      "noPatient": "Select a patient to view history."
+      "noPatient": "Wybierz pacjenta, aby zobaczyć historię."
     }
   },
   "insurance": {

--- a/frontend/public/locales/pl/medical.json
+++ b/frontend/public/locales/pl/medical.json
@@ -397,22 +397,22 @@
     },
     "history": {
       "viewMode": {
-        "byDate": "By Date",
-        "byDisease": "By Disease"
+        "byDate": "Według daty",
+        "byDisease": "Według choroby"
       },
-      "recordCount": "{{count}} vaccinations",
-      "recordCountSingular": "1 vaccination",
-      "dosesCount": "{{count}} doses",
-      "dosesCountSingular": "1 dose",
-      "doseLabel": "Dose {{n}}",
-      "lotLabel": "Lot {{lot}}",
-      "unlinkedTag": "Unlinked",
-      "emptyAll": "No vaccinations recorded yet.",
-      "emptyRange": "No vaccinations in this range.",
-      "dateRangePlaceholder": "Filter by date range",
-      "noDiseaseData": "No vaccinations are linked to the library. Switch to the By Date view to see all records, or edit a record and re-select a vaccine from the autocomplete to link it.",
-      "unmatchedTitle": "Some records aren't linked to the vaccine library",
-      "unmatchedBanner": "{{count}} records aren't linked. Edit a record and re-select from the autocomplete to link it."
+      "recordCount": "Liczba szczepień: {{count}}",
+      "recordCountSingular": "1 szczepienie",
+      "dosesCount": "Liczba dawek: {{count}}",
+      "dosesCountSingular": "1 dawka",
+      "doseLabel": "Dawka {{n}}",
+      "lotLabel": "Partia {{lot}}",
+      "unlinkedTag": "Niepowiązane",
+      "emptyAll": "Brak zarejestrowanych szczepień.",
+      "emptyRange": "Brak szczepień w tym zakresie.",
+      "dateRangePlaceholder": "Filtruj według zakresu dat",
+      "noDiseaseData": "Żadne szczepienia nie są powiązane z biblioteką. Przełącz na widok „Według daty”, aby zobaczyć wszystkie wpisy, lub edytuj wpis i ponownie wybierz szczepionkę z autouzupełniania, aby ją powiązać.",
+      "unmatchedTitle": "Niektóre wpisy nie są powiązane z biblioteką szczepionek",
+      "unmatchedBanner": "Liczba niepowiązanych wpisów: {{count}}. Edytuj wpis i wybierz go ponownie z autouzupełniania, aby go powiązać."
     }
   },
   "injuries": {

--- a/frontend/public/locales/pl/medical.json
+++ b/frontend/public/locales/pl/medical.json
@@ -394,6 +394,25 @@
       "searchPlaceholder": "Wpisz, aby wyszukać szczepionki...",
       "combinedHint": "Szczepionka złożona — składniki: {{components}}",
       "matchedCommonName": "dopasowano: {{name}}"
+    },
+    "history": {
+      "viewMode": {
+        "byDate": "By Date",
+        "byDisease": "By Disease"
+      },
+      "recordCount": "{{count}} vaccinations",
+      "recordCountSingular": "1 vaccination",
+      "dosesCount": "{{count}} doses",
+      "dosesCountSingular": "1 dose",
+      "doseLabel": "Dose {{n}}",
+      "lotLabel": "Lot {{lot}}",
+      "unlinkedTag": "Unlinked",
+      "emptyAll": "No vaccinations recorded yet.",
+      "emptyRange": "No vaccinations in this range.",
+      "dateRangePlaceholder": "Filter by date range",
+      "noDiseaseData": "No vaccinations are linked to the library. Switch to the By Date view to see all records, or edit a record and re-select a vaccine from the autocomplete to link it.",
+      "unmatchedTitle": "Some records aren't linked to the vaccine library",
+      "unmatchedBanner": "{{count}} records aren't linked. Edit a record and re-select from the autocomplete to link it."
     }
   },
   "injuries": {

--- a/frontend/public/locales/pt/common.json
+++ b/frontend/public/locales/pt/common.json
@@ -357,6 +357,13 @@
       "title": "Detalhes da Imunização",
       "tradeName": "Nome Comercial",
       "vaccineInfo": "Informações da Vacina"
+    },
+    "tabs": {
+      "records": "Records",
+      "history": "History"
+    },
+    "history": {
+      "noPatient": "Select a patient to view history."
     }
   },
   "insurance": {

--- a/frontend/public/locales/pt/common.json
+++ b/frontend/public/locales/pt/common.json
@@ -359,11 +359,11 @@
       "vaccineInfo": "Informações da Vacina"
     },
     "tabs": {
-      "records": "Records",
-      "history": "History"
+      "records": "Registros",
+      "history": "Histórico"
     },
     "history": {
-      "noPatient": "Select a patient to view history."
+      "noPatient": "Selecione um paciente para ver o histórico."
     }
   },
   "insurance": {

--- a/frontend/public/locales/pt/medical.json
+++ b/frontend/public/locales/pt/medical.json
@@ -397,22 +397,22 @@
     },
     "history": {
       "viewMode": {
-        "byDate": "By Date",
-        "byDisease": "By Disease"
+        "byDate": "Por data",
+        "byDisease": "Por doença"
       },
-      "recordCount": "{{count}} vaccinations",
-      "recordCountSingular": "1 vaccination",
+      "recordCount": "{{count}} vacinações",
+      "recordCountSingular": "1 vacinação",
       "dosesCount": "{{count}} doses",
       "dosesCountSingular": "1 dose",
       "doseLabel": "Dose {{n}}",
-      "lotLabel": "Lot {{lot}}",
-      "unlinkedTag": "Unlinked",
-      "emptyAll": "No vaccinations recorded yet.",
-      "emptyRange": "No vaccinations in this range.",
-      "dateRangePlaceholder": "Filter by date range",
-      "noDiseaseData": "No vaccinations are linked to the library. Switch to the By Date view to see all records, or edit a record and re-select a vaccine from the autocomplete to link it.",
-      "unmatchedTitle": "Some records aren't linked to the vaccine library",
-      "unmatchedBanner": "{{count}} records aren't linked. Edit a record and re-select from the autocomplete to link it."
+      "lotLabel": "Lote {{lot}}",
+      "unlinkedTag": "Não vinculado",
+      "emptyAll": "Nenhuma vacinação registrada ainda.",
+      "emptyRange": "Nenhuma vacinação neste intervalo.",
+      "dateRangePlaceholder": "Filtrar por intervalo de datas",
+      "noDiseaseData": "Nenhuma vacinação está vinculada à biblioteca. Mude para a visualização \"Por data\" para ver todos os registros, ou edite um registro e selecione novamente uma vacina no autocompletar para vinculá-lo.",
+      "unmatchedTitle": "Alguns registros não estão vinculados à biblioteca de vacinas",
+      "unmatchedBanner": "{{count}} registros não estão vinculados. Edite um registro e selecione-o novamente no autocompletar para vinculá-lo."
     }
   },
   "injuries": {

--- a/frontend/public/locales/pt/medical.json
+++ b/frontend/public/locales/pt/medical.json
@@ -394,6 +394,25 @@
       "searchPlaceholder": "Digite para pesquisar vacinas...",
       "combinedHint": "Vacina combinada — componentes: {{components}}",
       "matchedCommonName": "corresponde: {{name}}"
+    },
+    "history": {
+      "viewMode": {
+        "byDate": "By Date",
+        "byDisease": "By Disease"
+      },
+      "recordCount": "{{count}} vaccinations",
+      "recordCountSingular": "1 vaccination",
+      "dosesCount": "{{count}} doses",
+      "dosesCountSingular": "1 dose",
+      "doseLabel": "Dose {{n}}",
+      "lotLabel": "Lot {{lot}}",
+      "unlinkedTag": "Unlinked",
+      "emptyAll": "No vaccinations recorded yet.",
+      "emptyRange": "No vaccinations in this range.",
+      "dateRangePlaceholder": "Filter by date range",
+      "noDiseaseData": "No vaccinations are linked to the library. Switch to the By Date view to see all records, or edit a record and re-select a vaccine from the autocomplete to link it.",
+      "unmatchedTitle": "Some records aren't linked to the vaccine library",
+      "unmatchedBanner": "{{count}} records aren't linked. Edit a record and re-select from the autocomplete to link it."
     }
   },
   "injuries": {

--- a/frontend/public/locales/ru/common.json
+++ b/frontend/public/locales/ru/common.json
@@ -357,6 +357,13 @@
       "title": "Подробности прививки",
       "tradeName": "Торговое название",
       "vaccineInfo": "Информация о вакцине"
+    },
+    "tabs": {
+      "records": "Records",
+      "history": "History"
+    },
+    "history": {
+      "noPatient": "Select a patient to view history."
     }
   },
   "insurance": {

--- a/frontend/public/locales/ru/common.json
+++ b/frontend/public/locales/ru/common.json
@@ -359,11 +359,11 @@
       "vaccineInfo": "Информация о вакцине"
     },
     "tabs": {
-      "records": "Records",
-      "history": "History"
+      "records": "Записи",
+      "history": "История"
     },
     "history": {
-      "noPatient": "Select a patient to view history."
+      "noPatient": "Выберите пациента, чтобы просмотреть историю."
     }
   },
   "insurance": {

--- a/frontend/public/locales/ru/medical.json
+++ b/frontend/public/locales/ru/medical.json
@@ -394,6 +394,25 @@
       "searchPlaceholder": "Введите название для поиска вакцин...",
       "combinedHint": "Комбинированная вакцина — компоненты: {{components}}",
       "matchedCommonName": "совпадение: {{name}}"
+    },
+    "history": {
+      "viewMode": {
+        "byDate": "By Date",
+        "byDisease": "By Disease"
+      },
+      "recordCount": "{{count}} vaccinations",
+      "recordCountSingular": "1 vaccination",
+      "dosesCount": "{{count}} doses",
+      "dosesCountSingular": "1 dose",
+      "doseLabel": "Dose {{n}}",
+      "lotLabel": "Lot {{lot}}",
+      "unlinkedTag": "Unlinked",
+      "emptyAll": "No vaccinations recorded yet.",
+      "emptyRange": "No vaccinations in this range.",
+      "dateRangePlaceholder": "Filter by date range",
+      "noDiseaseData": "No vaccinations are linked to the library. Switch to the By Date view to see all records, or edit a record and re-select a vaccine from the autocomplete to link it.",
+      "unmatchedTitle": "Some records aren't linked to the vaccine library",
+      "unmatchedBanner": "{{count}} records aren't linked. Edit a record and re-select from the autocomplete to link it."
     }
   },
   "injuries": {

--- a/frontend/public/locales/ru/medical.json
+++ b/frontend/public/locales/ru/medical.json
@@ -397,22 +397,22 @@
     },
     "history": {
       "viewMode": {
-        "byDate": "By Date",
-        "byDisease": "By Disease"
+        "byDate": "По дате",
+        "byDisease": "По заболеванию"
       },
-      "recordCount": "{{count}} vaccinations",
-      "recordCountSingular": "1 vaccination",
-      "dosesCount": "{{count}} doses",
-      "dosesCountSingular": "1 dose",
-      "doseLabel": "Dose {{n}}",
-      "lotLabel": "Lot {{lot}}",
-      "unlinkedTag": "Unlinked",
-      "emptyAll": "No vaccinations recorded yet.",
-      "emptyRange": "No vaccinations in this range.",
-      "dateRangePlaceholder": "Filter by date range",
-      "noDiseaseData": "No vaccinations are linked to the library. Switch to the By Date view to see all records, or edit a record and re-select a vaccine from the autocomplete to link it.",
-      "unmatchedTitle": "Some records aren't linked to the vaccine library",
-      "unmatchedBanner": "{{count}} records aren't linked. Edit a record and re-select from the autocomplete to link it."
+      "recordCount": "Прививок: {{count}}",
+      "recordCountSingular": "1 прививка",
+      "dosesCount": "Доз: {{count}}",
+      "dosesCountSingular": "1 доза",
+      "doseLabel": "Доза {{n}}",
+      "lotLabel": "Партия {{lot}}",
+      "unlinkedTag": "Не связано",
+      "emptyAll": "Прививки ещё не зарегистрированы.",
+      "emptyRange": "Нет прививок в этом диапазоне.",
+      "dateRangePlaceholder": "Фильтр по диапазону дат",
+      "noDiseaseData": "Ни одна прививка не связана с библиотекой. Переключитесь на режим «По дате», чтобы увидеть все записи, или отредактируйте запись и заново выберите вакцину из автозаполнения, чтобы её связать.",
+      "unmatchedTitle": "Некоторые записи не связаны с библиотекой вакцин",
+      "unmatchedBanner": "Не связано записей: {{count}}. Отредактируйте запись и выберите её снова в автозаполнении, чтобы связать."
     }
   },
   "injuries": {

--- a/frontend/public/locales/sv/common.json
+++ b/frontend/public/locales/sv/common.json
@@ -359,11 +359,11 @@
       "vaccineInfo": "Vaccininformation"
     },
     "tabs": {
-      "records": "Records",
-      "history": "History"
+      "records": "Poster",
+      "history": "Historik"
     },
     "history": {
-      "noPatient": "Select a patient to view history."
+      "noPatient": "Välj en patient för att visa historik."
     }
   },
   "insurance": {

--- a/frontend/public/locales/sv/common.json
+++ b/frontend/public/locales/sv/common.json
@@ -357,6 +357,13 @@
       "title": "Vaccinationsdetaljer",
       "tradeName": "Handelsnamn",
       "vaccineInfo": "Vaccininformation"
+    },
+    "tabs": {
+      "records": "Records",
+      "history": "History"
+    },
+    "history": {
+      "noPatient": "Select a patient to view history."
     }
   },
   "insurance": {

--- a/frontend/public/locales/sv/medical.json
+++ b/frontend/public/locales/sv/medical.json
@@ -397,22 +397,22 @@
     },
     "history": {
       "viewMode": {
-        "byDate": "By Date",
-        "byDisease": "By Disease"
+        "byDate": "Efter datum",
+        "byDisease": "Efter sjukdom"
       },
-      "recordCount": "{{count}} vaccinations",
+      "recordCount": "{{count}} vaccinationer",
       "recordCountSingular": "1 vaccination",
-      "dosesCount": "{{count}} doses",
-      "dosesCountSingular": "1 dose",
-      "doseLabel": "Dose {{n}}",
-      "lotLabel": "Lot {{lot}}",
-      "unlinkedTag": "Unlinked",
-      "emptyAll": "No vaccinations recorded yet.",
-      "emptyRange": "No vaccinations in this range.",
-      "dateRangePlaceholder": "Filter by date range",
-      "noDiseaseData": "No vaccinations are linked to the library. Switch to the By Date view to see all records, or edit a record and re-select a vaccine from the autocomplete to link it.",
-      "unmatchedTitle": "Some records aren't linked to the vaccine library",
-      "unmatchedBanner": "{{count}} records aren't linked. Edit a record and re-select from the autocomplete to link it."
+      "dosesCount": "{{count}} doser",
+      "dosesCountSingular": "1 dos",
+      "doseLabel": "Dos {{n}}",
+      "lotLabel": "Sats {{lot}}",
+      "unlinkedTag": "Inte länkad",
+      "emptyAll": "Inga vaccinationer registrerade ännu.",
+      "emptyRange": "Inga vaccinationer i detta intervall.",
+      "dateRangePlaceholder": "Filtrera efter datumintervall",
+      "noDiseaseData": "Inga vaccinationer är länkade till biblioteket. Växla till vyn \"Efter datum\" för att se alla poster, eller redigera en post och välj ett vaccin igen från autoifyllningen för att länka det.",
+      "unmatchedTitle": "Vissa poster är inte länkade till vaccinbiblioteket",
+      "unmatchedBanner": "{{count}} poster är inte länkade. Redigera en post och välj den igen från autoifyllningen för att länka den."
     }
   },
   "injuries": {

--- a/frontend/public/locales/sv/medical.json
+++ b/frontend/public/locales/sv/medical.json
@@ -394,6 +394,25 @@
       "searchPlaceholder": "Skriv för att söka vacciner...",
       "combinedHint": "Kombinerat vaccin — komponenter: {{components}}",
       "matchedCommonName": "matchning: {{name}}"
+    },
+    "history": {
+      "viewMode": {
+        "byDate": "By Date",
+        "byDisease": "By Disease"
+      },
+      "recordCount": "{{count}} vaccinations",
+      "recordCountSingular": "1 vaccination",
+      "dosesCount": "{{count}} doses",
+      "dosesCountSingular": "1 dose",
+      "doseLabel": "Dose {{n}}",
+      "lotLabel": "Lot {{lot}}",
+      "unlinkedTag": "Unlinked",
+      "emptyAll": "No vaccinations recorded yet.",
+      "emptyRange": "No vaccinations in this range.",
+      "dateRangePlaceholder": "Filter by date range",
+      "noDiseaseData": "No vaccinations are linked to the library. Switch to the By Date view to see all records, or edit a record and re-select a vaccine from the autocomplete to link it.",
+      "unmatchedTitle": "Some records aren't linked to the vaccine library",
+      "unmatchedBanner": "{{count}} records aren't linked. Edit a record and re-select from the autocomplete to link it."
     }
   },
   "injuries": {

--- a/frontend/public/locales/th/common.json
+++ b/frontend/public/locales/th/common.json
@@ -359,11 +359,11 @@
       "vaccineInfo": "ข้อมูลวัคซีน"
     },
     "tabs": {
-      "records": "Records",
-      "history": "History"
+      "records": "บันทึก",
+      "history": "ประวัติ"
     },
     "history": {
-      "noPatient": "Select a patient to view history."
+      "noPatient": "เลือกผู้ป่วยเพื่อดูประวัติ"
     }
   },
   "insurance": {

--- a/frontend/public/locales/th/common.json
+++ b/frontend/public/locales/th/common.json
@@ -357,6 +357,13 @@
       "title": "รายละเอียดการฉีดวัคซีน",
       "tradeName": "ชื่อทางการค้า",
       "vaccineInfo": "ข้อมูลวัคซีน"
+    },
+    "tabs": {
+      "records": "Records",
+      "history": "History"
+    },
+    "history": {
+      "noPatient": "Select a patient to view history."
     }
   },
   "insurance": {

--- a/frontend/public/locales/th/medical.json
+++ b/frontend/public/locales/th/medical.json
@@ -397,22 +397,22 @@
     },
     "history": {
       "viewMode": {
-        "byDate": "By Date",
-        "byDisease": "By Disease"
+        "byDate": "ตามวันที่",
+        "byDisease": "ตามโรค"
       },
-      "recordCount": "{{count}} vaccinations",
-      "recordCountSingular": "1 vaccination",
-      "dosesCount": "{{count}} doses",
-      "dosesCountSingular": "1 dose",
-      "doseLabel": "Dose {{n}}",
-      "lotLabel": "Lot {{lot}}",
-      "unlinkedTag": "Unlinked",
-      "emptyAll": "No vaccinations recorded yet.",
-      "emptyRange": "No vaccinations in this range.",
-      "dateRangePlaceholder": "Filter by date range",
-      "noDiseaseData": "No vaccinations are linked to the library. Switch to the By Date view to see all records, or edit a record and re-select a vaccine from the autocomplete to link it.",
-      "unmatchedTitle": "Some records aren't linked to the vaccine library",
-      "unmatchedBanner": "{{count}} records aren't linked. Edit a record and re-select from the autocomplete to link it."
+      "recordCount": "การฉีดวัคซีน {{count}} ครั้ง",
+      "recordCountSingular": "การฉีดวัคซีน 1 ครั้ง",
+      "dosesCount": "{{count}} โดส",
+      "dosesCountSingular": "1 โดส",
+      "doseLabel": "โดสที่ {{n}}",
+      "lotLabel": "ล็อต {{lot}}",
+      "unlinkedTag": "ไม่ได้เชื่อมโยง",
+      "emptyAll": "ยังไม่มีการบันทึกการฉีดวัคซีน",
+      "emptyRange": "ไม่มีการฉีดวัคซีนในช่วงนี้",
+      "dateRangePlaceholder": "กรองตามช่วงวันที่",
+      "noDiseaseData": "ไม่มีการฉีดวัคซีนที่เชื่อมโยงกับคลัง สลับไปยังมุมมอง \"ตามวันที่\" เพื่อดูบันทึกทั้งหมด หรือแก้ไขบันทึกและเลือกวัคซีนใหม่จากระบบเติมข้อความอัตโนมัติเพื่อเชื่อมโยง",
+      "unmatchedTitle": "บางบันทึกไม่ได้เชื่อมโยงกับคลังวัคซีน",
+      "unmatchedBanner": "{{count}} บันทึกไม่ได้เชื่อมโยง แก้ไขบันทึกและเลือกใหม่จากระบบเติมข้อความอัตโนมัติเพื่อเชื่อมโยง"
     }
   },
   "injuries": {

--- a/frontend/public/locales/th/medical.json
+++ b/frontend/public/locales/th/medical.json
@@ -394,6 +394,25 @@
       "searchPlaceholder": "พิมพ์เพื่อค้นหาวัคซีน...",
       "combinedHint": "วัคซีนรวม — ส่วนประกอบ: {{components}}",
       "matchedCommonName": "ตรงกับ: {{name}}"
+    },
+    "history": {
+      "viewMode": {
+        "byDate": "By Date",
+        "byDisease": "By Disease"
+      },
+      "recordCount": "{{count}} vaccinations",
+      "recordCountSingular": "1 vaccination",
+      "dosesCount": "{{count}} doses",
+      "dosesCountSingular": "1 dose",
+      "doseLabel": "Dose {{n}}",
+      "lotLabel": "Lot {{lot}}",
+      "unlinkedTag": "Unlinked",
+      "emptyAll": "No vaccinations recorded yet.",
+      "emptyRange": "No vaccinations in this range.",
+      "dateRangePlaceholder": "Filter by date range",
+      "noDiseaseData": "No vaccinations are linked to the library. Switch to the By Date view to see all records, or edit a record and re-select a vaccine from the autocomplete to link it.",
+      "unmatchedTitle": "Some records aren't linked to the vaccine library",
+      "unmatchedBanner": "{{count}} records aren't linked. Edit a record and re-select from the autocomplete to link it."
     }
   },
   "injuries": {

--- a/frontend/public/locales/zh/common.json
+++ b/frontend/public/locales/zh/common.json
@@ -357,6 +357,13 @@
       "title": "疫苗详情",
       "tradeName": "商品名",
       "vaccineInfo": "疫苗信息"
+    },
+    "tabs": {
+      "records": "Records",
+      "history": "History"
+    },
+    "history": {
+      "noPatient": "Select a patient to view history."
     }
   },
   "insurance": {

--- a/frontend/public/locales/zh/common.json
+++ b/frontend/public/locales/zh/common.json
@@ -359,11 +359,11 @@
       "vaccineInfo": "疫苗信息"
     },
     "tabs": {
-      "records": "Records",
-      "history": "History"
+      "records": "记录",
+      "history": "历史"
     },
     "history": {
-      "noPatient": "Select a patient to view history."
+      "noPatient": "请选择患者以查看历史。"
     }
   },
   "insurance": {

--- a/frontend/public/locales/zh/medical.json
+++ b/frontend/public/locales/zh/medical.json
@@ -397,22 +397,22 @@
     },
     "history": {
       "viewMode": {
-        "byDate": "By Date",
-        "byDisease": "By Disease"
+        "byDate": "按日期",
+        "byDisease": "按疾病"
       },
-      "recordCount": "{{count}} vaccinations",
-      "recordCountSingular": "1 vaccination",
-      "dosesCount": "{{count}} doses",
-      "dosesCountSingular": "1 dose",
-      "doseLabel": "Dose {{n}}",
-      "lotLabel": "Lot {{lot}}",
-      "unlinkedTag": "Unlinked",
-      "emptyAll": "No vaccinations recorded yet.",
-      "emptyRange": "No vaccinations in this range.",
-      "dateRangePlaceholder": "Filter by date range",
-      "noDiseaseData": "No vaccinations are linked to the library. Switch to the By Date view to see all records, or edit a record and re-select a vaccine from the autocomplete to link it.",
-      "unmatchedTitle": "Some records aren't linked to the vaccine library",
-      "unmatchedBanner": "{{count}} records aren't linked. Edit a record and re-select from the autocomplete to link it."
+      "recordCount": "{{count}} 次接种",
+      "recordCountSingular": "1 次接种",
+      "dosesCount": "{{count}} 剂",
+      "dosesCountSingular": "1 剂",
+      "doseLabel": "第 {{n}} 剂",
+      "lotLabel": "批号 {{lot}}",
+      "unlinkedTag": "未关联",
+      "emptyAll": "暂无接种记录。",
+      "emptyRange": "此范围内无接种记录。",
+      "dateRangePlaceholder": "按日期范围筛选",
+      "noDiseaseData": "暂无接种记录关联到疫苗库。切换到「按日期」视图以查看所有记录，或编辑记录并从自动完成中重新选择疫苗以建立关联。",
+      "unmatchedTitle": "部分记录未关联到疫苗库",
+      "unmatchedBanner": "{{count}} 条记录未关联。编辑记录并从自动完成中重新选择以建立关联。"
     }
   },
   "injuries": {

--- a/frontend/public/locales/zh/medical.json
+++ b/frontend/public/locales/zh/medical.json
@@ -394,6 +394,25 @@
       "searchPlaceholder": "输入以搜索疫苗...",
       "combinedHint": "联合疫苗 — 成分：{{components}}",
       "matchedCommonName": "匹配：{{name}}"
+    },
+    "history": {
+      "viewMode": {
+        "byDate": "By Date",
+        "byDisease": "By Disease"
+      },
+      "recordCount": "{{count}} vaccinations",
+      "recordCountSingular": "1 vaccination",
+      "dosesCount": "{{count}} doses",
+      "dosesCountSingular": "1 dose",
+      "doseLabel": "Dose {{n}}",
+      "lotLabel": "Lot {{lot}}",
+      "unlinkedTag": "Unlinked",
+      "emptyAll": "No vaccinations recorded yet.",
+      "emptyRange": "No vaccinations in this range.",
+      "dateRangePlaceholder": "Filter by date range",
+      "noDiseaseData": "No vaccinations are linked to the library. Switch to the By Date view to see all records, or edit a record and re-select a vaccine from the autocomplete to link it.",
+      "unmatchedTitle": "Some records aren't linked to the vaccine library",
+      "unmatchedBanner": "{{count}} records aren't linked. Edit a record and re-select from the autocomplete to link it."
     }
   },
   "injuries": {

--- a/frontend/src/components/medical/immunizations/ImmunizationFormWrapper.jsx
+++ b/frontend/src/components/medical/immunizations/ImmunizationFormWrapper.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Autocomplete,
   Modal,
@@ -100,6 +100,11 @@ const ImmunizationFormWrapper = ({
   const [activeTab, setActiveTab] = useState('basic');
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  // Tracks whether the next onChange is from a picker selection (where Mantine
+  // re-fires onChange with the option label after onOptionSubmit). We must not
+  // null the who_code in that case — handleVaccineOptionSubmit just set it.
+  const pickerJustFiredRef = useRef(false);
+
   // Form handlers
   const { handleTextInputChange } = useFormHandlers(onInputChange);
 
@@ -123,6 +128,7 @@ const ImmunizationFormWrapper = ({
 
   const handleVaccineOptionSubmit = useCallback(
     selectedValue => {
+      pickerJustFiredRef.current = true;
       const canonicalName = extractVaccineName(selectedValue);
       const libraryEntry = getVaccineByName(canonicalName);
 
@@ -256,8 +262,14 @@ const ImmunizationFormWrapper = ({
                       value={formData.vaccine_name || ''}
                       onChange={value => {
                         setField('vaccine_name', value);
-                        // Typing after picking invalidates the link; the picker
-                        // re-populates the FK only when an option is submitted.
+                        // Mantine fires onChange synchronously after
+                        // onOptionSubmit with the picked option's label — skip
+                        // the clear in that case so the who_code that the
+                        // picker just set isn't immediately nulled out.
+                        if (pickerJustFiredRef.current) {
+                          pickerJustFiredRef.current = false;
+                          return;
+                        }
                         setField('standardized_vaccine_who_code', null);
                       }}
                       onOptionSubmit={handleVaccineOptionSubmit}

--- a/frontend/src/components/medical/immunizations/ImmunizationFormWrapper.jsx
+++ b/frontend/src/components/medical/immunizations/ImmunizationFormWrapper.jsx
@@ -129,6 +129,7 @@ const ImmunizationFormWrapper = ({
       if (!libraryEntry) {
         // Free-text fallback — keep whatever the user picked verbatim.
         setField('vaccine_name', canonicalName);
+        setField('standardized_vaccine_who_code', null);
         return;
       }
 
@@ -139,6 +140,7 @@ const ImmunizationFormWrapper = ({
       // duplicates data. Users can fill in a specific brand manually.
       const commonName = libraryEntry.short_name || libraryEntry.vaccine_name;
       setField('vaccine_name', commonName);
+      setField('standardized_vaccine_who_code', libraryEntry.who_code || null);
 
       if (libraryEntry.default_manufacturer) {
         setField('manufacturer', libraryEntry.default_manufacturer);
@@ -252,7 +254,12 @@ const ImmunizationFormWrapper = ({
                     <Autocomplete
                       label={t('shared:fields.vaccineName', 'Vaccine Name')}
                       value={formData.vaccine_name || ''}
-                      onChange={value => setField('vaccine_name', value)}
+                      onChange={value => {
+                        setField('vaccine_name', value);
+                        // Typing after picking invalidates the link; the picker
+                        // re-populates the FK only when an option is submitted.
+                        setField('standardized_vaccine_who_code', null);
+                      }}
                       onOptionSubmit={handleVaccineOptionSubmit}
                       data={vaccineOptions}
                       limit={50}

--- a/frontend/src/components/medical/immunizations/history/HistoryByDateView.tsx
+++ b/frontend/src/components/medical/immunizations/history/HistoryByDateView.tsx
@@ -1,5 +1,83 @@
-import type { ImmunizationHistoryItem } from './types';
+import { Badge, Card, Group, Stack, Text } from '@mantine/core';
+import { useTranslation } from 'react-i18next';
 
-// Stub - implemented in Task 10
-const HistoryByDateView = (_props: { items: ImmunizationHistoryItem[] }) => null;
+import { useDateFormat } from '../../../../hooks/useDateFormat';
+import type { ImmunizationHistoryItem } from './types';
+import { getDoseNumber } from './utils';
+
+interface Props {
+  items: ImmunizationHistoryItem[];
+}
+
+const HistoryByDateView = ({ items }: Props) => {
+  const { t } = useTranslation(['medical', 'shared']);
+  const { formatDate } = useDateFormat();
+
+  return (
+    <Stack gap="sm">
+      {items.map(item => {
+        const dose = getDoseNumber(item);
+        const doseLabel = dose !== null
+          ? t('medical:immunizations.history.doseLabel', 'Dose {{n}}', { n: dose })
+          : '';
+        const subParts = [doseLabel];
+        if (item.lot_number) {
+          subParts.push(
+            t('medical:immunizations.history.lotLabel', 'Lot {{lot}}', {
+              lot: item.lot_number,
+            })
+          );
+        }
+        const subline = subParts.filter(Boolean).join(' · ');
+
+        const displayName = item.vaccine_trade_name
+          ? `${item.vaccine_name} (${item.vaccine_trade_name})`
+          : item.vaccine_name;
+
+        return (
+          <Card key={item.id} withBorder padding="sm" radius="md">
+            <Group justify="space-between" align="flex-start" wrap="nowrap">
+              <Stack gap={4} style={{ flex: 1 }}>
+                <Group gap="xs" align="baseline">
+                  <Text size="sm" c="dimmed" fw={500}>
+                    {formatDate(item.date_administered)}
+                  </Text>
+                  <Text fw={600}>{displayName}</Text>
+                </Group>
+                {item.is_library_matched && item.components.length > 0 && (
+                  <Group gap="xs">
+                    {item.components.map(component => (
+                      <Badge
+                        key={component}
+                        variant="light"
+                        color="blue"
+                        size="sm"
+                      >
+                        {component}
+                      </Badge>
+                    ))}
+                  </Group>
+                )}
+                {!item.is_library_matched && (
+                  <Badge variant="outline" color="gray" size="sm">
+                    {t(
+                      'medical:immunizations.history.unlinkedTag',
+                      'Unlinked'
+                    )}
+                  </Badge>
+                )}
+                {subline && (
+                  <Text size="xs" c="dimmed">
+                    {subline}
+                  </Text>
+                )}
+              </Stack>
+            </Group>
+          </Card>
+        );
+      })}
+    </Stack>
+  );
+};
+
 export default HistoryByDateView;

--- a/frontend/src/components/medical/immunizations/history/HistoryByDateView.tsx
+++ b/frontend/src/components/medical/immunizations/history/HistoryByDateView.tsx
@@ -7,9 +7,10 @@ import { getDoseNumber } from './utils';
 
 interface Props {
   items: ImmunizationHistoryItem[];
+  onItemClick?: (_item: ImmunizationHistoryItem) => void;
 }
 
-const HistoryByDateView = ({ items }: Props) => {
+const HistoryByDateView = ({ items, onItemClick }: Props) => {
   const { t } = useTranslation(['medical']);
   const { formatDate } = useDateFormat();
 
@@ -34,8 +35,28 @@ const HistoryByDateView = ({ items }: Props) => {
           ? `${item.vaccine_name} (${item.vaccine_trade_name})`
           : item.vaccine_name;
 
+        const clickable = Boolean(onItemClick);
         return (
-          <Card key={item.id} withBorder padding="sm" radius="md">
+          <Card
+            key={item.id}
+            withBorder
+            padding="sm"
+            radius="md"
+            style={clickable ? { cursor: 'pointer' } : undefined}
+            onClick={clickable ? () => onItemClick?.(item) : undefined}
+            role={clickable ? 'button' : undefined}
+            tabIndex={clickable ? 0 : undefined}
+            onKeyDown={
+              clickable
+                ? e => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      onItemClick?.(item);
+                    }
+                  }
+                : undefined
+            }
+          >
             <Group justify="space-between" align="flex-start" wrap="nowrap">
               <Stack gap={4} style={{ flex: 1 }}>
                 <Group gap="xs" align="baseline">

--- a/frontend/src/components/medical/immunizations/history/HistoryByDateView.tsx
+++ b/frontend/src/components/medical/immunizations/history/HistoryByDateView.tsx
@@ -10,7 +10,7 @@ interface Props {
 }
 
 const HistoryByDateView = ({ items }: Props) => {
-  const { t } = useTranslation(['medical', 'shared']);
+  const { t } = useTranslation(['medical']);
   const { formatDate } = useDateFormat();
 
   return (
@@ -44,6 +44,8 @@ const HistoryByDateView = ({ items }: Props) => {
                   </Text>
                   <Text fw={600}>{displayName}</Text>
                 </Group>
+                {/* Backend invariant: is_library_matched implies components.length > 0,
+                    so this check doubles as a defensive guard. */}
                 {item.is_library_matched && item.components.length > 0 && (
                   <Group gap="xs">
                     {item.components.map(component => (

--- a/frontend/src/components/medical/immunizations/history/HistoryByDateView.tsx
+++ b/frontend/src/components/medical/immunizations/history/HistoryByDateView.tsx
@@ -1,0 +1,3 @@
+// Stub - implemented in Task 10
+const HistoryByDateView = (_props: { items: unknown[] }) => null;
+export default HistoryByDateView;

--- a/frontend/src/components/medical/immunizations/history/HistoryByDateView.tsx
+++ b/frontend/src/components/medical/immunizations/history/HistoryByDateView.tsx
@@ -1,3 +1,5 @@
+import type { ImmunizationHistoryItem } from './types';
+
 // Stub - implemented in Task 10
-const HistoryByDateView = (_props: { items: unknown[] }) => null;
+const HistoryByDateView = (_props: { items: ImmunizationHistoryItem[] }) => null;
 export default HistoryByDateView;

--- a/frontend/src/components/medical/immunizations/history/HistoryByDiseaseView.tsx
+++ b/frontend/src/components/medical/immunizations/history/HistoryByDiseaseView.tsx
@@ -1,6 +1,8 @@
+import type { ImmunizationHistoryItem } from './types';
+
 // Stub - implemented in Task 11
 const HistoryByDiseaseView = (_props: {
-  items: unknown[];
+  items: ImmunizationHistoryItem[];
   diseasesIndex: Record<string, number[]>;
 }) => null;
 export default HistoryByDiseaseView;

--- a/frontend/src/components/medical/immunizations/history/HistoryByDiseaseView.tsx
+++ b/frontend/src/components/medical/immunizations/history/HistoryByDiseaseView.tsx
@@ -9,9 +9,14 @@ import { getDoseNumber, groupItemsByDisease } from './utils';
 interface Props {
   items: ImmunizationHistoryItem[];
   diseasesIndex: Record<string, number[]>;
+  onItemClick?: (_item: ImmunizationHistoryItem) => void;
 }
 
-const HistoryByDiseaseView = ({ items, diseasesIndex }: Props) => {
+const HistoryByDiseaseView = ({
+  items,
+  diseasesIndex,
+  onItemClick,
+}: Props) => {
   const { t } = useTranslation(['medical']);
   const { formatDate } = useDateFormat();
 
@@ -59,8 +64,27 @@ const HistoryByDiseaseView = ({ items, diseasesIndex }: Props) => {
                 const doseLabel = dose !== null
                   ? t('medical:immunizations.history.doseLabel', 'Dose {{n}}', { n: dose })
                   : null;
+                const clickable = Boolean(onItemClick);
                 return (
-                  <Group key={item.id} justify="space-between" wrap="nowrap">
+                  <Group
+                    key={item.id}
+                    justify="space-between"
+                    wrap="nowrap"
+                    style={clickable ? { cursor: 'pointer' } : undefined}
+                    onClick={clickable ? () => onItemClick?.(item) : undefined}
+                    role={clickable ? 'button' : undefined}
+                    tabIndex={clickable ? 0 : undefined}
+                    onKeyDown={
+                      clickable
+                        ? e => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                              e.preventDefault();
+                              onItemClick?.(item);
+                            }
+                          }
+                        : undefined
+                    }
+                  >
                     <Group gap="md" wrap="nowrap">
                       <Text size="sm" c="dimmed" style={{ minWidth: 100 }}>
                         {formatDate(item.date_administered)}

--- a/frontend/src/components/medical/immunizations/history/HistoryByDiseaseView.tsx
+++ b/frontend/src/components/medical/immunizations/history/HistoryByDiseaseView.tsx
@@ -25,7 +25,7 @@ const HistoryByDiseaseView = ({ items, diseasesIndex }: Props) => {
       <Text c="dimmed" ta="center" py="md">
         {t(
           'medical:immunizations.history.noDiseaseData',
-          'No linked vaccinations to group by disease.'
+          'No vaccinations are linked to the library. Switch to the By Date view to see all records, or edit a record and re-select a vaccine from the autocomplete to link it.'
         )}
       </Text>
     );

--- a/frontend/src/components/medical/immunizations/history/HistoryByDiseaseView.tsx
+++ b/frontend/src/components/medical/immunizations/history/HistoryByDiseaseView.tsx
@@ -1,0 +1,6 @@
+// Stub - implemented in Task 11
+const HistoryByDiseaseView = (_props: {
+  items: unknown[];
+  diseasesIndex: Record<string, number[]>;
+}) => null;
+export default HistoryByDiseaseView;

--- a/frontend/src/components/medical/immunizations/history/HistoryByDiseaseView.tsx
+++ b/frontend/src/components/medical/immunizations/history/HistoryByDiseaseView.tsx
@@ -1,8 +1,86 @@
-import type { ImmunizationHistoryItem } from './types';
+import { Accordion, Badge, Group, Stack, Text } from '@mantine/core';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 
-// Stub - implemented in Task 11
-const HistoryByDiseaseView = (_props: {
+import { useDateFormat } from '../../../../hooks/useDateFormat';
+import type { ImmunizationHistoryItem } from './types';
+import { getDoseNumber, groupItemsByDisease } from './utils';
+
+interface Props {
   items: ImmunizationHistoryItem[];
   diseasesIndex: Record<string, number[]>;
-}) => null;
+}
+
+const HistoryByDiseaseView = ({ items, diseasesIndex }: Props) => {
+  const { t } = useTranslation(['medical']);
+  const { formatDate } = useDateFormat();
+
+  const grouped = useMemo(
+    () => groupItemsByDisease(items, diseasesIndex),
+    [items, diseasesIndex]
+  );
+
+  if (grouped.length === 0) {
+    return (
+      <Text c="dimmed" ta="center" py="md">
+        {t(
+          'medical:immunizations.history.noDiseaseData',
+          'No linked vaccinations to group by disease.'
+        )}
+      </Text>
+    );
+  }
+
+  return (
+    <Accordion multiple variant="separated">
+      {grouped.map(({ disease, items: diseaseItems }) => (
+        <Accordion.Item key={disease} value={disease}>
+          <Accordion.Control>
+            <Group justify="space-between" wrap="nowrap">
+              <Text fw={600}>{disease}</Text>
+              <Badge variant="light" color="blue">
+                {diseaseItems.length === 1
+                  ? t(
+                      'medical:immunizations.history.dosesCountSingular',
+                      '1 dose'
+                    )
+                  : t(
+                      'medical:immunizations.history.dosesCount',
+                      '{{count}} doses',
+                      { count: diseaseItems.length }
+                    )}
+              </Badge>
+            </Group>
+          </Accordion.Control>
+          <Accordion.Panel>
+            <Stack gap="xs">
+              {diseaseItems.map(item => {
+                const dose = getDoseNumber(item);
+                const doseLabel = dose !== null
+                  ? t('medical:immunizations.history.doseLabel', 'Dose {{n}}', { n: dose })
+                  : null;
+                return (
+                  <Group key={item.id} justify="space-between" wrap="nowrap">
+                    <Group gap="md" wrap="nowrap">
+                      <Text size="sm" c="dimmed" style={{ minWidth: 100 }}>
+                        {formatDate(item.date_administered)}
+                      </Text>
+                      <Text size="sm">{item.vaccine_name}</Text>
+                    </Group>
+                    {doseLabel && (
+                      <Text size="sm" c="dimmed">
+                        {doseLabel}
+                      </Text>
+                    )}
+                  </Group>
+                );
+              })}
+            </Stack>
+          </Accordion.Panel>
+        </Accordion.Item>
+      ))}
+    </Accordion>
+  );
+};
+
 export default HistoryByDiseaseView;

--- a/frontend/src/components/medical/immunizations/history/ImmunizationHistoryTab.tsx
+++ b/frontend/src/components/medical/immunizations/history/ImmunizationHistoryTab.tsx
@@ -36,6 +36,7 @@ const ImmunizationHistoryTab = ({ patientId }: Props) => {
   const [data, setData] = useState<ImmunizationHistoryResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [unmatchedDismissed, setUnmatchedDismissed] = useState(false);
 
   useEffect(() => {
     if (!patientId) return;
@@ -52,6 +53,7 @@ const ImmunizationHistoryTab = ({ patientId }: Props) => {
         controller.signal
       )
       .then((response: ImmunizationHistoryResponse) => {
+        if (controller.signal.aborted) return;
         setData(response);
         setLoading(false);
       })
@@ -185,7 +187,7 @@ const ImmunizationHistoryTab = ({ patientId }: Props) => {
         </Group>
       </Group>
 
-      {data.unmatched_count > 0 && (
+      {data.unmatched_count > 0 && !unmatchedDismissed && (
         <Alert
           color="blue"
           icon={<IconInfoCircle size={16} />}
@@ -194,6 +196,7 @@ const ImmunizationHistoryTab = ({ patientId }: Props) => {
             "Some records aren't linked to the vaccine library"
           )}
           withCloseButton
+          onClose={() => setUnmatchedDismissed(true)}
         >
           {t(
             'medical:immunizations.history.unmatchedBanner',

--- a/frontend/src/components/medical/immunizations/history/ImmunizationHistoryTab.tsx
+++ b/frontend/src/components/medical/immunizations/history/ImmunizationHistoryTab.tsx
@@ -17,11 +17,13 @@ import HistoryByDateView from './HistoryByDateView';
 import HistoryByDiseaseView from './HistoryByDiseaseView';
 import type {
   HistoryViewMode,
+  ImmunizationHistoryItem,
   ImmunizationHistoryResponse,
 } from './types';
 
 interface Props {
   patientId: number;
+  onItemClick?: (_item: ImmunizationHistoryItem) => void;
 }
 
 // Mantine v8 DatePickerInput emits ISO-formatted date strings (YYYY-MM-DD) by
@@ -29,7 +31,7 @@ interface Props {
 // the API without further conversion.
 type DateRange = [string | null, string | null];
 
-const ImmunizationHistoryTab = ({ patientId }: Props) => {
+const ImmunizationHistoryTab = ({ patientId, onItemClick }: Props) => {
   const { t } = useTranslation(['medical', 'common']);
   const [viewMode, setViewMode] = useState<HistoryViewMode>('byDate');
   const [dateRange, setDateRange] = useState<DateRange>([null, null]);
@@ -207,11 +209,12 @@ const ImmunizationHistoryTab = ({ patientId }: Props) => {
       )}
 
       {viewMode === 'byDate' ? (
-        <HistoryByDateView items={data.items} />
+        <HistoryByDateView items={data.items} onItemClick={onItemClick} />
       ) : (
         <HistoryByDiseaseView
           items={data.items}
           diseasesIndex={data.diseases_index}
+          onItemClick={onItemClick}
         />
       )}
     </Stack>

--- a/frontend/src/components/medical/immunizations/history/ImmunizationHistoryTab.tsx
+++ b/frontend/src/components/medical/immunizations/history/ImmunizationHistoryTab.tsx
@@ -45,6 +45,9 @@ const ImmunizationHistoryTab = ({ patientId, onItemClick }: Props) => {
     const controller = new AbortController();
     setLoading(true);
     setError(null);
+    // Show the unmatched banner again whenever query inputs change — the new
+    // result set may have different unmatched records than the dismissed one.
+    setUnmatchedDismissed(false);
     apiService
       .getImmunizationHistory(
         patientId,

--- a/frontend/src/components/medical/immunizations/history/ImmunizationHistoryTab.tsx
+++ b/frontend/src/components/medical/immunizations/history/ImmunizationHistoryTab.tsx
@@ -1,0 +1,218 @@
+import { useState, useEffect, useMemo } from 'react';
+import {
+  Alert,
+  Group,
+  SegmentedControl,
+  Skeleton,
+  Stack,
+  Text,
+} from '@mantine/core';
+import { DatePickerInput } from '@mantine/dates';
+import { IconAlertCircle, IconInfoCircle } from '@tabler/icons-react';
+import { useTranslation } from 'react-i18next';
+
+import { apiService } from '../../../../services/api';
+import logger from '../../../../services/logger';
+import HistoryByDateView from './HistoryByDateView';
+import HistoryByDiseaseView from './HistoryByDiseaseView';
+import type {
+  HistoryViewMode,
+  ImmunizationHistoryResponse,
+} from './types';
+
+interface Props {
+  patientId: number;
+}
+
+// Mantine v8 DatePickerInput emits ISO-formatted date strings (YYYY-MM-DD) by
+// default. We keep state in that same shape so the value can flow straight to
+// the API without further conversion.
+type DateRange = [string | null, string | null];
+
+const ImmunizationHistoryTab = ({ patientId }: Props) => {
+  const { t } = useTranslation(['medical', 'common']);
+  const [viewMode, setViewMode] = useState<HistoryViewMode>('byDate');
+  const [dateRange, setDateRange] = useState<DateRange>([null, null]);
+  const [data, setData] = useState<ImmunizationHistoryResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!patientId) return;
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+    apiService
+      .getImmunizationHistory(
+        patientId,
+        {
+          startDate: dateRange[0],
+          endDate: dateRange[1],
+        },
+        controller.signal
+      )
+      .then((response: ImmunizationHistoryResponse) => {
+        setData(response);
+        setLoading(false);
+      })
+      .catch((err: Error) => {
+        if (controller.signal.aborted) return;
+        logger.error('immunization_history_fetch_failed', {
+          message: 'Failed to fetch immunization history',
+          patientId,
+          error: err.message,
+          component: 'ImmunizationHistoryTab',
+        });
+        setError(err.message || 'Failed to load history');
+        setLoading(false);
+      });
+    return () => controller.abort();
+  }, [patientId, dateRange]);
+
+  const viewModeOptions = useMemo(
+    () => [
+      {
+        value: 'byDate',
+        label: t('medical:immunizations.history.viewMode.byDate', 'By Date'),
+      },
+      {
+        value: 'byDisease',
+        label: t(
+          'medical:immunizations.history.viewMode.byDisease',
+          'By Disease'
+        ),
+      },
+    ],
+    [t]
+  );
+
+  if (loading) {
+    return (
+      <Stack gap="sm">
+        <Skeleton height={36} width={240} />
+        <Skeleton height={80} />
+        <Skeleton height={80} />
+        <Skeleton height={80} />
+      </Stack>
+    );
+  }
+
+  if (error) {
+    return (
+      <Alert
+        color="red"
+        title={t('common:errors.loadFailed', 'Failed to load')}
+        icon={<IconAlertCircle size={16} />}
+        role="alert"
+      >
+        {error}
+      </Alert>
+    );
+  }
+
+  const hasDateFilter = Boolean(dateRange[0] || dateRange[1]);
+
+  if (!data || data.items.length === 0) {
+    return (
+      <Stack gap="md">
+        <Group justify="space-between" align="center" wrap="wrap">
+          <SegmentedControl
+            value={viewMode}
+            onChange={value => setViewMode(value as HistoryViewMode)}
+            data={viewModeOptions}
+          />
+          <DatePickerInput
+            type="range"
+            value={dateRange}
+            onChange={setDateRange}
+            placeholder={t(
+              'medical:immunizations.history.dateRangePlaceholder',
+              'Filter by date range'
+            )}
+            clearable
+            firstDayOfWeek={0}
+            popoverProps={{ withinPortal: true, zIndex: 3000 }}
+          />
+        </Group>
+        <Text c="dimmed" ta="center" py="xl">
+          {hasDateFilter
+            ? t(
+                'medical:immunizations.history.emptyRange',
+                'No vaccinations in this range.'
+              )
+            : t(
+                'medical:immunizations.history.emptyAll',
+                'No vaccinations recorded yet.'
+              )}
+        </Text>
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack gap="md">
+      <Group justify="space-between" align="center" wrap="wrap">
+        <SegmentedControl
+          value={viewMode}
+          onChange={value => setViewMode(value as HistoryViewMode)}
+          data={viewModeOptions}
+        />
+        <Group gap="md" wrap="nowrap">
+          <DatePickerInput
+            type="range"
+            value={dateRange}
+            onChange={setDateRange}
+            placeholder={t(
+              'medical:immunizations.history.dateRangePlaceholder',
+              'Filter by date range'
+            )}
+            clearable
+            firstDayOfWeek={0}
+            popoverProps={{ withinPortal: true, zIndex: 3000 }}
+          />
+          <Text size="sm" c="dimmed">
+            {data.items.length === 1
+              ? t(
+                  'medical:immunizations.history.recordCountSingular',
+                  '1 vaccination'
+                )
+              : t(
+                  'medical:immunizations.history.recordCount',
+                  '{{count}} vaccinations',
+                  { count: data.items.length }
+                )}
+          </Text>
+        </Group>
+      </Group>
+
+      {data.unmatched_count > 0 && (
+        <Alert
+          color="blue"
+          icon={<IconInfoCircle size={16} />}
+          title={t(
+            'medical:immunizations.history.unmatchedTitle',
+            "Some records aren't linked to the vaccine library"
+          )}
+          withCloseButton
+        >
+          {t(
+            'medical:immunizations.history.unmatchedBanner',
+            "{{count}} records aren't linked. Edit a record and re-select from the autocomplete to link it.",
+            { count: data.unmatched_count }
+          )}
+        </Alert>
+      )}
+
+      {viewMode === 'byDate' ? (
+        <HistoryByDateView items={data.items} />
+      ) : (
+        <HistoryByDiseaseView
+          items={data.items}
+          diseasesIndex={data.diseases_index}
+        />
+      )}
+    </Stack>
+  );
+};
+
+export default ImmunizationHistoryTab;

--- a/frontend/src/components/medical/immunizations/history/__tests__/HistoryByDateView.test.tsx
+++ b/frontend/src/components/medical/immunizations/history/__tests__/HistoryByDateView.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+
+import render from '../../../../../test-utils/render';
+import HistoryByDateView from '../HistoryByDateView';
+import type { ImmunizationHistoryItem } from '../types';
+
+const baseItem: ImmunizationHistoryItem = {
+  id: 1,
+  patient_id: 42,
+  vaccine_name: 'DTaP',
+  vaccine_trade_name: 'Daptacel',
+  date_administered: '2024-03-15',
+  dose_number: 4,
+  lot_number: 'ABC123',
+  ndc_number: null,
+  manufacturer: null,
+  site: null,
+  route: null,
+  expiration_date: null,
+  location: null,
+  notes: null,
+  practitioner_id: null,
+  tags: null,
+  standardized_vaccine_id: 10,
+  components: ['Diphtheria', 'Tetanus', 'Pertussis'],
+  is_combined: true,
+  is_library_matched: true,
+};
+
+const unmatched: ImmunizationHistoryItem = {
+  ...baseItem,
+  id: 2,
+  vaccine_name: 'Custom Vaccine',
+  vaccine_trade_name: null,
+  components: [],
+  is_combined: false,
+  is_library_matched: false,
+  standardized_vaccine_id: null,
+};
+
+describe('HistoryByDateView', () => {
+  it('renders vaccine name and disease badges', () => {
+    render(<HistoryByDateView items={[baseItem]} />);
+    expect(screen.getByText('DTaP (Daptacel)')).toBeInTheDocument();
+    expect(screen.getByText('Diphtheria')).toBeInTheDocument();
+    expect(screen.getByText('Tetanus')).toBeInTheDocument();
+    expect(screen.getByText('Pertussis')).toBeInTheDocument();
+    // Dose label uses t() — match the rendered output
+    expect(screen.getByText(/Dose 4/)).toBeInTheDocument();
+  });
+
+  it('shows Unlinked badge for unmatched records', () => {
+    render(<HistoryByDateView items={[unmatched]} />);
+    expect(screen.getByText(/unlinked/i)).toBeInTheDocument();
+  });
+
+  it('does not render disease badges for unmatched records', () => {
+    render(<HistoryByDateView items={[unmatched]} />);
+    expect(screen.queryByText('Diphtheria')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/medical/immunizations/history/__tests__/HistoryByDateView.test.tsx
+++ b/frontend/src/components/medical/immunizations/history/__tests__/HistoryByDateView.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import render from '../../../../../test-utils/render';
 import HistoryByDateView from '../HistoryByDateView';
@@ -58,5 +59,21 @@ describe('HistoryByDateView', () => {
   it('does not render disease badges for unmatched records', () => {
     render(<HistoryByDateView items={[unmatched]} />);
     expect(screen.queryByText('Diphtheria')).not.toBeInTheDocument();
+  });
+
+  it('calls onItemClick when a card is clicked', async () => {
+    const handleClick = vi.fn();
+    const user = userEvent.setup();
+    render(<HistoryByDateView items={[baseItem]} onItemClick={handleClick} />);
+
+    await user.click(screen.getByRole('button', { name: /DTaP/ }));
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+    expect(handleClick).toHaveBeenCalledWith(baseItem);
+  });
+
+  it('does not assign button role when onItemClick is omitted', () => {
+    render(<HistoryByDateView items={[baseItem]} />);
+    expect(screen.queryByRole('button', { name: /DTaP/ })).toBeNull();
   });
 });

--- a/frontend/src/components/medical/immunizations/history/__tests__/HistoryByDiseaseView.test.tsx
+++ b/frontend/src/components/medical/immunizations/history/__tests__/HistoryByDiseaseView.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import render from '../../../../../test-utils/render';
+import HistoryByDiseaseView from '../HistoryByDiseaseView';
+import type { ImmunizationHistoryItem } from '../types';
+
+const dtap: ImmunizationHistoryItem = {
+  id: 1,
+  patient_id: 42,
+  vaccine_name: 'DTaP',
+  vaccine_trade_name: null,
+  date_administered: '2024-03-15',
+  dose_number: 4,
+  lot_number: null,
+  ndc_number: null,
+  manufacturer: null,
+  site: null,
+  route: null,
+  expiration_date: null,
+  location: null,
+  notes: null,
+  practitioner_id: null,
+  tags: null,
+  standardized_vaccine_id: 10,
+  components: ['Diphtheria', 'Tetanus', 'Pertussis'],
+  is_combined: true,
+  is_library_matched: true,
+};
+
+const tdap: ImmunizationHistoryItem = {
+  ...dtap,
+  id: 2,
+  vaccine_name: 'Tdap',
+  date_administered: '2014-06-02',
+  dose_number: 3,
+  components: ['Tetanus', 'Diphtheria', 'Pertussis'],
+};
+
+describe('HistoryByDiseaseView', () => {
+  const diseasesIndex = {
+    Diphtheria: [1, 2],
+    Tetanus: [1, 2],
+    Pertussis: [1, 2],
+  };
+
+  it('renders an accordion section per disease alphabetically', async () => {
+    const user = userEvent.setup();
+    render(
+      <HistoryByDiseaseView
+        items={[dtap, tdap]}
+        diseasesIndex={diseasesIndex}
+      />
+    );
+    const headers = screen.getAllByRole('button', { name: /diphtheria|tetanus|pertussis/i });
+    expect(headers).toHaveLength(3);
+    expect(headers[0].textContent).toMatch(/diphtheria/i);
+    expect(headers[1].textContent).toMatch(/pertussis/i);
+    expect(headers[2].textContent).toMatch(/tetanus/i);
+
+    await user.click(headers[0]); // Open Diphtheria
+    expect(screen.getAllByText('DTaP').length).toBeGreaterThan(0);
+  });
+
+  it('shows dose counts per disease', () => {
+    render(
+      <HistoryByDiseaseView
+        items={[dtap, tdap]}
+        diseasesIndex={diseasesIndex}
+      />
+    );
+    // Diphtheria has 2 doses (DTaP + Tdap both cover it)
+    // The accordion header text combines disease name + count badge
+    const diphtheriaHeader = screen.getByRole('button', { name: /diphtheria.*2/i });
+    expect(diphtheriaHeader).toBeInTheDocument();
+  });
+
+  it('a single combined-vaccine record appears under each component disease', async () => {
+    const user = userEvent.setup();
+    render(
+      <HistoryByDiseaseView
+        items={[dtap]}
+        diseasesIndex={{
+          Diphtheria: [1],
+          Tetanus: [1],
+          Pertussis: [1],
+        }}
+      />
+    );
+    const headers = screen.getAllByRole('button', { name: /diphtheria|tetanus|pertussis/i });
+    for (const h of headers) {
+      // eslint-disable-next-line no-await-in-loop
+      await user.click(h);
+    }
+    // DTaP appears in all three open sections — THIS IS THE CORE FEATURE
+    expect(screen.getAllByText('DTaP').length).toBe(3);
+  });
+
+  it('renders helpful empty state when diseasesIndex is empty', () => {
+    render(<HistoryByDiseaseView items={[]} diseasesIndex={{}} />);
+    expect(screen.getByText(/no linked vaccinations/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/medical/immunizations/history/__tests__/HistoryByDiseaseView.test.tsx
+++ b/frontend/src/components/medical/immunizations/history/__tests__/HistoryByDiseaseView.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -102,5 +102,26 @@ describe('HistoryByDiseaseView', () => {
     expect(
       screen.getByText(/no vaccinations are linked to the library/i)
     ).toBeInTheDocument();
+  });
+
+  it('calls onItemClick when a row is clicked', async () => {
+    const handleClick = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <HistoryByDiseaseView
+        items={[dtap]}
+        diseasesIndex={{ Diphtheria: [1] }}
+        onItemClick={handleClick}
+      />
+    );
+    // Open the Diphtheria section first
+    await user.click(
+      screen.getByRole('button', { name: /diphtheria/i })
+    );
+    // Then click the DTaP row inside the panel (also rendered as a button)
+    await user.click(screen.getByRole('button', { name: /DTaP/ }));
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+    expect(handleClick).toHaveBeenCalledWith(dtap);
   });
 });

--- a/frontend/src/components/medical/immunizations/history/__tests__/HistoryByDiseaseView.test.tsx
+++ b/frontend/src/components/medical/immunizations/history/__tests__/HistoryByDiseaseView.test.tsx
@@ -99,6 +99,8 @@ describe('HistoryByDiseaseView', () => {
 
   it('renders helpful empty state when diseasesIndex is empty', () => {
     render(<HistoryByDiseaseView items={[]} diseasesIndex={{}} />);
-    expect(screen.getByText(/no linked vaccinations/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/no vaccinations are linked to the library/i)
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/medical/immunizations/history/__tests__/ImmunizationHistoryTab.test.tsx
+++ b/frontend/src/components/medical/immunizations/history/__tests__/ImmunizationHistoryTab.test.tsx
@@ -65,7 +65,7 @@ describe('ImmunizationHistoryTab', () => {
     expect(screen.getByText('Pertussis')).toBeInTheDocument();
   });
 
-  it.skip('switches to By Disease view when toggled [enable after Task 11]', async () => {
+  it('switches to By Disease view when toggled', async () => {
     mockedApi.getImmunizationHistory.mockResolvedValue(sampleResponse);
     const user = userEvent.setup();
 

--- a/frontend/src/components/medical/immunizations/history/__tests__/ImmunizationHistoryTab.test.tsx
+++ b/frontend/src/components/medical/immunizations/history/__tests__/ImmunizationHistoryTab.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import render from '../../../../../test-utils/render';
+import ImmunizationHistoryTab from '../ImmunizationHistoryTab';
+import { apiService } from '../../../../../services/api';
+
+vi.mock('../../../../../services/api', () => ({
+  apiService: {
+    getImmunizationHistory: vi.fn(),
+  },
+}));
+
+const mockedApi = apiService as unknown as {
+  getImmunizationHistory: ReturnType<typeof vi.fn>;
+};
+
+const sampleResponse = {
+  items: [
+    {
+      id: 1,
+      vaccine_name: 'DTaP',
+      vaccine_trade_name: null,
+      date_administered: '2024-03-15',
+      dose_number: 4,
+      lot_number: 'ABC123',
+      manufacturer: null,
+      notes: null,
+      practitioner_id: null,
+      tags: null,
+      standardized_vaccine_id: 10,
+      components: ['Diphtheria', 'Tetanus', 'Pertussis'],
+      is_combined: true,
+      is_library_matched: true,
+    },
+  ],
+  diseases_index: {
+    Diphtheria: [1],
+    Tetanus: [1],
+    Pertussis: [1],
+  },
+  unmatched_count: 0,
+};
+
+describe('ImmunizationHistoryTab', () => {
+  beforeEach(() => {
+    mockedApi.getImmunizationHistory.mockReset();
+  });
+
+  it('renders the By Date view by default and lists immunizations', async () => {
+    mockedApi.getImmunizationHistory.mockResolvedValue(sampleResponse);
+
+    render(<ImmunizationHistoryTab patientId={42} />);
+
+    await waitFor(() => expect(screen.getByText('DTaP')).toBeInTheDocument());
+    expect(screen.getByText('Diphtheria')).toBeInTheDocument();
+    expect(screen.getByText('Tetanus')).toBeInTheDocument();
+    expect(screen.getByText('Pertussis')).toBeInTheDocument();
+  });
+
+  it('switches to By Disease view when toggled', async () => {
+    mockedApi.getImmunizationHistory.mockResolvedValue(sampleResponse);
+    const user = userEvent.setup();
+
+    render(<ImmunizationHistoryTab patientId={42} />);
+    await waitFor(() => expect(screen.getByText('DTaP')).toBeInTheDocument());
+
+    await user.click(screen.getByRole('radio', { name: /by disease/i }));
+
+    expect(await screen.findByText(/Diphtheria/)).toBeInTheDocument();
+    expect(screen.getByText(/Tetanus/)).toBeInTheDocument();
+    expect(screen.getByText(/Pertussis/)).toBeInTheDocument();
+  });
+
+  it('renders empty state when no records', async () => {
+    mockedApi.getImmunizationHistory.mockResolvedValue({
+      items: [],
+      diseases_index: {},
+      unmatched_count: 0,
+    });
+    render(<ImmunizationHistoryTab patientId={42} />);
+    expect(
+      await screen.findByText(/no vaccinations/i)
+    ).toBeInTheDocument();
+  });
+
+  it('shows unmatched banner when unmatched_count > 0', async () => {
+    mockedApi.getImmunizationHistory.mockResolvedValue({
+      ...sampleResponse,
+      unmatched_count: 3,
+    });
+    render(<ImmunizationHistoryTab patientId={42} />);
+    // Both the alert title and body contain "aren't linked", so assert there
+    // is at least one matching element rather than insisting on uniqueness.
+    await waitFor(() =>
+      expect(screen.getAllByText(/aren.?t linked/i).length).toBeGreaterThan(0)
+    );
+  });
+
+  it('renders error state when API rejects', async () => {
+    mockedApi.getImmunizationHistory.mockRejectedValue(
+      new Error('Network down')
+    );
+    render(<ImmunizationHistoryTab patientId={42} />);
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/medical/immunizations/history/__tests__/ImmunizationHistoryTab.test.tsx
+++ b/frontend/src/components/medical/immunizations/history/__tests__/ImmunizationHistoryTab.test.tsx
@@ -54,7 +54,7 @@ describe('ImmunizationHistoryTab', () => {
     mockedApi.getImmunizationHistory.mockReset();
   });
 
-  it.skip('renders the By Date view by default and lists immunizations [enable after Task 10]', async () => {
+  it('renders the By Date view by default and lists immunizations', async () => {
     mockedApi.getImmunizationHistory.mockResolvedValue(sampleResponse);
 
     render(<ImmunizationHistoryTab patientId={42} />);

--- a/frontend/src/components/medical/immunizations/history/__tests__/ImmunizationHistoryTab.test.tsx
+++ b/frontend/src/components/medical/immunizations/history/__tests__/ImmunizationHistoryTab.test.tsx
@@ -20,12 +20,18 @@ const sampleResponse = {
   items: [
     {
       id: 1,
+      patient_id: 42,
       vaccine_name: 'DTaP',
       vaccine_trade_name: null,
       date_administered: '2024-03-15',
       dose_number: 4,
       lot_number: 'ABC123',
+      ndc_number: null,
       manufacturer: null,
+      site: null,
+      route: null,
+      expiration_date: null,
+      location: null,
       notes: null,
       practitioner_id: null,
       tags: null,
@@ -48,7 +54,7 @@ describe('ImmunizationHistoryTab', () => {
     mockedApi.getImmunizationHistory.mockReset();
   });
 
-  it('renders the By Date view by default and lists immunizations', async () => {
+  it.skip('renders the By Date view by default and lists immunizations [enable after Task 10]', async () => {
     mockedApi.getImmunizationHistory.mockResolvedValue(sampleResponse);
 
     render(<ImmunizationHistoryTab patientId={42} />);
@@ -59,7 +65,7 @@ describe('ImmunizationHistoryTab', () => {
     expect(screen.getByText('Pertussis')).toBeInTheDocument();
   });
 
-  it('switches to By Disease view when toggled', async () => {
+  it.skip('switches to By Disease view when toggled [enable after Task 11]', async () => {
     mockedApi.getImmunizationHistory.mockResolvedValue(sampleResponse);
     const user = userEvent.setup();
 

--- a/frontend/src/components/medical/immunizations/history/index.ts
+++ b/frontend/src/components/medical/immunizations/history/index.ts
@@ -1,0 +1,6 @@
+export { default as ImmunizationHistoryTab } from './ImmunizationHistoryTab';
+export type {
+  ImmunizationHistoryItem,
+  ImmunizationHistoryResponse,
+  HistoryViewMode,
+} from './types';

--- a/frontend/src/components/medical/immunizations/history/types.ts
+++ b/frontend/src/components/medical/immunizations/history/types.ts
@@ -1,0 +1,24 @@
+export interface ImmunizationHistoryItem {
+  id: number;
+  vaccine_name: string;
+  vaccine_trade_name: string | null;
+  date_administered: string; // YYYY-MM-DD
+  dose_number: number | null;
+  lot_number: string | null;
+  manufacturer: string | null;
+  notes: string | null;
+  practitioner_id: number | null;
+  tags: string[] | null;
+  standardized_vaccine_id: number | null;
+  components: string[];
+  is_combined: boolean;
+  is_library_matched: boolean;
+}
+
+export interface ImmunizationHistoryResponse {
+  items: ImmunizationHistoryItem[];
+  diseases_index: Record<string, number[]>;
+  unmatched_count: number;
+}
+
+export type HistoryViewMode = 'byDate' | 'byDisease';

--- a/frontend/src/components/medical/immunizations/history/types.ts
+++ b/frontend/src/components/medical/immunizations/history/types.ts
@@ -1,11 +1,17 @@
 export interface ImmunizationHistoryItem {
   id: number;
+  patient_id: number;
   vaccine_name: string;
   vaccine_trade_name: string | null;
   date_administered: string; // YYYY-MM-DD
   dose_number: number | null;
   lot_number: string | null;
+  ndc_number: string | null;
   manufacturer: string | null;
+  site: string | null;
+  route: string | null;
+  expiration_date: string | null;
+  location: string | null;
   notes: string | null;
   practitioner_id: number | null;
   tags: string[] | null;

--- a/frontend/src/components/medical/immunizations/history/utils.ts
+++ b/frontend/src/components/medical/immunizations/history/utils.ts
@@ -1,0 +1,25 @@
+import type { ImmunizationHistoryItem } from './types';
+
+/**
+ * Group history items by disease using the response's pre-aggregated
+ * diseases_index. Sort diseases alphabetically; items within a disease are
+ * already sorted newest-first because the backend orders the items array.
+ */
+export function groupItemsByDisease(
+  items: ImmunizationHistoryItem[],
+  diseasesIndex: Record<string, number[]>
+): Array<{ disease: string; items: ImmunizationHistoryItem[] }> {
+  const byId = new Map(items.map(item => [item.id, item]));
+  return Object.keys(diseasesIndex)
+    .sort((a, b) => a.localeCompare(b))
+    .map(disease => ({
+      disease,
+      items: diseasesIndex[disease]
+        .map(id => byId.get(id))
+        .filter((item): item is ImmunizationHistoryItem => item !== undefined),
+    }));
+}
+
+export function formatDoseLabel(item: ImmunizationHistoryItem): string {
+  return item.dose_number ? `Dose ${item.dose_number}` : '';
+}

--- a/frontend/src/components/medical/immunizations/history/utils.ts
+++ b/frontend/src/components/medical/immunizations/history/utils.ts
@@ -20,6 +20,11 @@ export function groupItemsByDisease(
     }));
 }
 
-export function formatDoseLabel(item: ImmunizationHistoryItem): string {
-  return item.dose_number ? `Dose ${item.dose_number}` : '';
+/**
+ * Return the dose number if set, otherwise null.
+ * Callers should wrap with `t('medical:immunizations.history.doseLabel', 'Dose {{n}}', { n })`
+ * for the display label.
+ */
+export function getDoseNumber(item: ImmunizationHistoryItem): number | null {
+  return item.dose_number ?? null;
 }

--- a/frontend/src/pages/medical/Immunization.jsx
+++ b/frontend/src/pages/medical/Immunization.jsx
@@ -607,7 +607,10 @@ const Immunization = () => {
 
           <Tabs.Panel value="history" pt="md">
             {currentPatient?.id ? (
-              <ImmunizationHistoryTab patientId={currentPatient.id} />
+              <ImmunizationHistoryTab
+                patientId={currentPatient.id}
+                onItemClick={handleViewImmunization}
+              />
             ) : (
               <Text c="dimmed">
                 {t(

--- a/frontend/src/pages/medical/Immunization.jsx
+++ b/frontend/src/pages/medical/Immunization.jsx
@@ -241,6 +241,18 @@ const Immunization = () => {
       return;
     }
 
+    // Decide whether to send standardized_vaccine_who_code. The backend treats
+    // an explicit null as "clear the FK link". We only want that when the
+    // user actually changed the vaccine identity (typed a new name or picked
+    // a new library entry). On a pure-other-field edit, omit the key so the
+    // backend's exclude_unset preserves the existing FK link.
+    const hasPickedFromLibrary = formData.standardized_vaccine_who_code != null;
+    const nameChanged =
+      editingImmunization &&
+      formData.vaccine_name !== editingImmunization.vaccine_name;
+    const includeWhoCode =
+      !editingImmunization || hasPickedFromLibrary || nameChanged;
+
     const immunizationData = {
       vaccine_name: formData.vaccine_name,
       vaccine_trade_name: formData.vaccine_trade_name || null,
@@ -260,8 +272,10 @@ const Immunization = () => {
       practitioner_id: formData.practitioner_id
         ? parseInt(formData.practitioner_id, 10)
         : null,
-      standardized_vaccine_who_code:
-        formData.standardized_vaccine_who_code || null,
+      ...(includeWhoCode && {
+        standardized_vaccine_who_code:
+          formData.standardized_vaccine_who_code || null,
+      }),
       tags: formData.tags || [],
     };
 

--- a/frontend/src/pages/medical/Immunization.jsx
+++ b/frontend/src/pages/medical/Immunization.jsx
@@ -6,6 +6,8 @@ import {
   Container,
   Paper,
   Stack,
+  Tabs,
+  Text,
 } from '@mantine/core';
 import { IconPlus, IconVaccine } from '@tabler/icons-react';
 import { useMedicalData } from '../../hooks/useMedicalData';
@@ -38,6 +40,7 @@ import {
   ImmunizationViewModal,
   ImmunizationFormWrapper,
 } from '../../components/medical/immunizations';
+import { ImmunizationHistoryTab } from '../../components/medical/immunizations/history';
 import { usePatientPermissions } from '../../hooks/usePatientPermissions';
 
 const Immunization = () => {
@@ -110,6 +113,7 @@ const Immunization = () => {
   // Form and UI state
   const [showAddForm, setShowAddForm] = useState(false);
   const [editingImmunization, setEditingImmunization] = useState(null);
+  const [activeTab, setActiveTab] = useState('records');
   const [formData, setFormData] = useState({
     vaccine_name: '',
     vaccine_trade_name: '',
@@ -379,24 +383,7 @@ const Immunization = () => {
           onClearError={clearError}
         />
 
-        <MedicalPageActions
-          primaryAction={{
-            label: t('immunizations.addImmunization', 'Add New Immunization'),
-            onClick: handleAddImmunization,
-            leftSection: <IconPlus size={16} />,
-            size: 'sm',
-            disabled: isViewOnly,
-            tooltip: viewOnlyTooltip,
-          }}
-          viewMode={viewMode}
-          onViewModeChange={setViewMode}
-          viewToggleSize="sm"
-          mb={0}
-        />
-
-        {/* Mantine Filter Controls */}
-        <MedicalPageFilters dataManagement={dataManagement} config={config} />
-
+        {/* Modals stay outside Tabs so switching tabs doesn't unmount them */}
         {/* Form Modal */}
         <ImmunizationFormWrapper
           isOpen={showAddForm}
@@ -433,143 +420,204 @@ const Immunization = () => {
           disableEditTooltip={viewOnlyTooltip}
         />
 
-        {/* Content */}
-        {processedImmunizations.length === 0 ? (
-          <EmptyState
-            icon={IconVaccine}
-            title={t(
-              'immunizations.noImmunizationsFound',
-              'No immunizations found'
-            )}
-            hasActiveFilters={dataManagement.hasActiveFilters}
-            filteredMessage={t(
-              'shared:emptyStates.adjustSearch',
-              'Try adjusting your search or filter criteria.'
-            )}
-            noDataMessage={t(
-              'immunizations.clickToGetStarted',
-              'Click "Add New Immunization" to get started.'
-            )}
-          />
-        ) : viewMode === 'cards' ? (
-          <AnimatedCardGrid
-            items={paginatedImmunizations}
-            renderCard={immunization => (
-              <ImmunizationCard
-                immunization={immunization}
-                onView={handleViewImmunization}
-                onEdit={handleEditImmunization}
-                onDelete={handleDeleteImmunization}
-                practitioners={practitioners}
-                navigate={navigate}
-                fileCount={fileCounts[immunization.id] || 0}
-                fileCountLoading={fileCountsLoading[immunization.id] || false}
-                disableActions={isViewOnly}
-                disableActionsTooltip={viewOnlyTooltip}
-              />
-            )}
-          />
-        ) : (
-          <Paper shadow="sm" radius="md" withBorder>
-            <ResponsiveTable
-              persistKey="immunizations"
-              data={paginatedImmunizations}
-              pagination={false}
-              disableEdit={isViewOnly}
-              disableDelete={isViewOnly}
-              disableActionsTooltip={viewOnlyTooltip}
-              columns={[
-                {
-                  header: t('shared:fields.vaccineName', 'Vaccine Name'),
-                  accessor: 'vaccine_name',
-                  priority: 'high',
-                  width: 200,
-                },
-                {
-                  header: t(
-                    'shared:fields.dateAdministered',
-                    'Date Administered'
+        <Tabs value={activeTab} onChange={setActiveTab} keepMounted={false}>
+          <Tabs.List>
+            <Tabs.Tab value="records">
+              {t('immunizations.tabs.records', 'Records')}
+            </Tabs.Tab>
+            <Tabs.Tab value="history">
+              {t('immunizations.tabs.history', 'History')}
+            </Tabs.Tab>
+          </Tabs.List>
+
+          <Tabs.Panel value="records" pt="md">
+            <Stack gap="sm">
+              <MedicalPageActions
+                primaryAction={{
+                  label: t(
+                    'immunizations.addImmunization',
+                    'Add New Immunization'
                   ),
-                  accessor: 'date_administered',
-                  priority: 'high',
-                  width: 150,
-                },
-                {
-                  header: t('shared:fields.doseNumber', 'Dose Number'),
-                  accessor: 'dose_number',
-                  priority: 'medium',
-                  width: 100,
-                },
-                {
-                  header: t('shared:fields.manufacturer', 'Manufacturer'),
-                  accessor: 'manufacturer',
-                  priority: 'medium',
-                  width: 150,
-                },
-                {
-                  header: t('immunizations.table.site', 'Site'),
-                  accessor: 'site',
-                  priority: 'low',
-                  width: 100,
-                },
-                {
-                  header: t('shared:labels.route', 'Route'),
-                  accessor: 'route',
-                  priority: 'low',
-                  width: 100,
-                },
-                {
-                  header: t('shared:fields.lotNumber', 'Lot Number'),
-                  accessor: 'lot_number',
-                  priority: 'low',
-                  width: 120,
-                },
-                {
-                  header: t('shared:fields.expirationDate', 'Expiration Date'),
-                  accessor: 'expiration_date',
-                  priority: 'medium',
-                  width: 130,
-                },
-                {
-                  header: t('shared:tabs.notes', 'Notes'),
-                  accessor: 'notes',
-                  priority: 'low',
-                  width: 200,
-                },
-              ]}
-              patientData={currentPatient}
-              tableName={t('shared:categories.immunizations', 'Immunizations')}
-              onView={handleViewImmunization}
-              onEdit={handleEditImmunization}
-              onDelete={handleDeleteImmunization}
-              formatters={{
-                vaccine_name: (value, item) =>
-                  immunizationFormatters.immunization_name(value, item),
-                date_administered: immunizationFormatters.administration_date,
-                expiration_date: immunizationFormatters.date,
-                site: immunizationFormatters.simple,
-                dose_number: immunizationFormatters.simple,
-                manufacturer: immunizationFormatters.simple,
-                route: immunizationFormatters.simple,
-                lot_number: immunizationFormatters.lot_number,
-                notes: immunizationFormatters.notes,
-              }}
-              dataType="medical"
-              responsive={responsive}
-            />
-          </Paper>
-        )}
-        {processedImmunizations.length > 0 && (
-          <PaginationControls
-            page={page}
-            totalPages={totalPages(processedImmunizations.length)}
-            pageSize={pageSize}
-            totalRecords={processedImmunizations.length}
-            onPageChange={setPage}
-            onPageSizeChange={handlePageSizeChange}
-            pageSizeOptions={PAGE_SIZE_OPTIONS}
-          />
-        )}
+                  onClick: handleAddImmunization,
+                  leftSection: <IconPlus size={16} />,
+                  size: 'sm',
+                  disabled: isViewOnly,
+                  tooltip: viewOnlyTooltip,
+                }}
+                viewMode={viewMode}
+                onViewModeChange={setViewMode}
+                viewToggleSize="sm"
+                mb={0}
+              />
+
+              {/* Mantine Filter Controls */}
+              <MedicalPageFilters
+                dataManagement={dataManagement}
+                config={config}
+              />
+
+              {/* Content */}
+              {processedImmunizations.length === 0 ? (
+                <EmptyState
+                  icon={IconVaccine}
+                  title={t(
+                    'immunizations.noImmunizationsFound',
+                    'No immunizations found'
+                  )}
+                  hasActiveFilters={dataManagement.hasActiveFilters}
+                  filteredMessage={t(
+                    'shared:emptyStates.adjustSearch',
+                    'Try adjusting your search or filter criteria.'
+                  )}
+                  noDataMessage={t(
+                    'immunizations.clickToGetStarted',
+                    'Click "Add New Immunization" to get started.'
+                  )}
+                />
+              ) : viewMode === 'cards' ? (
+                <AnimatedCardGrid
+                  items={paginatedImmunizations}
+                  renderCard={immunization => (
+                    <ImmunizationCard
+                      immunization={immunization}
+                      onView={handleViewImmunization}
+                      onEdit={handleEditImmunization}
+                      onDelete={handleDeleteImmunization}
+                      practitioners={practitioners}
+                      navigate={navigate}
+                      fileCount={fileCounts[immunization.id] || 0}
+                      fileCountLoading={
+                        fileCountsLoading[immunization.id] || false
+                      }
+                      disableActions={isViewOnly}
+                      disableActionsTooltip={viewOnlyTooltip}
+                    />
+                  )}
+                />
+              ) : (
+                <Paper shadow="sm" radius="md" withBorder>
+                  <ResponsiveTable
+                    persistKey="immunizations"
+                    data={paginatedImmunizations}
+                    pagination={false}
+                    disableEdit={isViewOnly}
+                    disableDelete={isViewOnly}
+                    disableActionsTooltip={viewOnlyTooltip}
+                    columns={[
+                      {
+                        header: t('shared:fields.vaccineName', 'Vaccine Name'),
+                        accessor: 'vaccine_name',
+                        priority: 'high',
+                        width: 200,
+                      },
+                      {
+                        header: t(
+                          'shared:fields.dateAdministered',
+                          'Date Administered'
+                        ),
+                        accessor: 'date_administered',
+                        priority: 'high',
+                        width: 150,
+                      },
+                      {
+                        header: t('shared:fields.doseNumber', 'Dose Number'),
+                        accessor: 'dose_number',
+                        priority: 'medium',
+                        width: 100,
+                      },
+                      {
+                        header: t('shared:fields.manufacturer', 'Manufacturer'),
+                        accessor: 'manufacturer',
+                        priority: 'medium',
+                        width: 150,
+                      },
+                      {
+                        header: t('immunizations.table.site', 'Site'),
+                        accessor: 'site',
+                        priority: 'low',
+                        width: 100,
+                      },
+                      {
+                        header: t('shared:labels.route', 'Route'),
+                        accessor: 'route',
+                        priority: 'low',
+                        width: 100,
+                      },
+                      {
+                        header: t('shared:fields.lotNumber', 'Lot Number'),
+                        accessor: 'lot_number',
+                        priority: 'low',
+                        width: 120,
+                      },
+                      {
+                        header: t(
+                          'shared:fields.expirationDate',
+                          'Expiration Date'
+                        ),
+                        accessor: 'expiration_date',
+                        priority: 'medium',
+                        width: 130,
+                      },
+                      {
+                        header: t('shared:tabs.notes', 'Notes'),
+                        accessor: 'notes',
+                        priority: 'low',
+                        width: 200,
+                      },
+                    ]}
+                    patientData={currentPatient}
+                    tableName={t(
+                      'shared:categories.immunizations',
+                      'Immunizations'
+                    )}
+                    onView={handleViewImmunization}
+                    onEdit={handleEditImmunization}
+                    onDelete={handleDeleteImmunization}
+                    formatters={{
+                      vaccine_name: (value, item) =>
+                        immunizationFormatters.immunization_name(value, item),
+                      date_administered:
+                        immunizationFormatters.administration_date,
+                      expiration_date: immunizationFormatters.date,
+                      site: immunizationFormatters.simple,
+                      dose_number: immunizationFormatters.simple,
+                      manufacturer: immunizationFormatters.simple,
+                      route: immunizationFormatters.simple,
+                      lot_number: immunizationFormatters.lot_number,
+                      notes: immunizationFormatters.notes,
+                    }}
+                    dataType="medical"
+                    responsive={responsive}
+                  />
+                </Paper>
+              )}
+              {processedImmunizations.length > 0 && (
+                <PaginationControls
+                  page={page}
+                  totalPages={totalPages(processedImmunizations.length)}
+                  pageSize={pageSize}
+                  totalRecords={processedImmunizations.length}
+                  onPageChange={setPage}
+                  onPageSizeChange={handlePageSizeChange}
+                  pageSizeOptions={PAGE_SIZE_OPTIONS}
+                />
+              )}
+            </Stack>
+          </Tabs.Panel>
+
+          <Tabs.Panel value="history" pt="md">
+            {currentPatient?.id ? (
+              <ImmunizationHistoryTab patientId={currentPatient.id} />
+            ) : (
+              <Text c="dimmed">
+                {t(
+                  'immunizations.history.noPatient',
+                  'Select a patient to view history.'
+                )}
+              </Text>
+            )}
+          </Tabs.Panel>
+        </Tabs>
       </Stack>
     </Container>
   );

--- a/frontend/src/pages/medical/Immunization.jsx
+++ b/frontend/src/pages/medical/Immunization.jsx
@@ -186,6 +186,7 @@ const Immunization = () => {
       location: '',
       notes: '',
       practitioner_id: null,
+      standardized_vaccine_who_code: null,
       tags: [],
     });
     setEditingImmunization(null);

--- a/frontend/src/pages/medical/Immunization.jsx
+++ b/frontend/src/pages/medical/Immunization.jsx
@@ -215,6 +215,7 @@ const Immunization = () => {
       location: immunization.location || '',
       notes: immunization.notes || '',
       practitioner_id: immunization.practitioner_id || null,
+      standardized_vaccine_who_code: null,
       tags: immunization.tags || [],
     });
     setEditingImmunization(immunization);
@@ -254,6 +255,8 @@ const Immunization = () => {
       practitioner_id: formData.practitioner_id
         ? parseInt(formData.practitioner_id, 10)
         : null,
+      standardized_vaccine_who_code:
+        formData.standardized_vaccine_who_code || null,
       tags: formData.tags || [],
     };
 

--- a/frontend/src/services/api/index.js
+++ b/frontend/src/services/api/index.js
@@ -1586,8 +1586,8 @@ class ApiService {
 
   getImmunizationHistory(patientId, params = {}, signal) {
     const queryParams = {};
-    if (params.startDate) queryParams.start_date = params.startDate;
-    if (params.endDate) queryParams.end_date = params.endDate;
+    if (params.startDate != null) queryParams.start_date = params.startDate;
+    if (params.endDate != null) queryParams.end_date = params.endDate;
     return this.get(`/immunizations/patient/${patientId}/history`, {
       params: queryParams,
       signal,

--- a/frontend/src/services/api/index.js
+++ b/frontend/src/services/api/index.js
@@ -1584,6 +1584,16 @@ class ApiService {
     );
   }
 
+  getImmunizationHistory(patientId, params = {}, signal) {
+    const queryParams = {};
+    if (params.startDate) queryParams.start_date = params.startDate;
+    if (params.endDate) queryParams.end_date = params.endDate;
+    return this.get(`/immunizations/patient/${patientId}/history`, {
+      params: queryParams,
+      signal,
+    });
+  }
+
   createImmunization(immunizationData, signal) {
     return this.createEntity(
       ENTITY_TYPES.IMMUNIZATION,

--- a/tests/api/test_immunization_history.py
+++ b/tests/api/test_immunization_history.py
@@ -222,4 +222,4 @@ class TestImmunizationHistory:
             f"/api/v1/immunizations/patient/{other_patient.id}/history",
             headers=auth_headers,
         )
-        assert resp.status_code in (403, 404)
+        assert resp.status_code == 403

--- a/tests/api/test_immunization_history.py
+++ b/tests/api/test_immunization_history.py
@@ -1,0 +1,225 @@
+"""Tests for the Immunization history endpoint."""
+from datetime import date
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.crud.patient import patient as patient_crud
+from app.models.clinical import Immunization, StandardizedVaccine
+from app.schemas.patient import PatientCreate
+from tests.utils.user import create_random_user, create_user_token_headers
+
+
+def _seed_library(db_session: Session) -> dict[str, StandardizedVaccine]:
+    """Seed minimal library entries used by the history tests."""
+    dtap = StandardizedVaccine(
+        who_code="DTAP-TEST",
+        vaccine_name="DTaP",
+        is_combined=True,
+        components=["Diphtheria", "Tetanus", "Pertussis"],
+        is_common=True,
+    )
+    mmr = StandardizedVaccine(
+        who_code="MMR-TEST",
+        vaccine_name="MMR",
+        common_names=["MMR II"],
+        is_combined=True,
+        components=["Measles", "Mumps", "Rubella"],
+        is_common=True,
+    )
+    flu = StandardizedVaccine(
+        who_code="FLU-TEST",
+        vaccine_name="Influenza",
+        is_combined=False,
+        is_common=True,
+    )
+    db_session.add_all([dtap, mmr, flu])
+    db_session.commit()
+    db_session.refresh(dtap)
+    db_session.refresh(mmr)
+    db_session.refresh(flu)
+    return {"dtap": dtap, "mmr": mmr, "flu": flu}
+
+
+class TestImmunizationHistory:
+    @pytest.fixture
+    def user_with_patient(self, db_session: Session):
+        user_data = create_random_user(db_session)
+        patient = patient_crud.create_for_user(
+            db_session,
+            user_id=user_data["user"].id,
+            patient_data=PatientCreate(
+                first_name="John",
+                last_name="Doe",
+                birth_date=date(1990, 1, 1),
+                gender="M",
+                address="123 Main St",
+            ),
+        )
+        user_data["user"].active_patient_id = patient.id
+        db_session.commit()
+        db_session.refresh(user_data["user"])
+        return {**user_data, "patient": patient}
+
+    @pytest.fixture
+    def auth_headers(self, user_with_patient):
+        return create_user_token_headers(user_with_patient["user"].username)
+
+    def test_returns_empty_response_when_no_immunizations(
+        self, client: TestClient, user_with_patient, auth_headers
+    ):
+        resp = client.get(
+            f"/api/v1/immunizations/patient/{user_with_patient['patient'].id}/history",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["items"] == []
+        assert body["diseases_index"] == {}
+        assert body["unmatched_count"] == 0
+
+    def test_resolves_combined_vaccine_via_fk(
+        self, client: TestClient, db_session, user_with_patient, auth_headers
+    ):
+        library = _seed_library(db_session)
+        imm = Immunization(
+            patient_id=user_with_patient["patient"].id,
+            vaccine_name="DTaP",
+            date_administered=date(2024, 3, 15),
+            standardized_vaccine_id=library["dtap"].id,
+        )
+        db_session.add(imm)
+        db_session.commit()
+        db_session.refresh(imm)
+
+        resp = client.get(
+            f"/api/v1/immunizations/patient/{user_with_patient['patient'].id}/history",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["items"]) == 1
+        item = body["items"][0]
+        assert set(item["components"]) == {"Diphtheria", "Tetanus", "Pertussis"}
+        assert item["is_combined"] is True
+        assert item["is_library_matched"] is True
+        for disease in ("Diphtheria", "Tetanus", "Pertussis"):
+            assert imm.id in body["diseases_index"][disease]
+        assert body["unmatched_count"] == 0
+
+    def test_resolves_via_name_match_when_no_fk(
+        self, client: TestClient, db_session, user_with_patient, auth_headers
+    ):
+        library = _seed_library(db_session)
+        imm = Immunization(
+            patient_id=user_with_patient["patient"].id,
+            vaccine_name="mmr",  # lowercase to verify case-insensitive
+            date_administered=date(2024, 3, 15),
+            standardized_vaccine_id=None,
+        )
+        db_session.add(imm)
+        db_session.commit()
+        db_session.refresh(imm)
+
+        resp = client.get(
+            f"/api/v1/immunizations/patient/{user_with_patient['patient'].id}/history",
+            headers=auth_headers,
+        )
+        body = resp.json()
+        item = body["items"][0]
+        assert set(item["components"]) == {"Measles", "Mumps", "Rubella"}
+        assert item["is_library_matched"] is True
+        assert body["unmatched_count"] == 0
+
+    def test_unmatched_record_contributes_to_unmatched_count(
+        self, client: TestClient, db_session, user_with_patient, auth_headers
+    ):
+        _seed_library(db_session)
+        imm = Immunization(
+            patient_id=user_with_patient["patient"].id,
+            vaccine_name="Bigfoot Vaccine",
+            date_administered=date(2024, 3, 15),
+        )
+        db_session.add(imm)
+        db_session.commit()
+
+        resp = client.get(
+            f"/api/v1/immunizations/patient/{user_with_patient['patient'].id}/history",
+            headers=auth_headers,
+        )
+        body = resp.json()
+        item = body["items"][0]
+        assert item["components"] == []
+        assert item["is_library_matched"] is False
+        assert body["unmatched_count"] == 1
+        assert body["diseases_index"] == {}  # unmatched records contribute no diseases
+
+    def test_date_range_filtering(
+        self, client: TestClient, db_session, user_with_patient, auth_headers
+    ):
+        library = _seed_library(db_session)
+        old = Immunization(
+            patient_id=user_with_patient["patient"].id,
+            vaccine_name="Influenza",
+            date_administered=date(2020, 1, 1),
+            standardized_vaccine_id=library["flu"].id,
+        )
+        recent = Immunization(
+            patient_id=user_with_patient["patient"].id,
+            vaccine_name="Influenza",
+            date_administered=date(2024, 1, 1),
+            standardized_vaccine_id=library["flu"].id,
+        )
+        db_session.add_all([old, recent])
+        db_session.commit()
+
+        resp = client.get(
+            f"/api/v1/immunizations/patient/{user_with_patient['patient'].id}/history",
+            params={"start_date": "2023-01-01"},
+            headers=auth_headers,
+        )
+        body = resp.json()
+        assert len(body["items"]) == 1
+        assert body["items"][0]["date_administered"] == "2024-01-01"
+
+    def test_results_ordered_newest_first(
+        self, client: TestClient, db_session, user_with_patient, auth_headers
+    ):
+        library = _seed_library(db_session)
+        for d in [date(2020, 1, 1), date(2024, 1, 1), date(2022, 1, 1)]:
+            db_session.add(Immunization(
+                patient_id=user_with_patient["patient"].id,
+                vaccine_name="Influenza",
+                date_administered=d,
+                standardized_vaccine_id=library["flu"].id,
+            ))
+        db_session.commit()
+
+        resp = client.get(
+            f"/api/v1/immunizations/patient/{user_with_patient['patient'].id}/history",
+            headers=auth_headers,
+        )
+        dates = [item["date_administered"] for item in resp.json()["items"]]
+        assert dates == ["2024-01-01", "2022-01-01", "2020-01-01"]
+
+    def test_cross_patient_access_blocked(
+        self, client: TestClient, db_session, auth_headers
+    ):
+        other_user = create_random_user(db_session)
+        other_patient = patient_crud.create_for_user(
+            db_session,
+            user_id=other_user["user"].id,
+            patient_data=PatientCreate(
+                first_name="Jane",
+                last_name="Other",
+                birth_date=date(1985, 1, 1),
+                gender="F",
+                address="456 Other St",
+            ),
+        )
+        resp = client.get(
+            f"/api/v1/immunizations/patient/{other_patient.id}/history",
+            headers=auth_headers,
+        )
+        assert resp.status_code in (403, 404)

--- a/tests/crud/test_immunization.py
+++ b/tests/crud/test_immunization.py
@@ -9,10 +9,147 @@ from sqlalchemy.orm import Session
 from app.crud.immunization import immunization as immunization_crud
 from app.crud.patient import patient as patient_crud
 from app.crud.practitioner import practitioner as practitioner_crud
+from app.models.clinical import StandardizedVaccine
 from app.models.models import Immunization
 from app.schemas.immunization import ImmunizationCreate, ImmunizationUpdate
 from app.schemas.patient import PatientCreate
 from app.schemas.practitioner import PractitionerCreate
+from tests.utils.user import create_random_user
+
+
+@pytest.fixture
+def user_with_patient(db_session: Session):
+    """Create a user with patient record for CRUD tests that need a real patient FK."""
+    user_data = create_random_user(db_session)
+    patient_data = PatientCreate(
+        first_name="John",
+        last_name="Doe",
+        birth_date=date(1990, 1, 1),
+        gender="M",
+        address="123 Main St",
+    )
+    patient = patient_crud.create_for_user(
+        db_session, user_id=user_data["user"].id, patient_data=patient_data
+    )
+    user_data["user"].active_patient_id = patient.id
+    db_session.commit()
+    db_session.refresh(user_data["user"])
+    return {**user_data, "patient": patient}
+
+
+def _make_library_vaccine(db_session, who_code="TEST-001", name="Test Vaccine"):
+    sv = StandardizedVaccine(
+        who_code=who_code,
+        vaccine_name=name,
+        is_combined=False,
+        is_common=False,
+    )
+    db_session.add(sv)
+    db_session.commit()
+    db_session.refresh(sv)
+    return sv
+
+
+def test_create_resolves_who_code_to_fk(db_session, user_with_patient):
+    sv = _make_library_vaccine(db_session)
+    payload = ImmunizationCreate(
+        vaccine_name="Test Vaccine",
+        date_administered=date(2024, 1, 1),
+        patient_id=user_with_patient["patient"].id,
+        standardized_vaccine_who_code=sv.who_code,
+    )
+    created = immunization_crud.create(db_session, obj_in=payload)
+    assert created.standardized_vaccine_id == sv.id
+
+
+def test_create_with_unknown_who_code_sets_fk_null(db_session, user_with_patient):
+    payload = ImmunizationCreate(
+        vaccine_name="Custom Brew",
+        date_administered=date(2024, 1, 1),
+        patient_id=user_with_patient["patient"].id,
+        standardized_vaccine_who_code="DOES-NOT-EXIST",
+    )
+    created = immunization_crud.create(db_session, obj_in=payload)
+    assert created.standardized_vaccine_id is None
+
+
+def test_update_resolves_who_code_to_fk(db_session, user_with_patient):
+    create_payload = ImmunizationCreate(
+        vaccine_name="MMR",
+        date_administered=date(2024, 1, 1),
+        patient_id=user_with_patient["patient"].id,
+    )
+    existing = immunization_crud.create(db_session, obj_in=create_payload)
+    assert existing.standardized_vaccine_id is None
+
+    sv = _make_library_vaccine(db_session, who_code="MMR-001", name="MMR")
+    update_payload = ImmunizationUpdate(standardized_vaccine_who_code=sv.who_code)
+    updated = immunization_crud.update(
+        db_session, db_obj=existing, obj_in=update_payload
+    )
+    assert updated.standardized_vaccine_id == sv.id
+
+
+def test_update_with_unknown_who_code_clears_fk(db_session, user_with_patient):
+    """If the picked WHO code isn't in the library, treat it like a clear - better
+    to silently drop the link than to keep a stale FK that doesn't match the typed name."""
+    sv = _make_library_vaccine(db_session, who_code="EXISTING-001", name="Existing")
+    create_payload = ImmunizationCreate(
+        vaccine_name="Existing",
+        date_administered=date(2024, 1, 1),
+        patient_id=user_with_patient["patient"].id,
+        standardized_vaccine_who_code=sv.who_code,
+    )
+    existing = immunization_crud.create(db_session, obj_in=create_payload)
+    assert existing.standardized_vaccine_id == sv.id
+
+    update_payload = ImmunizationUpdate(
+        standardized_vaccine_who_code="UNKNOWN-CODE"
+    )
+    updated = immunization_crud.update(
+        db_session, db_obj=existing, obj_in=update_payload
+    )
+    assert updated.standardized_vaccine_id is None
+
+
+def test_update_explicit_null_clears_fk(db_session, user_with_patient):
+    """Carried over from Task 3 review: pass explicit null to clear the link."""
+    sv = _make_library_vaccine(db_session, who_code="LINK-001", name="LinkedVax")
+    create_payload = ImmunizationCreate(
+        vaccine_name="LinkedVax",
+        date_administered=date(2024, 1, 1),
+        patient_id=user_with_patient["patient"].id,
+        standardized_vaccine_who_code=sv.who_code,
+    )
+    existing = immunization_crud.create(db_session, obj_in=create_payload)
+    assert existing.standardized_vaccine_id == sv.id
+
+    update_payload = ImmunizationUpdate(standardized_vaccine_who_code=None)
+    updated = immunization_crud.update(
+        db_session, db_obj=existing, obj_in=update_payload
+    )
+    assert updated.standardized_vaccine_id is None
+
+
+def test_update_without_who_code_field_preserves_fk(db_session, user_with_patient):
+    """If the payload doesn't include who_code at all, the existing FK is preserved."""
+    sv = _make_library_vaccine(db_session, who_code="KEEP-001", name="KeepVax")
+    create_payload = ImmunizationCreate(
+        vaccine_name="KeepVax",
+        date_administered=date(2024, 1, 1),
+        patient_id=user_with_patient["patient"].id,
+        standardized_vaccine_who_code=sv.who_code,
+    )
+    existing = immunization_crud.create(db_session, obj_in=create_payload)
+    assert existing.standardized_vaccine_id == sv.id
+
+    # Update vaccine_name only - don't touch who_code
+    update_payload = ImmunizationUpdate(vaccine_name="Updated Name")
+    updated = immunization_crud.update(
+        db_session, db_obj=existing, obj_in=update_payload
+    )
+    assert updated.standardized_vaccine_id == sv.id, "FK should be preserved"
+    assert updated.vaccine_name == "Updated Name"
 
 
 class TestImmunizationCRUD:

--- a/tests/schemas/test_immunization_schemas.py
+++ b/tests/schemas/test_immunization_schemas.py
@@ -1,0 +1,69 @@
+from datetime import date
+
+from app.schemas.immunization import (
+    ImmunizationCreate,
+    ImmunizationResponse,
+    ImmunizationUpdate,
+    ImmunizationHistoryItem,
+    ImmunizationHistoryResponse,
+)
+
+
+def test_create_accepts_standardized_vaccine_who_code():
+    payload = {
+        "vaccine_name": "MMR",
+        "date_administered": date(2024, 1, 1),
+        "patient_id": 1,
+        "standardized_vaccine_who_code": "PCV-WHO-1234",
+    }
+    obj = ImmunizationCreate(**payload)
+    assert obj.standardized_vaccine_who_code == "PCV-WHO-1234"
+
+
+def test_update_accepts_standardized_vaccine_who_code_clear():
+    obj = ImmunizationUpdate(standardized_vaccine_who_code=None)
+    assert obj.standardized_vaccine_who_code is None
+
+
+def test_response_exposes_standardized_vaccine_id():
+    class Stub:
+        id = 7
+        vaccine_name = "MMR"
+        date_administered = date(2024, 1, 1)
+        patient_id = 1
+        standardized_vaccine_id = 42
+        vaccine_trade_name = None
+        dose_number = None
+        lot_number = None
+        ndc_number = None
+        manufacturer = None
+        site = None
+        route = None
+        expiration_date = None
+        location = None
+        notes = None
+        practitioner_id = None
+        tags = None
+
+    resp = ImmunizationResponse.model_validate(Stub())
+    assert resp.standardized_vaccine_id == 42
+
+
+def test_history_response_shape():
+    item_payload = {
+        "id": 1,
+        "vaccine_name": "DTaP",
+        "date_administered": date(2024, 1, 1),
+        "patient_id": 1,
+        "standardized_vaccine_id": 10,
+        "components": ["Diphtheria", "Tetanus", "Pertussis"],
+        "is_combined": True,
+        "is_library_matched": True,
+    }
+    resp = ImmunizationHistoryResponse(
+        items=[ImmunizationHistoryItem(**item_payload)],
+        diseases_index={"Tetanus": [1], "Diphtheria": [1], "Pertussis": [1]},
+        unmatched_count=0,
+    )
+    assert resp.unmatched_count == 0
+    assert "Tetanus" in resp.diseases_index

--- a/tests/schemas/test_immunization_schemas.py
+++ b/tests/schemas/test_immunization_schemas.py
@@ -67,3 +67,25 @@ def test_history_response_shape():
     )
     assert resp.unmatched_count == 0
     assert "Tetanus" in resp.diseases_index
+
+
+def test_create_rejects_standardized_vaccine_id_as_client_input():
+    """The FK is server-set via who_code resolution; clients must not be able
+    to set it directly through ImmunizationCreate or ImmunizationUpdate."""
+    create_obj = ImmunizationCreate(
+        vaccine_name="MMR",
+        date_administered=date(2024, 1, 1),
+        patient_id=1,
+        standardized_vaccine_id=999,  # type: ignore[call-arg]
+    )
+    # Pydantic v2 silently ignores unknown fields by default; verify it's not
+    # present in the dumped dict (so it can't reach the SQLAlchemy constructor)
+    assert "standardized_vaccine_id" not in create_obj.model_dump()
+
+
+def test_update_rejects_standardized_vaccine_id_as_client_input():
+    update_obj = ImmunizationUpdate(
+        vaccine_name="MMR",
+        standardized_vaccine_id=999,  # type: ignore[call-arg]
+    )
+    assert "standardized_vaccine_id" not in update_obj.model_dump(exclude_unset=True)

--- a/tests/services/test_vaccine_resolver.py
+++ b/tests/services/test_vaccine_resolver.py
@@ -1,0 +1,145 @@
+"""Unit tests for app.services.vaccine_resolver."""
+from datetime import date
+from types import SimpleNamespace
+
+from app.services.vaccine_resolver import (
+    build_library_index,
+    resolve_components,
+)
+
+
+def make_library_entry(
+    id_: int,
+    vaccine_name: str,
+    common_names=None,
+    is_combined=False,
+    components=None,
+):
+    return SimpleNamespace(
+        id=id_,
+        vaccine_name=vaccine_name,
+        common_names=common_names,
+        is_combined=is_combined,
+        components=components,
+    )
+
+
+def make_immunization(
+    vaccine_name: str,
+    standardized_vaccine_id=None,
+):
+    return SimpleNamespace(
+        vaccine_name=vaccine_name,
+        standardized_vaccine_id=standardized_vaccine_id,
+        date_administered=date(2024, 1, 1),
+    )
+
+
+def test_fk_present_returns_components_for_combined():
+    dtap = make_library_entry(
+        10, "DTaP", is_combined=True,
+        components=["Diphtheria", "Tetanus", "Pertussis"],
+    )
+    index = {"by_id": {10: dtap}, "by_name": {"dtap": dtap}}
+    imm = make_immunization("anything", standardized_vaccine_id=10)
+    components, matched = resolve_components(imm, index)
+    assert components == ["Diphtheria", "Tetanus", "Pertussis"]
+    assert matched is True
+
+
+def test_fk_present_returns_vaccine_name_for_single_disease():
+    polio = make_library_entry(11, "Polio (IPV)")
+    index = {"by_id": {11: polio}, "by_name": {"polio (ipv)": polio}}
+    imm = make_immunization("Polio (IPV)", standardized_vaccine_id=11)
+    components, matched = resolve_components(imm, index)
+    assert components == ["Polio (IPV)"]
+    assert matched is True
+
+
+def test_fk_missing_falls_back_to_exact_name_match():
+    mmr = make_library_entry(
+        12, "MMR", is_combined=True,
+        components=["Measles", "Mumps", "Rubella"],
+    )
+    index = {"by_id": {12: mmr}, "by_name": {"mmr": mmr}}
+    imm = make_immunization("MMR")
+    components, matched = resolve_components(imm, index)
+    assert components == ["Measles", "Mumps", "Rubella"]
+    assert matched is True
+
+
+def test_name_match_is_case_insensitive():
+    flu = make_library_entry(13, "Influenza")
+    index = {"by_id": {13: flu}, "by_name": {"influenza": flu}}
+    imm = make_immunization("INFLUENZA")
+    components, matched = resolve_components(imm, index)
+    assert components == ["Influenza"]
+    assert matched is True
+
+
+def test_common_name_match():
+    shingrix = make_library_entry(
+        14, "Recombinant Zoster Vaccine", common_names=["Shingrix"],
+    )
+    index = {
+        "by_id": {14: shingrix},
+        "by_name": {
+            "recombinant zoster vaccine": shingrix,
+            "shingrix": shingrix,
+        },
+    }
+    imm = make_immunization("Shingrix")
+    components, matched = resolve_components(imm, index)
+    assert components == ["Recombinant Zoster Vaccine"]
+    assert matched is True
+
+
+def test_no_match_returns_empty():
+    index = {"by_id": {}, "by_name": {}}
+    imm = make_immunization("Bigfoot Vaccine")
+    components, matched = resolve_components(imm, index)
+    assert components == []
+    assert matched is False
+
+
+def test_fk_pointing_to_missing_entry_falls_back_to_name():
+    mmr = make_library_entry(
+        12, "MMR", is_combined=True, components=["Measles", "Mumps", "Rubella"],
+    )
+    index = {"by_id": {12: mmr}, "by_name": {"mmr": mmr}}
+    imm = make_immunization("MMR", standardized_vaccine_id=999)
+    components, matched = resolve_components(imm, index)
+    assert components == ["Measles", "Mumps", "Rubella"]
+    assert matched is True
+
+
+def test_combined_vaccine_with_null_components_treated_as_unmatched():
+    bad = make_library_entry(15, "BadCombo", is_combined=True, components=None)
+    index = {"by_id": {15: bad}, "by_name": {"badcombo": bad}}
+    imm = make_immunization("BadCombo", standardized_vaccine_id=15)
+    components, matched = resolve_components(imm, index)
+    assert components == []
+    assert matched is False
+
+
+def test_build_library_index_populates_name_and_id_maps():
+    mmr = make_library_entry(
+        12, "MMR", common_names=["MMR II"], is_combined=True,
+        components=["Measles", "Mumps", "Rubella"],
+    )
+    polio = make_library_entry(13, "Polio")
+
+    class StubQuery:
+        def all(self):
+            return [mmr, polio]
+
+    class StubDB:
+        def query(self, _model):
+            return StubQuery()
+
+    index = build_library_index(StubDB())
+    assert index["by_id"][12] is mmr
+    assert index["by_id"][13] is polio
+    assert index["by_name"]["mmr"] is mmr
+    assert index["by_name"]["mmr ii"] is mmr  # common name indexed
+    assert index["by_name"]["polio"] is polio

--- a/tests/services/test_vaccine_resolver.py
+++ b/tests/services/test_vaccine_resolver.py
@@ -42,7 +42,7 @@ def test_fk_present_returns_components_for_combined():
     )
     index = {"by_id": {10: dtap}, "by_name": {"dtap": dtap}}
     imm = make_immunization("anything", standardized_vaccine_id=10)
-    components, matched = resolve_components(imm, index)
+    components, matched, _ = resolve_components(imm, index)
     assert components == ["Diphtheria", "Tetanus", "Pertussis"]
     assert matched is True
 
@@ -51,7 +51,7 @@ def test_fk_present_returns_vaccine_name_for_single_disease():
     polio = make_library_entry(11, "Polio (IPV)")
     index = {"by_id": {11: polio}, "by_name": {"polio (ipv)": polio}}
     imm = make_immunization("Polio (IPV)", standardized_vaccine_id=11)
-    components, matched = resolve_components(imm, index)
+    components, matched, _ = resolve_components(imm, index)
     assert components == ["Polio (IPV)"]
     assert matched is True
 
@@ -63,7 +63,7 @@ def test_fk_missing_falls_back_to_exact_name_match():
     )
     index = {"by_id": {12: mmr}, "by_name": {"mmr": mmr}}
     imm = make_immunization("MMR")
-    components, matched = resolve_components(imm, index)
+    components, matched, _ = resolve_components(imm, index)
     assert components == ["Measles", "Mumps", "Rubella"]
     assert matched is True
 
@@ -72,7 +72,7 @@ def test_name_match_is_case_insensitive():
     flu = make_library_entry(13, "Influenza")
     index = {"by_id": {13: flu}, "by_name": {"influenza": flu}}
     imm = make_immunization("INFLUENZA")
-    components, matched = resolve_components(imm, index)
+    components, matched, _ = resolve_components(imm, index)
     assert components == ["Influenza"]
     assert matched is True
 
@@ -89,7 +89,7 @@ def test_common_name_match():
         },
     }
     imm = make_immunization("Shingrix")
-    components, matched = resolve_components(imm, index)
+    components, matched, _ = resolve_components(imm, index)
     assert components == ["Recombinant Zoster Vaccine"]
     assert matched is True
 
@@ -97,7 +97,7 @@ def test_common_name_match():
 def test_no_match_returns_empty():
     index = {"by_id": {}, "by_name": {}}
     imm = make_immunization("Bigfoot Vaccine")
-    components, matched = resolve_components(imm, index)
+    components, matched, _ = resolve_components(imm, index)
     assert components == []
     assert matched is False
 
@@ -108,7 +108,7 @@ def test_fk_pointing_to_missing_entry_falls_back_to_name():
     )
     index = {"by_id": {12: mmr}, "by_name": {"mmr": mmr}}
     imm = make_immunization("MMR", standardized_vaccine_id=999)
-    components, matched = resolve_components(imm, index)
+    components, matched, _ = resolve_components(imm, index)
     assert components == ["Measles", "Mumps", "Rubella"]
     assert matched is True
 
@@ -117,9 +117,33 @@ def test_combined_vaccine_with_null_components_treated_as_unmatched():
     bad = make_library_entry(15, "BadCombo", is_combined=True, components=None)
     index = {"by_id": {15: bad}, "by_name": {"badcombo": bad}}
     imm = make_immunization("BadCombo", standardized_vaccine_id=15)
-    components, matched = resolve_components(imm, index)
+    components, matched, _ = resolve_components(imm, index)
     assert components == []
     assert matched is False
+
+
+def test_resolve_returns_matched_vaccine_object():
+    """The matched vaccine should be returned so callers can read extra fields
+    (e.g., is_combined) without repeating the lookup."""
+    dtap = make_library_entry(
+        10, "DTaP", is_combined=True,
+        components=["Diphtheria", "Tetanus", "Pertussis"],
+    )
+    index = {"by_id": {10: dtap}, "by_name": {"dtap": dtap}}
+    imm = make_immunization("anything", standardized_vaccine_id=10)
+
+    components, matched, vaccine = resolve_components(imm, index)
+    assert vaccine is dtap
+    assert vaccine.is_combined is True
+
+
+def test_resolve_returns_none_vaccine_when_unmatched():
+    index = {"by_id": {}, "by_name": {}}
+    imm = make_immunization("Unknown")
+
+    _, matched, vaccine = resolve_components(imm, index)
+    assert matched is False
+    assert vaccine is None
 
 
 def test_build_library_index_populates_name_and_id_maps():

--- a/tests/services/test_vaccine_resolver.py
+++ b/tests/services/test_vaccine_resolver.py
@@ -132,7 +132,7 @@ def test_resolve_returns_matched_vaccine_object():
     index = {"by_id": {10: dtap}, "by_name": {"dtap": dtap}}
     imm = make_immunization("anything", standardized_vaccine_id=10)
 
-    components, matched, vaccine = resolve_components(imm, index)
+    _components, _matched, vaccine = resolve_components(imm, index)
     assert vaccine is dtap
     assert vaccine.is_combined is True
 

--- a/tests/services/test_vaccine_resolver.py
+++ b/tests/services/test_vaccine_resolver.py
@@ -143,3 +143,47 @@ def test_build_library_index_populates_name_and_id_maps():
     assert index["by_name"]["mmr"] is mmr
     assert index["by_name"]["mmr ii"] is mmr  # common name indexed
     assert index["by_name"]["polio"] is polio
+
+
+def test_canonical_name_always_wins_over_alias_collision():
+    """A common-name alias must never displace another vaccine's canonical name,
+    regardless of iteration order in the catalog."""
+    # Vaccine A has "Fluzone" as a common alias
+    a = make_library_entry(1, "Flu", common_names=["Fluzone"])
+    # Vaccine B has "Fluzone" as its CANONICAL name
+    b = make_library_entry(2, "Fluzone")
+
+    class StubQuery:
+        def __init__(self, vs): self._vs = vs
+        def all(self): return self._vs
+
+    class StubDB:
+        def __init__(self, vs): self._vs = vs
+        def query(self, _model): return StubQuery(self._vs)
+
+    # Try both iteration orders - canonical entry B must win either way
+    index_a_first = build_library_index(StubDB([a, b]))
+    assert index_a_first["by_name"]["fluzone"] is b, (
+        "B's canonical name 'Fluzone' must beat A's common-name alias"
+    )
+
+    index_b_first = build_library_index(StubDB([b, a]))
+    assert index_b_first["by_name"]["fluzone"] is b, (
+        "B's canonical name 'Fluzone' must beat A's common-name alias "
+        "regardless of iteration order"
+    )
+
+
+def test_empty_canonical_name_is_skipped():
+    """Defensive: an empty vaccine_name string must not pollute by_name with a blank key."""
+    bad = make_library_entry(99, "")
+
+    class StubQuery:
+        def all(self): return [bad]
+
+    class StubDB:
+        def query(self, _model): return StubQuery()
+
+    index = build_library_index(StubDB())
+    assert "" not in index["by_name"]
+    assert 99 in index["by_id"]  # id index still populated


### PR DESCRIPTION

## Summary

This pull request introduces major enhancements to the immunization records system by adding a new optional foreign key linking immunizations to standardized vaccines, supporting richer data entry and more powerful querying. It also introduces a new API endpoint for retrieving a patient's immunization history, where combined vaccines are expanded into their disease components, and provides improved schema and documentation to support these features.

**Database and Model Changes:**

* Added a nullable `standardized_vaccine_id` foreign key to the `immunizations` table, linking immunizations to entries in the `standardized_vaccines` library. This enables direct association of immunization records with standardized vaccine definitions, while preserving support for legacy and free-text entries. Corresponding index and relationship fields were also added. [[1]](diffhunk://#diff-941eae14ea0933eb6c5bccb5fd9e778370fe51123a04122aacccc1c202b6fc84R1-R53) [[2]](diffhunk://#diff-8aa70ad1539fd0c3bbbe563a82757957c38cda9597467cb0cede0b819b44e8c1R276-R297) [[3]](diffhunk://#diff-1ed4ba78cede8552f355229a24c22e10a0cd7e7c9aedfb072684e3457d26f30bR593-R609)

**API and CRUD Enhancements:**

* Updated the immunization create and update logic to accept a `standardized_vaccine_who_code` field. When present, this code is resolved to a standardized vaccine and the foreign key is set. If the code is unknown or explicitly set to null, the foreign key is cleared or left unset. [[1]](diffhunk://#diff-6120e7d38d920d766bdd38fae45764eda1542efd7306cc0f6078177808d35d67L21-L29) [[2]](diffhunk://#diff-6120e7d38d920d766bdd38fae45764eda1542efd7306cc0f6078177808d35d67L39-R62) [[3]](diffhunk://#diff-3010322e61964ad9aea69e9be5c5d6f5319a51a6d7c5f0f57250d9b882b9923aL101-R109) [[4]](diffhunk://#diff-3010322e61964ad9aea69e9be5c5d6f5319a51a6d7c5f0f57250d9b882b9923aR127-R134)
* Extended the immunization response schema to include the `standardized_vaccine_id` and added new schemas for the immunization history endpoint, including disease components, combination vaccine status, and library match status. [[1]](diffhunk://#diff-3010322e61964ad9aea69e9be5c5d6f5319a51a6d7c5f0f57250d9b882b9923aR183-R187) [[2]](diffhunk://#diff-3010322e61964ad9aea69e9be5c5d6f5319a51a6d7c5f0f57250d9b882b9923aR208-R232)

**New Endpoint and Disease Component Resolution:**

* Added a new endpoint `/immunizations/patient/{patient_id}/history` that returns a patient's immunizations enriched with disease components, expanding combination vaccines and providing a mapping of diseases to immunization IDs. This endpoint leverages a new resolver service for efficient component lookup. [[1]](diffhunk://#diff-75ccafd95efc4a44b84475d8533722ffb2d125a072ce276312ed81e68740db29R316-R391) [[2]](diffhunk://#diff-75ccafd95efc4a44b84475d8533722ffb2d125a072ce276312ed81e68740db29R21-R30) [[3]](diffhunk://#diff-75ccafd95efc4a44b84475d8533722ffb2d125a072ce276312ed81e68740db29R1-R2) [[4]](diffhunk://#diff-486bab14c9d96dfeea72d77fbb57ce5dc690cad51cf28b8399825d6deb5bdf04R1-R101)

**Documentation Updates:**

* Updated API and database documentation to describe the new foreign key, new fields, and the new immunization history endpoint, including example responses and usage notes. [[1]](diffhunk://#diff-1a9fb546cf7d8e7fe373361c585bc639db88fcedb5c4939f6ce42b1cb8196f15L1264-R1279) [[2]](diffhunk://#diff-1a9fb546cf7d8e7fe373361c585bc639db88fcedb5c4939f6ce42b1cb8196f15R1290-R1346) [[3]](diffhunk://#diff-1ed4ba78cede8552f355229a24c22e10a0cd7e7c9aedfb072684e3457d26f30bR593-R609)

These changes lay the groundwork for more robust immunization tracking, improved data integrity, and enhanced UI features for displaying immunization histories.
## Related issue

<!-- e.g. "Closes #123" or "N/A" -->

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Translation / i18n
- [ ] Other

## Testing

<!-- How did you verify this works? Manual steps, screenshots, or test names. -->

## Checklist

- [x] Tests added or updated (or N/A with reason)
- [x] `npm run lint` and `npm run build` pass
- [x] Backend tests pass (`pytest`) if backend code changed
- [x] No PHI, secrets, or `console.log` left in the diff
- [x] User-facing strings go through `t()` translations
- [x] Documentation updated if API, schema, or service behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Immunizations "History" tab with two views: By Date and By Disease.
  * Date-range filtering for immunization history.
  * History items show expanded vaccine components or an "Unlinked" badge and surface an unmatched-records count/alert.
  * Immunization records can be linked to a standardized vaccine library (affects display of components).
  * Multi-language/localization added for the immunization history UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->