### PR TITLE
feat: Move Ordered/Completed LabResults to main tab on add

### DIFF
--- a/frontend/src/components/medical/labresults/LabResultFormWrapper.jsx
+++ b/frontend/src/components/medical/labresults/LabResultFormWrapper.jsx
@@ -653,6 +653,50 @@ const LabResultFormWrapper = ({
                       comboboxProps={{ withinPortal: true, zIndex: 3000 }}
                     />
                   </Grid.Col>
+                  <Grid.Col span={{ base: 12, sm: 6 }}>
+                    <DateInput
+                      label={t('shared:labels.orderedDate')}
+                      value={parseDateInput(formData.ordered_date)}
+                      onChange={date => {
+                        const formattedDate = formatDateInputChange(date);
+                        onInputChange({
+                          target: {
+                            name: 'ordered_date',
+                            value: formattedDate,
+                          },
+                        });
+                      }}
+                      placeholder={dateInputFormat}
+                      valueFormat={dateInputFormat}
+                      dateParser={dateParser}
+                      description={t('labresults:orderedDate.description')}
+                      clearable
+                      firstDayOfWeek={0}
+                      popoverProps={{ withinPortal: true, zIndex: 3000 }}
+                    />
+                  </Grid.Col>
+                  <Grid.Col span={{ base: 12, sm: 6 }}>
+                    <DateInput
+                      label={t('shared:labels.completedDate')}
+                      value={parseDateInput(formData.completed_date)}
+                      onChange={date => {
+                        const formattedDate = formatDateInputChange(date);
+                        onInputChange({
+                          target: {
+                            name: 'completed_date',
+                            value: formattedDate,
+                          },
+                        });
+                      }}
+                      placeholder={dateInputFormat}
+                      valueFormat={dateInputFormat}
+                      dateParser={dateParser}
+                      description={t('labresults:completedDate.description')}
+                      clearable
+                      firstDayOfWeek={0}
+                      popoverProps={{ withinPortal: true, zIndex: 3000 }}
+                    />
+                  </Grid.Col>
                   <Grid.Col span={12}>
                     <Box>
                       <Text size="sm" fw={500} mb="xs">
@@ -709,50 +753,6 @@ const LabResultFormWrapper = ({
                       description={t('labresults:labResult.description')}
                       clearable
                       comboboxProps={{ withinPortal: true, zIndex: 3000 }}
-                    />
-                  </Grid.Col>
-                  <Grid.Col span={{ base: 12, sm: 6 }}>
-                    <DateInput
-                      label={t('shared:labels.orderedDate')}
-                      value={parseDateInput(formData.ordered_date)}
-                      onChange={date => {
-                        const formattedDate = formatDateInputChange(date);
-                        onInputChange({
-                          target: {
-                            name: 'ordered_date',
-                            value: formattedDate,
-                          },
-                        });
-                      }}
-                      placeholder={dateInputFormat}
-                      valueFormat={dateInputFormat}
-                      dateParser={dateParser}
-                      description={t('labresults:orderedDate.description')}
-                      clearable
-                      firstDayOfWeek={0}
-                      popoverProps={{ withinPortal: true, zIndex: 3000 }}
-                    />
-                  </Grid.Col>
-                  <Grid.Col span={{ base: 12, sm: 6 }}>
-                    <DateInput
-                      label={t('shared:labels.completedDate')}
-                      value={parseDateInput(formData.completed_date)}
-                      onChange={date => {
-                        const formattedDate = formatDateInputChange(date);
-                        onInputChange({
-                          target: {
-                            name: 'completed_date',
-                            value: formattedDate,
-                          },
-                        });
-                      }}
-                      placeholder={dateInputFormat}
-                      valueFormat={dateInputFormat}
-                      dateParser={dateParser}
-                      description={t('labresults:completedDate.description')}
-                      clearable
-                      firstDayOfWeek={0}
-                      popoverProps={{ withinPortal: true, zIndex: 3000 }}
                     />
                   </Grid.Col>
                   {formData.status && (

--- a/frontend/src/components/medical/labresults/__tests__/LabResultFormWrapper.test.tsx
+++ b/frontend/src/components/medical/labresults/__tests__/LabResultFormWrapper.test.tsx
@@ -1,0 +1,173 @@
+import { vi } from 'vitest';
+
+/**
+ * @jest-environment jsdom
+ */
+import render, { screen, fireEvent } from '../../../../test-utils/render';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import LabResultFormWrapper from '../LabResultFormWrapper';
+
+// Paths are relative to this test file (src/components/medical/labresults/__tests__/)
+
+vi.mock('../InlineTestComponentEntry', () => ({
+  default: ({ onRef }) => {
+    if (onRef) onRef({ getComponents: () => [] });
+    return <div data-testid="inline-test-component" />;
+  },
+}));
+vi.mock('../../../shared/DocumentManagerWithProgress', () => ({
+  default: () => <div data-testid="document-manager" />,
+}));
+vi.mock('../../ConditionRelationships', () => ({
+  default: () => <div data-testid="condition-relationships" />,
+}));
+vi.mock('../LabResultEncounterRelationships', () => ({
+  default: () => <div data-testid="encounter-relationships" />,
+}));
+
+vi.mock('../../../../hooks/useDateFormat', () => ({
+  useDateFormat: () => ({
+    dateInputFormat: 'MM/DD/YYYY',
+    dateParser: s => new Date(s),
+  }),
+}));
+vi.mock('../../../../services/logger', () => ({
+  default: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+
+
+const defaultProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  title: 'Add Lab Result',
+  formData: {
+    test_name: '',
+    test_code: '',
+    test_category: '',
+    test_type: '',
+    facility: '',
+    practitioner_id: '',
+    ordered_date: '',
+    completed_date: '',
+    status: '',
+    labs_result: '',
+    notes: '',
+    tags: [],
+  },
+  onInputChange: vi.fn(),
+  onSubmit: vi.fn(),
+  editingItem: null,
+  practitioners: [{ id: 1, name: 'Dr. Smith', specialty: 'Internal Medicine' }],
+};
+
+describe('LabResultFormWrapper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Basic Info tab (default)', () => {
+    test('renders the form when open', () => {
+      render(<LabResultFormWrapper {...defaultProps} />);
+      expect(screen.getByText('Add Lab Result')).toBeInTheDocument();
+    });
+
+    test('does not render when closed', () => {
+      render(<LabResultFormWrapper {...defaultProps} isOpen={false} />);
+      expect(screen.queryByText('Add Lab Result')).not.toBeInTheDocument();
+    });
+
+    test('shows Ordered Date on the Basic Info tab without switching tabs', () => {
+      render(<LabResultFormWrapper {...defaultProps} />);
+      // Basic Info is the default active tab — dates must be immediately visible
+      expect(screen.getByText('shared:labels.orderedDate')).toBeInTheDocument();
+    });
+
+    test('shows Completed Date on the Basic Info tab without switching tabs', () => {
+      render(<LabResultFormWrapper {...defaultProps} />);
+      expect(
+        screen.getByText('shared:labels.completedDate')
+      ).toBeInTheDocument();
+    });
+
+    test('shows Tags field on the Basic Info tab', () => {
+      render(<LabResultFormWrapper {...defaultProps} />);
+      // Use getAllByText since "tags" may appear in multiple places (e.g. navigation)
+      const tagLabels = screen.getAllByText('shared:labels.tags');
+      expect(tagLabels.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Results & Status tab', () => {
+    // Helper: find the Results & Status tab by its exact i18n key text
+    function getResultsTab() {
+      return screen.getByRole('tab', { name: 'labresults:tabs.resultsStatus' });
+    }
+
+    test('shows Status and Lab Result selects', () => {
+      render(<LabResultFormWrapper {...defaultProps} />);
+
+      fireEvent.click(getResultsTab());
+
+      expect(
+        screen.getByText('labresults:testStatus.label')
+      ).toBeInTheDocument();
+      expect(screen.getByText('shared:labels.labResult')).toBeInTheDocument();
+    });
+
+    test('Ordered Date and Completed Date are not visible on Results & Status tab', () => {
+      render(<LabResultFormWrapper {...defaultProps} />);
+
+      fireEvent.click(getResultsTab());
+
+      // Mantine keeps all panels mounted but hides inactive ones with CSS
+      const orderedLabel = screen.queryByText('shared:labels.orderedDate');
+      const completedLabel = screen.queryByText('shared:labels.completedDate');
+      if (orderedLabel) expect(orderedLabel).not.toBeVisible();
+      if (completedLabel) expect(completedLabel).not.toBeVisible();
+    });
+  });
+
+  describe('Form submission', () => {
+    test('calls onClose when Cancel is clicked', async () => {
+      const mockClose = vi.fn();
+      render(<LabResultFormWrapper {...defaultProps} onClose={mockClose} />);
+
+      // i18n keys are rendered as-is in the test environment
+      const cancelButton = screen.getByRole('button', {
+        name: 'shared:fields.cancel',
+      });
+      await userEvent.click(cancelButton);
+
+      expect(mockClose).toHaveBeenCalled();
+    });
+
+    test('Submit button is disabled when test_name is empty', () => {
+      render(<LabResultFormWrapper {...defaultProps} />);
+
+      // Button text: "common:buttons.create shared:categories.lab_results"
+      const submitButtons = screen.getAllByRole('button');
+      const submitButton = submitButtons.find(btn =>
+        btn.textContent.includes('common:buttons.create')
+      );
+      expect(submitButton).toBeDefined();
+      expect(submitButton).toBeDisabled();
+    });
+
+    test('Submit button is enabled when test_name is provided', () => {
+      render(
+        <LabResultFormWrapper
+          {...defaultProps}
+          formData={{ ...defaultProps.formData, test_name: 'CBC' }}
+        />
+      );
+
+      const submitButtons = screen.getAllByRole('button');
+      const submitButton = submitButtons.find(btn =>
+        btn.textContent.includes('common:buttons.create')
+      );
+      expect(submitButton).toBeDefined();
+      expect(submitButton).not.toBeDisabled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Moves the Ordered Date and Completed Date fields from the **Results & Status** tab to the **Basic Info** tab in the Add/Edit Lab Result dialog. These dates are core metadata that users typically fill in at creation time — having them on a secondary tab added unnecessary navigation friction. The layout now mirrors the Procedure form, where the date field appears on the main pane alongside the other primary fields.

## Related issue

N/A

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code quality
- [ ] Documentation
- [ ] Translation / i18n
- [ ] Other

## Testing

Added `LabResultFormWrapper.test.tsx` (10 tests) covering:
- Form renders when open; returns null when closed
- Ordered Date and Completed Date are visible on the Basic Info tab without switching tabs
- Ordered Date and Completed Date are not visible when the Results & Status tab is active
- Status and Lab Result selects are present on the Results & Status tab
- Cancel button calls `onClose`
- Submit button disabled when `test_name` is empty; enabled when populated

All 10 tests pass (`npm run test:run`).

## Checklist

- [x] Tests added or updated (or N/A with reason)
- [x] `npm run lint` and `npm run build` pass
- [x] Backend tests pass (`pytest`) if backend code changed — N/A, no backend changes
- [x] No PHI, secrets, or `console.log` left in the diff
- [x] User-facing strings go through `t()` translations
- [x] Documentation updated if API, schema, or service behavior changed — N/A, UI-only change
