### PR TITLE
Remove unused sqlalchemy import in migration file

### DIFF
--- a/alembic/migrations/versions/20250719_1740_26dd25579d9f_remove_overly_restrictive_invitation_.py
+++ b/alembic/migrations/versions/20250719_1740_26dd25579d9f_remove_overly_restrictive_invitation_.py
@@ -6,7 +6,6 @@ Create Date: 2025-07-19 17:40:39.408545
 
 """
 from alembic import op
-import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.


### PR DESCRIPTION
## Problem
The migration file `alembic/migrations/versions/20250719_1740_26dd25579d9f_remove_overly_restrictive_invitation_.py` contained an unused import of `sqlalchemy as sa`. This can lead to lint warnings, increase code clutter, and reduce readability without affecting functionality.

## Solution
Removed the unused import statement `import sqlalchemy as sa` from the file to clean up the code and adhere to lint best practices.

## Verification
- Run lint tools (e.g., flake8, pylint) to confirm no remaining unused import warnings in this file.
- Execute Alembic migration commands (e.g., `alembic upgrade head`) to ensure the migration still functions correctly.
- Review the codebase to confirm no other dependencies on this import, as it was unused and should not impact any features.