### PR TITLE
feat: Allow practitoner to be added to medical forms while filling them out.

### DIFF
--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -769,6 +769,13 @@
       "addTitle": "Neue medizinische Fachkraft hinzufügen",
       "editTitle": "Medizinische Fachkraft bearbeiten"
     },
+    "createInline": {
+      "buttonTooltip": "New practitioner",
+      "nameRequired": "Name is required",
+      "specialtyRequired": "Medical specialty is required",
+      "createError": "Failed to create practitioner. Please try again.",
+      "successMessage": "Practitioner created and selected"
+    },
     "groupByPractice": "Nach Praxis gruppieren",
     "loading": "Medizinische Fachkräfte werden geladen...",
     "practices": {

--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -770,11 +770,11 @@
       "editTitle": "Medizinische Fachkraft bearbeiten"
     },
     "createInline": {
-      "buttonTooltip": "New practitioner",
-      "nameRequired": "Name is required",
-      "specialtyRequired": "Medical specialty is required",
-      "createError": "Failed to create practitioner. Please try again.",
-      "successMessage": "Practitioner created and selected"
+      "buttonTooltip": "Neuer Behandler",
+      "nameRequired": "Name ist erforderlich",
+      "specialtyRequired": "Fachrichtung ist erforderlich",
+      "createError": "Behandler konnte nicht erstellt werden. Bitte erneut versuchen.",
+      "successMessage": "Behandler erstellt und ausgewählt"
     },
     "groupByPractice": "Nach Praxis gruppieren",
     "loading": "Medizinische Fachkräfte werden geladen...",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -769,6 +769,13 @@
       "addTitle": "Add New Practitioner",
       "editTitle": "Edit Practitioner"
     },
+    "createInline": {
+      "buttonTooltip": "New practitioner",
+      "nameRequired": "Name is required",
+      "specialtyRequired": "Medical specialty is required",
+      "createError": "Failed to create practitioner. Please try again.",
+      "successMessage": "Practitioner created and selected"
+    },
     "groupByPractice": "Group by Practice",
     "loading": "Loading practitioners...",
     "practices": {

--- a/frontend/public/locales/es/common.json
+++ b/frontend/public/locales/es/common.json
@@ -769,6 +769,13 @@
       "addTitle": "Añadir nuevo profesional",
       "editTitle": "Editar profesional"
     },
+    "createInline": {
+      "buttonTooltip": "New practitioner",
+      "nameRequired": "Name is required",
+      "specialtyRequired": "Medical specialty is required",
+      "createError": "Failed to create practitioner. Please try again.",
+      "successMessage": "Practitioner created and selected"
+    },
     "groupByPractice": "Agrupar por consultorio",
     "loading": "Cargando profesionales...",
     "practices": {

--- a/frontend/public/locales/es/common.json
+++ b/frontend/public/locales/es/common.json
@@ -770,11 +770,11 @@
       "editTitle": "Editar profesional"
     },
     "createInline": {
-      "buttonTooltip": "New practitioner",
-      "nameRequired": "Name is required",
-      "specialtyRequired": "Medical specialty is required",
-      "createError": "Failed to create practitioner. Please try again.",
-      "successMessage": "Practitioner created and selected"
+      "buttonTooltip": "Nuevo profesional",
+      "nameRequired": "El nombre es obligatorio",
+      "specialtyRequired": "La especialidad médica es obligatoria",
+      "createError": "Error al crear el profesional. Por favor, inténtelo de nuevo.",
+      "successMessage": "Profesional creado y seleccionado"
     },
     "groupByPractice": "Agrupar por consultorio",
     "loading": "Cargando profesionales...",

--- a/frontend/public/locales/fr/common.json
+++ b/frontend/public/locales/fr/common.json
@@ -769,6 +769,13 @@
       "addTitle": "Ajouter un médecin",
       "editTitle": "Editer le médecin"
     },
+    "createInline": {
+      "buttonTooltip": "New practitioner",
+      "nameRequired": "Name is required",
+      "specialtyRequired": "Medical specialty is required",
+      "createError": "Failed to create practitioner. Please try again.",
+      "successMessage": "Practitioner created and selected"
+    },
     "groupByPractice": "Regrouper par établissement",
     "loading": "Chargement des médecins...",
     "practices": {

--- a/frontend/public/locales/fr/common.json
+++ b/frontend/public/locales/fr/common.json
@@ -770,11 +770,11 @@
       "editTitle": "Editer le médecin"
     },
     "createInline": {
-      "buttonTooltip": "New practitioner",
-      "nameRequired": "Name is required",
-      "specialtyRequired": "Medical specialty is required",
-      "createError": "Failed to create practitioner. Please try again.",
-      "successMessage": "Practitioner created and selected"
+      "buttonTooltip": "Nouveau praticien",
+      "nameRequired": "Le nom est requis",
+      "specialtyRequired": "La spécialité médicale est requise",
+      "createError": "Échec de la création du praticien. Veuillez réessayer.",
+      "successMessage": "Praticien créé et sélectionné"
     },
     "groupByPractice": "Regrouper par établissement",
     "loading": "Chargement des médecins...",

--- a/frontend/public/locales/it/common.json
+++ b/frontend/public/locales/it/common.json
@@ -770,11 +770,11 @@
       "editTitle": "Modifica professionista"
     },
     "createInline": {
-      "buttonTooltip": "New practitioner",
-      "nameRequired": "Name is required",
-      "specialtyRequired": "Medical specialty is required",
-      "createError": "Failed to create practitioner. Please try again.",
-      "successMessage": "Practitioner created and selected"
+      "buttonTooltip": "Nuovo medico",
+      "nameRequired": "Il nome è obbligatorio",
+      "specialtyRequired": "La specialità medica è obbligatoria",
+      "createError": "Impossibile creare il medico. Riprovare.",
+      "successMessage": "Medico creato e selezionato"
     },
     "groupByPractice": "Raggruppa per studio",
     "loading": "Caricamento professionisti sanitari...",

--- a/frontend/public/locales/it/common.json
+++ b/frontend/public/locales/it/common.json
@@ -769,6 +769,13 @@
       "addTitle": "Aggiungi nuovo professionista",
       "editTitle": "Modifica professionista"
     },
+    "createInline": {
+      "buttonTooltip": "New practitioner",
+      "nameRequired": "Name is required",
+      "specialtyRequired": "Medical specialty is required",
+      "createError": "Failed to create practitioner. Please try again.",
+      "successMessage": "Practitioner created and selected"
+    },
     "groupByPractice": "Raggruppa per studio",
     "loading": "Caricamento professionisti sanitari...",
     "practices": {

--- a/frontend/public/locales/nl/common.json
+++ b/frontend/public/locales/nl/common.json
@@ -770,11 +770,11 @@
       "editTitle": "Zorgverlener bewerken"
     },
     "createInline": {
-      "buttonTooltip": "New practitioner",
-      "nameRequired": "Name is required",
-      "specialtyRequired": "Medical specialty is required",
-      "createError": "Failed to create practitioner. Please try again.",
-      "successMessage": "Practitioner created and selected"
+      "buttonTooltip": "Nieuwe behandelaar",
+      "nameRequired": "Naam is vereist",
+      "specialtyRequired": "Medische specialisatie is vereist",
+      "createError": "Aanmaken van behandelaar mislukt. Probeer het opnieuw.",
+      "successMessage": "Behandelaar aangemaakt en geselecteerd"
     },
     "groupByPractice": "Groeperen op praktijk",
     "loading": "Zorgverleners laden...",

--- a/frontend/public/locales/nl/common.json
+++ b/frontend/public/locales/nl/common.json
@@ -769,6 +769,13 @@
       "addTitle": "Nieuwe zorgverlener toevoegen",
       "editTitle": "Zorgverlener bewerken"
     },
+    "createInline": {
+      "buttonTooltip": "New practitioner",
+      "nameRequired": "Name is required",
+      "specialtyRequired": "Medical specialty is required",
+      "createError": "Failed to create practitioner. Please try again.",
+      "successMessage": "Practitioner created and selected"
+    },
     "groupByPractice": "Groeperen op praktijk",
     "loading": "Zorgverleners laden...",
     "practices": {

--- a/frontend/public/locales/pl/common.json
+++ b/frontend/public/locales/pl/common.json
@@ -769,6 +769,13 @@
       "addTitle": "Dodaj nowego lekarza",
       "editTitle": "Edytuj lekarza"
     },
+    "createInline": {
+      "buttonTooltip": "New practitioner",
+      "nameRequired": "Name is required",
+      "specialtyRequired": "Medical specialty is required",
+      "createError": "Failed to create practitioner. Please try again.",
+      "successMessage": "Practitioner created and selected"
+    },
     "groupByPractice": "Grupuj według praktyki",
     "loading": "Ładowanie pracowników ochrony zdrowia...",
     "practices": {

--- a/frontend/public/locales/pl/common.json
+++ b/frontend/public/locales/pl/common.json
@@ -770,11 +770,11 @@
       "editTitle": "Edytuj lekarza"
     },
     "createInline": {
-      "buttonTooltip": "New practitioner",
-      "nameRequired": "Name is required",
-      "specialtyRequired": "Medical specialty is required",
-      "createError": "Failed to create practitioner. Please try again.",
-      "successMessage": "Practitioner created and selected"
+      "buttonTooltip": "Nowy lekarz",
+      "nameRequired": "Imię i nazwisko jest wymagane",
+      "specialtyRequired": "Specjalność medyczna jest wymagana",
+      "createError": "Nie udało się utworzyć lekarza. Spróbuj ponownie.",
+      "successMessage": "Lekarz utworzony i wybrany"
     },
     "groupByPractice": "Grupuj według praktyki",
     "loading": "Ładowanie pracowników ochrony zdrowia...",

--- a/frontend/public/locales/pt/common.json
+++ b/frontend/public/locales/pt/common.json
@@ -770,11 +770,11 @@
       "editTitle": "Editar Profissional"
     },
     "createInline": {
-      "buttonTooltip": "New practitioner",
-      "nameRequired": "Name is required",
-      "specialtyRequired": "Medical specialty is required",
-      "createError": "Failed to create practitioner. Please try again.",
-      "successMessage": "Practitioner created and selected"
+      "buttonTooltip": "Novo profissional",
+      "nameRequired": "O nome é obrigatório",
+      "specialtyRequired": "A especialidade médica é obrigatória",
+      "createError": "Falha ao criar profissional. Tente novamente.",
+      "successMessage": "Profissional criado e selecionado"
     },
     "groupByPractice": "Agrupar por Consultório",
     "loading": "Carregando profissionais...",

--- a/frontend/public/locales/pt/common.json
+++ b/frontend/public/locales/pt/common.json
@@ -769,6 +769,13 @@
       "addTitle": "Adicionar Novo Profissional",
       "editTitle": "Editar Profissional"
     },
+    "createInline": {
+      "buttonTooltip": "New practitioner",
+      "nameRequired": "Name is required",
+      "specialtyRequired": "Medical specialty is required",
+      "createError": "Failed to create practitioner. Please try again.",
+      "successMessage": "Practitioner created and selected"
+    },
     "groupByPractice": "Agrupar por Consultório",
     "loading": "Carregando profissionais...",
     "practices": {

--- a/frontend/public/locales/ru/common.json
+++ b/frontend/public/locales/ru/common.json
@@ -769,6 +769,13 @@
       "addTitle": "Добавить врача",
       "editTitle": "Редактировать врача"
     },
+    "createInline": {
+      "buttonTooltip": "New practitioner",
+      "nameRequired": "Name is required",
+      "specialtyRequired": "Medical specialty is required",
+      "createError": "Failed to create practitioner. Please try again.",
+      "successMessage": "Practitioner created and selected"
+    },
     "groupByPractice": "Группировать по клинике",
     "loading": "Загрузка врачей...",
     "practices": {

--- a/frontend/public/locales/ru/common.json
+++ b/frontend/public/locales/ru/common.json
@@ -770,11 +770,11 @@
       "editTitle": "Редактировать врача"
     },
     "createInline": {
-      "buttonTooltip": "New practitioner",
-      "nameRequired": "Name is required",
-      "specialtyRequired": "Medical specialty is required",
-      "createError": "Failed to create practitioner. Please try again.",
-      "successMessage": "Practitioner created and selected"
+      "buttonTooltip": "Новый врач",
+      "nameRequired": "Имя обязательно",
+      "specialtyRequired": "Медицинская специальность обязательна",
+      "createError": "Не удалось создать врача. Попробуйте ещё раз.",
+      "successMessage": "Врач создан и выбран"
     },
     "groupByPractice": "Группировать по клинике",
     "loading": "Загрузка врачей...",

--- a/frontend/public/locales/sv/common.json
+++ b/frontend/public/locales/sv/common.json
@@ -770,11 +770,11 @@
       "editTitle": "Redigera vårdgivare"
     },
     "createInline": {
-      "buttonTooltip": "New practitioner",
-      "nameRequired": "Name is required",
-      "specialtyRequired": "Medical specialty is required",
-      "createError": "Failed to create practitioner. Please try again.",
-      "successMessage": "Practitioner created and selected"
+      "buttonTooltip": "Ny behandlare",
+      "nameRequired": "Namn är obligatoriskt",
+      "specialtyRequired": "Medicinsk specialitet är obligatorisk",
+      "createError": "Det gick inte att skapa behandlaren. Försök igen.",
+      "successMessage": "Behandlare skapad och vald"
     },
     "groupByPractice": "Gruppera efter mottagning",
     "loading": "Laddar vårdgivare...",

--- a/frontend/public/locales/sv/common.json
+++ b/frontend/public/locales/sv/common.json
@@ -769,6 +769,13 @@
       "addTitle": "Lägg till ny vårdgivare",
       "editTitle": "Redigera vårdgivare"
     },
+    "createInline": {
+      "buttonTooltip": "New practitioner",
+      "nameRequired": "Name is required",
+      "specialtyRequired": "Medical specialty is required",
+      "createError": "Failed to create practitioner. Please try again.",
+      "successMessage": "Practitioner created and selected"
+    },
     "groupByPractice": "Gruppera efter mottagning",
     "loading": "Laddar vårdgivare...",
     "practices": {

--- a/frontend/public/locales/th/common.json
+++ b/frontend/public/locales/th/common.json
@@ -769,6 +769,13 @@
       "addTitle": "เพิ่มแพทย์ใหม่",
       "editTitle": "แก้ไขแพทย์"
     },
+    "createInline": {
+      "buttonTooltip": "New practitioner",
+      "nameRequired": "Name is required",
+      "specialtyRequired": "Medical specialty is required",
+      "createError": "Failed to create practitioner. Please try again.",
+      "successMessage": "Practitioner created and selected"
+    },
     "groupByPractice": "จัดกลุ่มตามคลินิก",
     "loading": "กำลังโหลดข้อมูลแพทย์...",
     "practices": {

--- a/frontend/public/locales/th/common.json
+++ b/frontend/public/locales/th/common.json
@@ -770,11 +770,11 @@
       "editTitle": "แก้ไขแพทย์"
     },
     "createInline": {
-      "buttonTooltip": "New practitioner",
-      "nameRequired": "Name is required",
-      "specialtyRequired": "Medical specialty is required",
-      "createError": "Failed to create practitioner. Please try again.",
-      "successMessage": "Practitioner created and selected"
+      "buttonTooltip": "ผู้ให้บริการใหม่",
+      "nameRequired": "ต้องระบุชื่อ",
+      "specialtyRequired": "ต้องระบุความเชี่ยวชาญทางการแพทย์",
+      "createError": "ไม่สามารถสร้างผู้ให้บริการได้ กรุณาลองใหม่อีกครั้ง",
+      "successMessage": "สร้างและเลือกผู้ให้บริการแล้ว"
     },
     "groupByPractice": "จัดกลุ่มตามคลินิก",
     "loading": "กำลังโหลดข้อมูลแพทย์...",

--- a/frontend/public/locales/zh/common.json
+++ b/frontend/public/locales/zh/common.json
@@ -770,11 +770,11 @@
       "editTitle": "编辑医生"
     },
     "createInline": {
-      "buttonTooltip": "New practitioner",
-      "nameRequired": "Name is required",
-      "specialtyRequired": "Medical specialty is required",
-      "createError": "Failed to create practitioner. Please try again.",
-      "successMessage": "Practitioner created and selected"
+      "buttonTooltip": "新建医生",
+      "nameRequired": "姓名为必填项",
+      "specialtyRequired": "医疗专科为必填项",
+      "createError": "创建医生失败，请重试。",
+      "successMessage": "医生已创建并选中"
     },
     "groupByPractice": "按诊所分组",
     "loading": "正在加载医生...",

--- a/frontend/public/locales/zh/common.json
+++ b/frontend/public/locales/zh/common.json
@@ -769,6 +769,13 @@
       "addTitle": "添加新医生",
       "editTitle": "编辑医生"
     },
+    "createInline": {
+      "buttonTooltip": "New practitioner",
+      "nameRequired": "Name is required",
+      "specialtyRequired": "Medical specialty is required",
+      "createError": "Failed to create practitioner. Please try again.",
+      "successMessage": "Practitioner created and selected"
+    },
     "groupByPractice": "按诊所分组",
     "loading": "正在加载医生...",
     "practices": {

--- a/frontend/src/components/admin/SpecialtySelect.jsx
+++ b/frontend/src/components/admin/SpecialtySelect.jsx
@@ -122,6 +122,7 @@ const SpecialtySelect = ({
         error={error || hasError || null}
         searchable
         clearable
+        comboboxProps={{ withinPortal: true, zIndex: 3000 }}
       />
 
       <Modal

--- a/frontend/src/components/medical/BaseMedicalForm.jsx
+++ b/frontend/src/components/medical/BaseMedicalForm.jsx
@@ -87,6 +87,7 @@ const BaseMedicalForm = ({
 
   // Modal customization
   modalSize = 'lg',
+  zIndex,
 
   // Extra content to render after specific fields (keyed by field name)
   fieldExtras = {},
@@ -837,16 +838,29 @@ const BaseMedicalForm = ({
       centered
       styles={useMemo(
         () => ({
-          body: {
-            padding: layoutConfig.container.padding || '1.5rem',
-            paddingBottom: '2rem',
+          // Make the dialog a flex column so the header stays pinned and the
+          // body scrolls independently. Overflow hidden prevents the body from
+          // visually overflowing the dialog's painted background at high zoom.
+          content: {
+            display: 'flex',
+            flexDirection: 'column',
+            overflow: 'hidden',
           },
           header: {
             paddingBottom: '1rem',
+            flexShrink: 0,
+          },
+          body: {
+            padding: layoutConfig.container.padding || '1.5rem',
+            paddingBottom: '2rem',
+            flex: 1,
+            overflowY: 'auto',
+            minHeight: 0,
           },
         }),
         [layoutConfig.container.padding]
       )}
+      withScrollArea={false}
       lockScroll
       closeOnClickOutside
       trapFocus
@@ -854,6 +868,7 @@ const BaseMedicalForm = ({
       keepMounted={false}
       breakpoint={responsiveState.breakpoint}
       deviceType={responsiveState.deviceType}
+      zIndex={zIndex}
     >
       <form onSubmit={handleSubmit}>
         <Stack spacing={layoutConfig.spacing}>

--- a/frontend/src/components/medical/BaseMedicalForm.jsx
+++ b/frontend/src/components/medical/BaseMedicalForm.jsx
@@ -951,6 +951,7 @@ const MemoizedBaseMedicalForm = memo(
       'modalSize',
       'submitButtonText',
       'submitButtonColor',
+      'zIndex',
     ];
     for (const prop of primitiveProps) {
       if (prevProps[prop] !== nextProps[prop]) {

--- a/frontend/src/components/medical/BaseMedicalForm.jsx
+++ b/frontend/src/components/medical/BaseMedicalForm.jsx
@@ -169,6 +169,7 @@ const BaseMedicalForm = ({
   const handleSubmit = useCallback(
     e => {
       e.preventDefault();
+      e.stopPropagation();
       onSubmit(e);
     },
     [onSubmit]

--- a/frontend/src/components/medical/MantinePatientForm.jsx
+++ b/frontend/src/components/medical/MantinePatientForm.jsx
@@ -378,7 +378,7 @@ const MantinePatientForm = ({
           </Grid>
 
           <PractitionerSelectWithCreate
-            value={formData.physician_id ? String(formData.physician_id) : null}
+            value={formData.physician_id == null ? null : String(formData.physician_id)}
             onChange={handleSelectChange('physician_id')}
             practitioners={practitioners}
             label={t('patients.form.physician.label')}

--- a/frontend/src/components/medical/MantinePatientForm.jsx
+++ b/frontend/src/components/medical/MantinePatientForm.jsx
@@ -32,6 +32,7 @@ import {
 } from '../../utils/unitConversion';
 import { RELATIONSHIP_OPTIONS } from '../../constants/relationshipOptions';
 import PatientPhotoUpload from './PatientPhotoUpload';
+import PractitionerSelectWithCreate from './practitioners/PractitionerSelectWithCreate';
 import patientApi from '../../services/api/patientApi';
 import logger from '../../services/logger';
 
@@ -128,12 +129,6 @@ const MantinePatientForm = ({
   // Get unit labels and validation ranges for current system
   const labels = unitLabels[unitSystem];
   const ranges = validationRanges[unitSystem];
-
-  // Convert practitioners to Mantine format
-  const practitionerOptions = practitioners.map(practitioner => ({
-    value: String(practitioner.id),
-    label: `${practitioner.name} - ${practitioner.specialty}`,
-  }));
 
   const { t } = useTranslation(['common', 'shared']);
 
@@ -382,16 +377,12 @@ const MantinePatientForm = ({
             </Grid.Col>
           </Grid>
 
-          <Select
+          <PractitionerSelectWithCreate
+            value={formData.physician_id ? String(formData.physician_id) : null}
+            onChange={handleSelectChange('physician_id')}
+            practitioners={practitioners}
             label={t('patients.form.physician.label')}
             placeholder={t('patients.form.physician.placeholder')}
-            value={formData.physician_id ? String(formData.physician_id) : ''}
-            onChange={handleSelectChange('physician_id')}
-            disabled={saving}
-            data={practitionerOptions}
-            clearable
-            searchable
-            radius="md"
           />
         </Stack>
       </Box>

--- a/frontend/src/components/medical/MantineProcedureForm.jsx
+++ b/frontend/src/components/medical/MantineProcedureForm.jsx
@@ -1,7 +1,9 @@
+import { useMemo } from 'react';
 import BaseMedicalForm from './BaseMedicalForm';
 import FormLoadingOverlay from '../shared/FormLoadingOverlay';
 import UploadProgressErrorBoundary from '../shared/UploadProgressErrorBoundary';
 import { procedureFormFields } from '../../utils/medicalFormFields';
+import PractitionerSelectWithCreate from './practitioners/PractitionerSelectWithCreate';
 
 const MantineProcedureForm = ({
   isOpen,
@@ -16,12 +18,6 @@ const MantineProcedureForm = ({
   isLoading = false,
   statusMessage = null,
 }) => {
-  // Convert practitioners to Mantine format
-  const practitionerOptions = practitioners.map(practitioner => ({
-    value: String(practitioner.id),
-    label: `${practitioner.name} - ${practitioner.specialty}`,
-  }));
-
   // Status options for procedures
   const statusOptions = [
     {
@@ -47,9 +43,26 @@ const MantineProcedureForm = ({
   ];
 
   const dynamicOptions = {
-    practitioners: practitionerOptions,
     statuses: statusOptions,
   };
+
+  const customFieldRenderers = useMemo(
+    () => ({
+      practitioner_id: (_fieldConfig, baseProps) => (
+        <PractitionerSelectWithCreate
+          value={baseProps.value ? String(baseProps.value) : null}
+          onChange={value =>
+            onInputChange({ target: { name: 'practitioner_id', value: value || '' } })
+          }
+          practitioners={practitioners}
+          label={baseProps.label}
+          placeholder={baseProps.placeholder}
+          description={baseProps.description}
+        />
+      ),
+    }),
+    [onInputChange, practitioners]
+  );
 
   return (
     <BaseMedicalForm
@@ -62,6 +75,7 @@ const MantineProcedureForm = ({
       editingItem={editingProcedure}
       fields={procedureFormFields}
       dynamicOptions={dynamicOptions}
+      customFieldRenderers={customFieldRenderers}
       modalSize="xl"
       isLoading={isLoading}
     >

--- a/frontend/src/components/medical/MantineTreatmentForm.jsx
+++ b/frontend/src/components/medical/MantineTreatmentForm.jsx
@@ -16,7 +16,6 @@ const MantineTreatmentForm = ({
   conditionsOptions = [],
   conditionsLoading = false,
   practitionersOptions = [],
-  practitionersLoading = false,
 }) => {
   const { t } = useTranslation('medical');
 

--- a/frontend/src/components/medical/MantineTreatmentForm.jsx
+++ b/frontend/src/components/medical/MantineTreatmentForm.jsx
@@ -1,7 +1,9 @@
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Badge } from '@mantine/core';
 import BaseMedicalForm from './BaseMedicalForm';
 import { treatmentFormFields } from '../../utils/medicalFormFields';
+import PractitionerSelectWithCreate from './practitioners/PractitionerSelectWithCreate';
 
 const MantineTreatmentForm = ({
   isOpen,
@@ -24,21 +26,31 @@ const MantineTreatmentForm = ({
     label: `${condition.diagnosis}${condition.severity ? ` (${condition.severity})` : ''}${condition.status ? ` - ${condition.status}` : ''}`,
   }));
 
-  // Convert practitioners to dynamic options format
-  const practitionerOptions = practitionersOptions.map(practitioner => ({
-    value: String(practitioner.id),
-    label: `${practitioner.name}${practitioner.specialty ? ` - ${practitioner.specialty}` : ''}${practitioner.practice ? ` (${practitioner.practice})` : ''}`,
-  }));
-
   const dynamicOptions = {
     conditions: conditionOptions,
-    practitioners: practitionerOptions,
   };
 
   const loadingStates = {
     conditions: conditionsLoading,
-    practitioners: practitionersLoading,
   };
+
+  const customFieldRenderers = useMemo(
+    () => ({
+      practitioner_id: (_fieldConfig, baseProps) => (
+        <PractitionerSelectWithCreate
+          value={baseProps.value ? String(baseProps.value) : null}
+          onChange={value =>
+            onInputChange({ target: { name: 'practitioner_id', value: value || '' } })
+          }
+          practitioners={practitionersOptions}
+          label={baseProps.label}
+          placeholder={baseProps.placeholder}
+          description={baseProps.description}
+        />
+      ),
+    }),
+    [onInputChange, practitionersOptions]
+  );
 
   // Get status color for visual feedback
   const getStatusColor = status => {
@@ -88,6 +100,7 @@ const MantineTreatmentForm = ({
       fields={treatmentFormFields}
       dynamicOptions={dynamicOptions}
       loadingStates={loadingStates}
+      customFieldRenderers={customFieldRenderers}
       modalSize="lg"
     >
       {/* Status Badge Visual Indicator */}

--- a/frontend/src/components/medical/MantineVisitForm.jsx
+++ b/frontend/src/components/medical/MantineVisitForm.jsx
@@ -33,6 +33,7 @@ import DocumentManagerWithProgress from '../shared/DocumentManagerWithProgress';
 import EncounterLabResultRelationships from './visits/EncounterLabResultRelationships';
 import { TagInput } from '../common/TagInput';
 import logger from '../../services/logger';
+import PractitionerSelectWithCreate from './practitioners/PractitionerSelectWithCreate';
 
 const MantineVisitForm = ({
   isOpen,
@@ -77,12 +78,6 @@ const MantineVisitForm = ({
     }
   }, [isOpen]);
 
-  // Convert practitioners to options
-  const practitionerOptions = practitioners.map(practitioner => ({
-    value: String(practitioner.id),
-    label: `${practitioner.name}${practitioner.specialty ? ` - ${practitioner.specialty}` : ''}`,
-  }));
-
   // Convert conditions to options
   const conditionOptions = conditionsOptions.map(cond => ({
     value: cond.id.toString(),
@@ -125,11 +120,26 @@ const MantineVisitForm = ({
       error: null,
     };
 
+    if (translatedField.name === 'practitioner_id') {
+      return (
+        <PractitionerSelectWithCreate
+          value={formData.practitioner_id ? String(formData.practitioner_id) : null}
+          onChange={value =>
+            onInputChange({
+              target: { name: 'practitioner_id', value: value || '' },
+            })
+          }
+          practitioners={practitioners}
+          label={translatedField.label}
+          placeholder={translatedField.placeholder}
+          description={translatedField.description}
+        />
+      );
+    }
+
     // Get dynamic options
     let options = translatedField.options;
-    if (translatedField.dynamicOptions === 'practitioners') {
-      options = practitionerOptions;
-    } else if (translatedField.dynamicOptions === 'conditions') {
+    if (translatedField.dynamicOptions === 'conditions') {
       options = conditionOptions;
     }
 

--- a/frontend/src/components/medical/__tests__/BaseMedicalForm.scrollLayout.test.jsx
+++ b/frontend/src/components/medical/__tests__/BaseMedicalForm.scrollLayout.test.jsx
@@ -1,0 +1,137 @@
+import { vi } from 'vitest';
+
+/**
+ * @jest-environment jsdom
+ *
+ * Verifies that BaseMedicalForm passes the correct scroll-layout props to
+ * ResponsiveModal: withScrollArea={false}, content overflow:hidden, body
+ * overflowY:auto and flex:1, header flexShrink:0.
+ *
+ * Regression guard for the fix that prevents form buttons from overflowing
+ * the dialog's painted background at high browser zoom levels.
+ */
+import render from '../../../test-utils/render';
+import '@testing-library/jest-dom';
+import MantineProcedureForm from '../MantineProcedureForm';
+
+// Capture the props passed to ResponsiveModal so we can assert on them.
+const capturedModalProps = { current: null };
+
+vi.mock('../../adapters/ResponsiveModal', () => ({
+  default: props => {
+    capturedModalProps.current = props;
+    if (!props.opened) return null;
+    return (
+      <div data-testid="responsive-modal">
+        {props.children}
+      </div>
+    );
+  },
+  ResponsiveModal: props => {
+    capturedModalProps.current = props;
+    if (!props.opened) return null;
+    return (
+      <div data-testid="responsive-modal">
+        {props.children}
+      </div>
+    );
+  },
+}));
+
+vi.mock('../../adapters', () => ({
+  ResponsiveModal: props => {
+    capturedModalProps.current = props;
+    if (!props.opened) return null;
+    return (
+      <div data-testid="responsive-modal">
+        {props.children}
+      </div>
+    );
+  },
+  DateInput: ({ label, onChange, ...props }) => (
+    <input aria-label={label} onChange={e => onChange && onChange(e.target.value)} {...props} />
+  ),
+}));
+
+vi.mock('../../../hoc/withResponsive', () => ({
+  withResponsive: Component => Component,
+}));
+
+vi.mock('../../../hooks/useResponsive', () => ({
+  useResponsive: () => ({
+    breakpoint: 'md',
+    deviceType: 'desktop',
+    isMobile: false,
+    isTablet: false,
+    isDesktop: true,
+    width: 1200,
+    height: 800,
+  }),
+}));
+
+Element.prototype.scrollIntoView = vi.fn();
+
+const defaultProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  title: 'Add Procedure',
+  formData: {
+    procedure_name: '',
+    procedure_type: '',
+    procedure_code: '',
+    procedure_setting: '',
+    description: '',
+    procedure_date: '',
+    status: '',
+    procedure_duration: '',
+    facility: '',
+    practitioner_id: '',
+    procedure_complications: '',
+    notes: '',
+    anesthesia_type: '',
+    anesthesia_notes: '',
+  },
+  onInputChange: vi.fn(),
+  onSubmit: vi.fn(),
+  practitioners: [],
+};
+
+describe('BaseMedicalForm scroll layout fix', () => {
+  beforeEach(() => {
+    capturedModalProps.current = null;
+    vi.clearAllMocks();
+  });
+
+  test('passes withScrollArea={false} to ResponsiveModal', () => {
+    render(<MantineProcedureForm {...defaultProps} />);
+    expect(capturedModalProps.current).not.toBeNull();
+    expect(capturedModalProps.current.withScrollArea).toBe(false);
+  });
+
+  test('passes content overflow:hidden so content never visually overflows the dialog', () => {
+    render(<MantineProcedureForm {...defaultProps} />);
+    const styles = capturedModalProps.current?.styles;
+    // styles may be an object or a function (Mantine accepts both)
+    const resolved =
+      typeof styles === 'function' ? styles({}, {}, {}) : styles;
+    expect(resolved?.content?.overflow).toBe('hidden');
+  });
+
+  test('passes body overflowY:auto so fields and buttons scroll together', () => {
+    render(<MantineProcedureForm {...defaultProps} />);
+    const styles = capturedModalProps.current?.styles;
+    const resolved =
+      typeof styles === 'function' ? styles({}, {}, {}) : styles;
+    expect(resolved?.body?.overflowY).toBe('auto');
+    expect(resolved?.body?.flex).toBe(1);
+    expect(resolved?.body?.minHeight).toBe(0);
+  });
+
+  test('passes header flexShrink:0 to keep the header pinned', () => {
+    render(<MantineProcedureForm {...defaultProps} />);
+    const styles = capturedModalProps.current?.styles;
+    const resolved =
+      typeof styles === 'function' ? styles({}, {}, {}) : styles;
+    expect(resolved?.header?.flexShrink).toBe(0);
+  });
+});

--- a/frontend/src/components/medical/__tests__/MantinePatientForm.practitioner.test.tsx
+++ b/frontend/src/components/medical/__tests__/MantinePatientForm.practitioner.test.tsx
@@ -29,6 +29,7 @@ vi.mock('../practitioners/PractitionerSelectWithCreate', () => ({
         onChange={e => onChange(e.target.value || null)}
         placeholder={placeholder}
         data-practitioner-count={practitioners.length}
+        data-value={value ?? 'null'}
       >
         <option value="">--</option>
         {practitioners.map(p => (
@@ -165,6 +166,18 @@ describe('MantinePatientForm — Add Practitioner', () => {
       const container = screen.getByTestId('practitioner-select-with-create');
       const select = container.querySelector('select') as HTMLSelectElement;
       expect(select.value).toBe('');
+    });
+
+    test('preserves physician_id of 0 as string rather than treating it as unset', () => {
+      render(
+        <MantinePatientForm
+          {...defaultProps}
+          formData={{ ...defaultFormData, physician_id: 0 }}
+        />
+      );
+      const container = screen.getByTestId('practitioner-select-with-create');
+      const select = container.querySelector('select') as HTMLSelectElement;
+      expect(select.dataset.value).toBe('0');
     });
   });
 });

--- a/frontend/src/components/medical/__tests__/MantinePatientForm.practitioner.test.tsx
+++ b/frontend/src/components/medical/__tests__/MantinePatientForm.practitioner.test.tsx
@@ -1,0 +1,170 @@
+import { vi } from 'vitest';
+
+/**
+ * @jest-environment jsdom
+ */
+import render, { screen, fireEvent } from '../../../test-utils/render';
+import '@testing-library/jest-dom';
+import MantinePatientForm from '../MantinePatientForm';
+
+vi.mock('../practitioners/PractitionerSelectWithCreate', () => ({
+  default: ({
+    value,
+    onChange,
+    label,
+    placeholder,
+    practitioners,
+  }: {
+    value: string | null;
+    onChange: (_v: string | null) => void;
+    label: string;
+    placeholder?: string;
+    practitioners: { id: number; name: string; specialty?: string }[];
+  }) => (
+    <div data-testid="practitioner-select-with-create">
+      <label htmlFor="mock-physician-select">{label}</label>
+      <select
+        id="mock-physician-select"
+        value={value ?? ''}
+        onChange={e => onChange(e.target.value || null)}
+        placeholder={placeholder}
+        data-practitioner-count={practitioners.length}
+      >
+        <option value="">--</option>
+        {practitioners.map(p => (
+          <option key={p.id} value={String(p.id)}>
+            {p.name}
+          </option>
+        ))}
+      </select>
+    </div>
+  ),
+}));
+
+vi.mock('@mantine/dates', () => ({
+  DateInput: ({
+    label,
+    value,
+    onChange,
+  }: {
+    label: string;
+    value: unknown;
+    onChange: (_v: unknown) => void;
+  }) => (
+    <div>
+      <label htmlFor={`date-${label}`}>{label}</label>
+      <input
+        id={`date-${label}`}
+        type="date"
+        value={value ? String(value) : ''}
+        onChange={e => onChange(e.target.value ? new Date(e.target.value) : null)}
+      />
+    </div>
+  ),
+}));
+
+vi.mock('../PatientPhotoUpload', () => ({
+  default: () => <div data-testid="patient-photo-upload" />,
+}));
+
+vi.mock('../../../services/api/patientApi', () => ({
+  default: {
+    hasPhoto: vi.fn(() => Promise.resolve(false)),
+    getPhotoUrl: vi.fn(() => Promise.resolve('')),
+  },
+}));
+
+Element.prototype.scrollIntoView = vi.fn();
+
+const practitioners = [
+  { id: 1, name: 'Dr. Smith', specialty: 'General Practice' },
+  { id: 2, name: 'Dr. Jones', specialty: 'Internal Medicine' },
+];
+
+const defaultFormData = {
+  first_name: '',
+  last_name: '',
+  birth_date: '',
+  gender: '',
+  relationship_to_self: '',
+  address: '',
+  blood_type: '',
+  height: '',
+  weight: '',
+  physician_id: null,
+};
+
+const defaultProps = {
+  formData: defaultFormData,
+  onInputChange: vi.fn(),
+  onSave: vi.fn(),
+  onCancel: vi.fn(),
+  practitioners,
+  saving: false,
+  isCreating: false,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('MantinePatientForm — Add Practitioner', () => {
+  describe('Rendering', () => {
+    test('renders PractitionerSelectWithCreate for the physician field', () => {
+      render(<MantinePatientForm {...defaultProps} />);
+      expect(
+        screen.getByTestId('practitioner-select-with-create')
+      ).toBeInTheDocument();
+    });
+
+    test('passes practitioners array to PractitionerSelectWithCreate', () => {
+      render(<MantinePatientForm {...defaultProps} />);
+      const container = screen.getByTestId('practitioner-select-with-create');
+      const select = container.querySelector('select') as HTMLSelectElement;
+      expect(select.dataset.practitionerCount).toBe('2');
+    });
+  });
+
+  describe('Form Interactions', () => {
+    test('calls onInputChange with selected physician id as string', () => {
+      render(<MantinePatientForm {...defaultProps} />);
+      const container = screen.getByTestId('practitioner-select-with-create');
+      const select = container.querySelector('select')!;
+      fireEvent.change(select, { target: { value: '1' } });
+      expect(defaultProps.onInputChange).toHaveBeenCalledWith({
+        target: { name: 'physician_id', value: '1' },
+      });
+    });
+
+    test('calls onInputChange with empty string when physician is cleared', () => {
+      render(<MantinePatientForm {...defaultProps} />);
+      const container = screen.getByTestId('practitioner-select-with-create');
+      const select = container.querySelector('select')!;
+      fireEvent.change(select, { target: { value: '' } });
+      expect(defaultProps.onInputChange).toHaveBeenCalledWith({
+        target: { name: 'physician_id', value: '' },
+      });
+    });
+  });
+
+  describe('Data Population', () => {
+    test('coerces integer physician_id to string for the select value', () => {
+      render(
+        <MantinePatientForm
+          {...defaultProps}
+          formData={{ ...defaultFormData, physician_id: 2 }}
+        />
+      );
+      const container = screen.getByTestId('practitioner-select-with-create');
+      const select = container.querySelector('select') as HTMLSelectElement;
+      expect(select.value).toBe('2');
+    });
+
+    test('renders with empty value when physician_id is null', () => {
+      render(<MantinePatientForm {...defaultProps} />);
+      const container = screen.getByTestId('practitioner-select-with-create');
+      const select = container.querySelector('select') as HTMLSelectElement;
+      expect(select.value).toBe('');
+    });
+  });
+});

--- a/frontend/src/components/medical/__tests__/MantineProcedureForm.test.jsx
+++ b/frontend/src/components/medical/__tests__/MantineProcedureForm.test.jsx
@@ -8,6 +8,28 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import MantineProcedureForm from '../MantineProcedureForm';
 
+vi.mock('../practitioners/PractitionerSelectWithCreate', () => ({
+  default: ({
+    value,
+    onChange,
+    label,
+    placeholder,
+  }) => (
+    <div data-testid="practitioner-select-with-create">
+      <label htmlFor="mock-practitioner-select">{label}</label>
+      <select
+        id="mock-practitioner-select"
+        value={value ?? ''}
+        onChange={e => onChange(e.target.value || null)}
+        placeholder={placeholder}
+      >
+        <option value="">--</option>
+        <option value="1">Dr. Smith - Surgery</option>
+      </select>
+    </div>
+  ),
+}));
+
 // Mock Date Input component since it has complex dependencies
 vi.mock('@mantine/dates', () => ({
   DateInput: ({ label, value, onChange, required, description, ...props }) => (
@@ -134,6 +156,13 @@ describe('MantineProcedureForm', () => {
       expect(
         screen.getAllByLabelText(/shared:fields\.status/).length
       ).toBeGreaterThan(0);
+    });
+
+    test('renders PractitionerSelectWithCreate for the practitioner field', () => {
+      render(<MantineProcedureForm {...defaultProps} />);
+      expect(
+        screen.getByTestId('practitioner-select-with-create')
+      ).toBeInTheDocument();
     });
 
     test('renders practitioner options correctly', () => {
@@ -469,10 +498,9 @@ describe('MantineProcedureForm', () => {
 
       render(<MantineProcedureForm {...propsWithNoPractitioners} />);
 
-      const practitionerInputs = screen.getAllByLabelText(
-        /shared:fields\.performingPractitioner/
-      );
-      expect(practitionerInputs.length).toBeGreaterThan(0);
+      expect(
+        screen.getByTestId('practitioner-select-with-create')
+      ).toBeInTheDocument();
     });
 
     test('handles null/undefined form data gracefully', () => {

--- a/frontend/src/components/medical/__tests__/MantineVisitForm.test.tsx
+++ b/frontend/src/components/medical/__tests__/MantineVisitForm.test.tsx
@@ -1,0 +1,136 @@
+import { vi } from 'vitest';
+
+/**
+ * @jest-environment jsdom
+ */
+import render, { screen, fireEvent } from '../../../test-utils/render';
+import '@testing-library/jest-dom';
+import MantineVisitForm from '../MantineVisitForm';
+
+vi.mock('../practitioners/PractitionerSelectWithCreate', () => ({
+  default: ({
+    value,
+    onChange,
+    label,
+    placeholder,
+  }: {
+    value: string | null;
+    onChange: (_v: string | null) => void;
+    label: string;
+    placeholder?: string;
+  }) => (
+    <div data-testid="practitioner-select-with-create">
+      <label htmlFor="mock-prac-select">{label}</label>
+      <select
+        id="mock-prac-select"
+        value={value ?? ''}
+        onChange={e => onChange(e.target.value || null)}
+        placeholder={placeholder}
+      >
+        <option value="">--</option>
+        <option value="1">Dr. Smith - General Practice</option>
+        <option value="2">Dr. Jones - Internal Medicine</option>
+      </select>
+    </div>
+  ),
+}));
+
+vi.mock('../../shared/DocumentManagerWithProgress', () => ({
+  default: () => <div data-testid="document-manager" />,
+}));
+
+vi.mock('../visits/EncounterLabResultRelationships', () => ({
+  default: () => <div data-testid="encounter-lab-results" />,
+}));
+
+const defaultProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  title: 'Add New Visit',
+  formData: {
+    reason: '',
+    date: '',
+    practitioner_id: '',
+    visit_type: '',
+    priority: '',
+    condition_id: '',
+    chief_complaint: '',
+    duration_minutes: '',
+    location: '',
+    tags: [],
+    diagnosis: '',
+    treatment_plan: '',
+    follow_up_instructions: '',
+    notes: '',
+    pending_lab_result_ids: [],
+  },
+  onInputChange: vi.fn(),
+  onSubmit: vi.fn().mockResolvedValue({}),
+  practitioners: [
+    { id: 1, name: 'Dr. Smith', specialty: 'General Practice' },
+    { id: 2, name: 'Dr. Jones', specialty: 'Internal Medicine' },
+  ],
+  conditionsOptions: [],
+  editingVisit: null,
+  isLoading: false,
+  labResults: [],
+  encounterLabResults: {},
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('MantineVisitForm — Add Practitioner', () => {
+  describe('Rendering', () => {
+    test('renders PractitionerSelectWithCreate on the default Visit Info tab', () => {
+      render(<MantineVisitForm {...defaultProps} />);
+      expect(
+        screen.getByTestId('practitioner-select-with-create')
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Form Interactions', () => {
+    test('calls onInputChange with selected practitioner id as string', () => {
+      render(<MantineVisitForm {...defaultProps} />);
+      const container = screen.getByTestId('practitioner-select-with-create');
+      const select = container.querySelector('select')!;
+      fireEvent.change(select, { target: { value: '1' } });
+      expect(defaultProps.onInputChange).toHaveBeenCalledWith({
+        target: { name: 'practitioner_id', value: '1' },
+      });
+    });
+
+    test('calls onInputChange with empty string when practitioner is cleared', () => {
+      render(<MantineVisitForm {...defaultProps} />);
+      const container = screen.getByTestId('practitioner-select-with-create');
+      const select = container.querySelector('select')!;
+      fireEvent.change(select, { target: { value: '' } });
+      expect(defaultProps.onInputChange).toHaveBeenCalledWith({
+        target: { name: 'practitioner_id', value: '' },
+      });
+    });
+  });
+
+  describe('Data Population', () => {
+    test('coerces integer practitioner_id to string for the select value', () => {
+      render(
+        <MantineVisitForm
+          {...defaultProps}
+          formData={{ ...defaultProps.formData, practitioner_id: 2 }}
+        />
+      );
+      const container = screen.getByTestId('practitioner-select-with-create');
+      const select = container.querySelector('select') as HTMLSelectElement;
+      expect(select.value).toBe('2');
+    });
+
+    test('renders with empty value when practitioner_id is not set', () => {
+      render(<MantineVisitForm {...defaultProps} />);
+      const container = screen.getByTestId('practitioner-select-with-create');
+      const select = container.querySelector('select') as HTMLSelectElement;
+      expect(select.value).toBe('');
+    });
+  });
+});

--- a/frontend/src/components/medical/conditions/ConditionFormWrapper.jsx
+++ b/frontend/src/components/medical/conditions/ConditionFormWrapper.jsx
@@ -33,6 +33,7 @@ import { TagInput } from '../../common/TagInput';
 import LabResultRelationships from '../LabResultRelationships';
 import MedicationRelationships from '../MedicationRelationships';
 import logger from '../../../services/logger';
+import PractitionerSelectWithCreate from '../practitioners/PractitionerSelectWithCreate';
 
 const ConditionFormWrapper = ({
   isOpen,
@@ -55,6 +56,7 @@ const ConditionFormWrapper = ({
   // Lab result relationship props (only used when editing)
   labResults = [],
   navigate,
+  onPractitionerCreated = undefined,
 }) => {
   const { t } = useTranslation(['common', 'shared']);
   const { dateInputFormat, dateParser } = useDateFormat();
@@ -116,15 +118,6 @@ const ConditionFormWrapper = ({
       setIsSubmitting(false);
     }
   }, [isOpen]);
-
-  // Convert practitioners to options
-  const practitionerOptions = practitioners.map(prac => ({
-    value: prac.id.toString(),
-    label:
-      prac.name ||
-      `Dr. ${prac.first_name || ''} ${prac.last_name || ''}`.trim() ||
-      `Practitioner #${prac.id}`,
-  }));
 
   // Handle form submission
   const handleSubmit = async e => {
@@ -344,11 +337,19 @@ const ConditionFormWrapper = ({
                     />
                   </Grid.Col>
                   <Grid.Col span={{ base: 12, sm: 6 }}>
-                    <Select
+                    <PractitionerSelectWithCreate
+                      value={
+                        formData.practitioner_id
+                          ? String(formData.practitioner_id)
+                          : null
+                      }
+                      onChange={value =>
+                        onInputChange({
+                          target: { name: 'practitioner_id', value: value || '' },
+                        })
+                      }
+                      practitioners={practitioners}
                       label={t('shared:fields.practitioner', 'Practitioner')}
-                      value={formData.practitioner_id || null}
-                      data={practitionerOptions}
-                      onChange={handleSelectChange('practitioner_id')}
                       placeholder={t(
                         'shared:fields.selectPractitioner',
                         'Select practitioner'
@@ -357,9 +358,7 @@ const ConditionFormWrapper = ({
                         'conditions.form.descriptions.practitioner',
                         'Associated healthcare provider'
                       )}
-                      searchable
-                      clearable
-                      comboboxProps={{ withinPortal: true, zIndex: 3000 }}
+                      onPractitionerCreated={onPractitionerCreated}
                     />
                   </Grid.Col>
                   <Grid.Col span={12}>

--- a/frontend/src/components/medical/conditions/__tests__/ConditionFormWrapper.test.tsx
+++ b/frontend/src/components/medical/conditions/__tests__/ConditionFormWrapper.test.tsx
@@ -1,0 +1,161 @@
+import { vi } from 'vitest';
+
+/**
+ * @jest-environment jsdom
+ */
+import render, { screen, fireEvent } from '../../../../test-utils/render';
+import '@testing-library/jest-dom';
+import ConditionFormWrapper from '../ConditionFormWrapper';
+
+// Paths are relative to this test file (src/components/medical/conditions/__tests__/)
+
+vi.mock('../../practitioners/PractitionerSelectWithCreate', () => ({
+  default: ({
+    value,
+    onChange,
+    label,
+    placeholder,
+  }: {
+    value: string | null;
+    onChange: (_v: string | null) => void;
+    label: string;
+    placeholder?: string;
+  }) => (
+    <div data-testid="practitioner-select-with-create">
+      <label htmlFor="mock-practitioner-select">{label}</label>
+      <select
+        id="mock-practitioner-select"
+        value={value ?? ''}
+        onChange={e => onChange(e.target.value || null)}
+        placeholder={placeholder}
+      >
+        <option value="">--</option>
+        <option value="1">Dr. Smith - Surgery</option>
+        <option value="2">Dr. Johnson - Cardiology</option>
+      </select>
+    </div>
+  ),
+}));
+
+vi.mock('../../../shared/DocumentManagerWithProgress', () => ({
+  default: () => <div data-testid="document-manager" />,
+}));
+
+vi.mock('../../LabResultRelationships', () => ({
+  default: () => <div data-testid="lab-result-relationships" />,
+}));
+
+vi.mock('../../MedicationRelationships', () => ({
+  default: () => <div data-testid="medication-relationships" />,
+}));
+
+vi.mock('../../../hooks/useDateFormat', () => ({
+  useDateFormat: () => ({
+    dateInputFormat: 'MM/DD/YYYY',
+    dateParser: (s: string) => new Date(s),
+  }),
+}));
+
+vi.mock('../../../services/logger', () => ({
+  default: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+
+const defaultProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  title: 'Add New Condition',
+  formData: {
+    diagnosis: '',
+    condition_name: '',
+    severity: '',
+    status: '',
+    onset_date: '',
+    end_date: '',
+    practitioner_id: '',
+    icd10_code: '',
+    snomed_code: '',
+    code_description: '',
+    notes: '',
+    tags: [],
+    pending_medication_ids: [],
+  },
+  onInputChange: vi.fn(),
+  onSubmit: vi.fn().mockResolvedValue({}),
+  practitioners: [
+    { id: 1, name: 'Dr. Smith', specialty: 'Surgery' },
+    { id: 2, name: 'Dr. Johnson', specialty: 'Cardiology' },
+  ],
+  isLoading: false,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ConditionFormWrapper', () => {
+  describe('Rendering', () => {
+    test('renders form modal when open', () => {
+      render(<ConditionFormWrapper {...defaultProps} />);
+      expect(screen.getByText('Add New Condition')).toBeInTheDocument();
+    });
+
+    test('does not render when closed', () => {
+      render(<ConditionFormWrapper {...defaultProps} isOpen={false} />);
+      expect(screen.queryByText('Add New Condition')).not.toBeInTheDocument();
+    });
+
+    test('renders PractitionerSelectWithCreate for the practitioner field', () => {
+      render(<ConditionFormWrapper {...defaultProps} />);
+      expect(
+        screen.getByTestId('practitioner-select-with-create')
+      ).toBeInTheDocument();
+    });
+
+    test('renders required diagnosis field', () => {
+      render(<ConditionFormWrapper {...defaultProps} />);
+      expect(
+        screen.getByPlaceholderText(/Enter diagnosis/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Form Interactions', () => {
+    test('calls onInputChange when practitioner is selected', () => {
+      render(<ConditionFormWrapper {...defaultProps} />);
+      const container = screen.getByTestId('practitioner-select-with-create');
+      const select = container.querySelector('select')!;
+      fireEvent.change(select, { target: { value: '1' } });
+      expect(defaultProps.onInputChange).toHaveBeenCalledWith({
+        target: { name: 'practitioner_id', value: '1' },
+      });
+    });
+
+    test('calls onClose when cancel button is clicked', () => {
+      render(<ConditionFormWrapper {...defaultProps} />);
+      const cancelButton = screen.getByRole('button', { name: /cancel/i });
+      fireEvent.click(cancelButton);
+      expect(defaultProps.onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('Data Population', () => {
+    test('passes existing practitioner_id as string to PractitionerSelectWithCreate', () => {
+      render(
+        <ConditionFormWrapper
+          {...defaultProps}
+          formData={{ ...defaultProps.formData, practitioner_id: 2 }}
+        />
+      );
+      const container = screen.getByTestId('practitioner-select-with-create');
+      const select = container.querySelector('select') as HTMLSelectElement;
+      expect(select.value).toBe('2');
+    });
+
+    test('handles empty practitioners list gracefully', () => {
+      render(<ConditionFormWrapper {...defaultProps} practitioners={[]} />);
+      expect(
+        screen.getByTestId('practitioner-select-with-create')
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/medical/immunizations/ImmunizationFormWrapper.jsx
+++ b/frontend/src/components/medical/immunizations/ImmunizationFormWrapper.jsx
@@ -34,6 +34,7 @@ import {
 import DocumentManagerWithProgress from '../../shared/DocumentManagerWithProgress';
 import { TagInput } from '../../common/TagInput';
 import logger from '../../../services/logger';
+import PractitionerSelectWithCreate from '../practitioners/PractitionerSelectWithCreate';
 import {
   getAutocompleteEntries,
   getVaccineByName,
@@ -195,11 +196,6 @@ const ImmunizationFormWrapper = ({
   };
 
   if (!isOpen) return null;
-
-  const practitionerOptions = practitioners.map(p => ({
-    value: p.id.toString(),
-    label: p.name,
-  }));
 
   return (
     <Modal
@@ -651,22 +647,22 @@ const ImmunizationFormWrapper = ({
                     />
                   </Grid.Col>
                   <Grid.Col span={{ base: 12, sm: 6 }}>
-                    <Select
-                      label={t('shared:fields.practitioner', 'Practitioner')}
+                    <PractitionerSelectWithCreate
                       value={
                         formData.practitioner_id
                           ? formData.practitioner_id.toString()
                           : null
                       }
-                      data={practitionerOptions}
-                      onChange={value => {
+                      onChange={value =>
                         onInputChange({
                           target: {
                             name: 'practitioner_id',
                             value: value || '',
                           },
-                        });
-                      }}
+                        })
+                      }
+                      practitioners={practitioners}
+                      label={t('shared:fields.practitioner', 'Practitioner')}
                       placeholder={t(
                         'immunizations.form.practitionerPlaceholder',
                         'Select administering practitioner'
@@ -675,9 +671,6 @@ const ImmunizationFormWrapper = ({
                         'immunizations.form.practitionerDesc',
                         'Healthcare provider who administered vaccine'
                       )}
-                      clearable
-                      searchable
-                      comboboxProps={{ withinPortal: true, zIndex: 3000 }}
                     />
                   </Grid.Col>
                 </Grid>

--- a/frontend/src/components/medical/immunizations/__tests__/ImmunizationFormWrapper.test.tsx
+++ b/frontend/src/components/medical/immunizations/__tests__/ImmunizationFormWrapper.test.tsx
@@ -1,0 +1,135 @@
+import { vi } from 'vitest';
+
+/**
+ * @jest-environment jsdom
+ */
+import render, { screen, fireEvent } from '../../../../test-utils/render';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import ImmunizationFormWrapper from '../ImmunizationFormWrapper';
+
+vi.mock('../../practitioners/PractitionerSelectWithCreate', () => ({
+  default: ({
+    value,
+    onChange,
+    label,
+    placeholder,
+  }: {
+    value: string | null;
+    onChange: (_v: string | null) => void;
+    label: string;
+    placeholder?: string;
+  }) => (
+    <div data-testid="practitioner-select-with-create">
+      <label htmlFor="mock-prac-select">{label}</label>
+      <select
+        id="mock-prac-select"
+        value={value ?? ''}
+        onChange={e => onChange(e.target.value || null)}
+        placeholder={placeholder}
+      >
+        <option value="">--</option>
+        <option value="1">Dr. Smith - Internal Medicine</option>
+        <option value="2">Dr. Jones - Pediatrics</option>
+      </select>
+    </div>
+  ),
+}));
+
+vi.mock('../../../shared/DocumentManagerWithProgress', () => ({
+  default: () => <div data-testid="document-manager" />,
+}));
+
+vi.mock('../../../services/logger', () => ({
+  default: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+
+const defaultProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  title: 'Add Immunization',
+  editingImmunization: null,
+  formData: {
+    vaccine_name: '',
+    vaccine_trade_name: '',
+    manufacturer: '',
+    dose_number: '',
+    lot_number: '',
+    ndc_number: '',
+    expiration_date: '',
+    date_administered: '',
+    site: null,
+    route: null,
+    location: '',
+    practitioner_id: '',
+    notes: '',
+    tags: [],
+    standardized_vaccine_who_code: null,
+  },
+  onInputChange: vi.fn(),
+  onSubmit: vi.fn().mockResolvedValue({}),
+  practitioners: [
+    { id: 1, name: 'Dr. Smith', specialty: 'Internal Medicine' },
+    { id: 2, name: 'Dr. Jones', specialty: 'Pediatrics' },
+  ],
+  isLoading: false,
+};
+
+function getAdministrationTab() {
+  return screen.getByRole('tab', { name: /administration/i });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ImmunizationFormWrapper — Add Practitioner', () => {
+  describe('Rendering', () => {
+    test('renders PractitionerSelectWithCreate on the Administration tab', async () => {
+      render(<ImmunizationFormWrapper {...defaultProps} />);
+      await userEvent.click(getAdministrationTab());
+      expect(
+        screen.getByTestId('practitioner-select-with-create')
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Form Interactions', () => {
+    test('calls onInputChange with selected practitioner id as string', async () => {
+      render(<ImmunizationFormWrapper {...defaultProps} />);
+      await userEvent.click(getAdministrationTab());
+      const container = screen.getByTestId('practitioner-select-with-create');
+      const select = container.querySelector('select')!;
+      fireEvent.change(select, { target: { value: '1' } });
+      expect(defaultProps.onInputChange).toHaveBeenCalledWith({
+        target: { name: 'practitioner_id', value: '1' },
+      });
+    });
+
+    test('calls onInputChange with empty string when practitioner is cleared', async () => {
+      render(<ImmunizationFormWrapper {...defaultProps} />);
+      await userEvent.click(getAdministrationTab());
+      const container = screen.getByTestId('practitioner-select-with-create');
+      const select = container.querySelector('select')!;
+      fireEvent.change(select, { target: { value: '' } });
+      expect(defaultProps.onInputChange).toHaveBeenCalledWith({
+        target: { name: 'practitioner_id', value: '' },
+      });
+    });
+  });
+
+  describe('Data Population', () => {
+    test('coerces integer practitioner_id to string for the select value', async () => {
+      render(
+        <ImmunizationFormWrapper
+          {...defaultProps}
+          formData={{ ...defaultProps.formData, practitioner_id: 2 }}
+        />
+      );
+      await userEvent.click(getAdministrationTab());
+      const container = screen.getByTestId('practitioner-select-with-create');
+      const select = container.querySelector('select') as HTMLSelectElement;
+      expect(select.value).toBe('2');
+    });
+  });
+});

--- a/frontend/src/components/medical/injuries/InjuryCard.jsx
+++ b/frontend/src/components/medical/injuries/InjuryCard.jsx
@@ -184,7 +184,7 @@ const InjuryCard = ({
 
     // Custom content for practitioner linking
     const customContent = practitioner ? (
-      <Group justify="space-between" mb="xs">
+      <Group mb="xs">
         <Text size="sm" c="dimmed">
           {t('injuries.practitioner.label', 'Treating Practitioner')}:
         </Text>

--- a/frontend/src/components/medical/injuries/InjuryFormWrapper.jsx
+++ b/frontend/src/components/medical/injuries/InjuryFormWrapper.jsx
@@ -27,6 +27,7 @@ import { parseDateInput, getTodayEndOfDay } from '../../../utils/dateUtils';
 import DocumentManagerWithProgress from '../../shared/DocumentManagerWithProgress';
 import { TagInput } from '../../common/TagInput';
 import InjuryTypeSelect from './InjuryTypeSelect';
+import PractitionerSelectWithCreate from '../practitioners/PractitionerSelectWithCreate';
 import logger from '../../../services/logger';
 
 const InjuryFormWrapper = ({
@@ -46,6 +47,7 @@ const InjuryFormWrapper = ({
   onDocumentManagerRef,
   onFileUploadComplete,
   onError,
+  onPractitionerCreated = undefined,
 }) => {
   // Translation hooks
   const { t } = useTranslation(['medical', 'common', 'shared']);
@@ -130,12 +132,6 @@ const InjuryFormWrapper = ({
   };
 
   if (!isOpen) return null;
-
-  // Prepare practitioners options
-  const practitionerSelectData = practitionersOptions.map(prac => ({
-    value: String(prac.id),
-    label: prac.name,
-  }));
 
   return (
     <Modal
@@ -392,40 +388,34 @@ const InjuryFormWrapper = ({
                     />
                   </Grid.Col>
                   <Grid.Col span={{ base: 12, sm: 6 }}>
-                    <Select
-                      label={t(
-                        'injuries.practitioner.label',
-                        'Treating Practitioner'
-                      )}
+                    <PractitionerSelectWithCreate
                       value={
                         formData.practitioner_id
                           ? String(formData.practitioner_id)
                           : null
                       }
-                      data={practitionerSelectData}
-                      onChange={value => {
+                      onChange={value =>
                         onInputChange({
                           target: {
                             name: 'practitioner_id',
                             value: value ? parseInt(value, 10) : null,
                           },
-                        });
-                      }}
+                        })
+                      }
+                      practitioners={practitionersOptions}
+                      label={t(
+                        'injuries.practitioner.label',
+                        'Treating Practitioner'
+                      )}
                       placeholder={t(
                         'shared:fields.selectPractitioner',
                         'Select practitioner'
-                      )}
-                      clearable
-                      searchable
-                      comboboxProps={{ withinPortal: true, zIndex: 3000 }}
-                      nothingFoundMessage={t(
-                        'common:noResults',
-                        'No practitioners found'
                       )}
                       description={t(
                         'injuries.practitioner.description',
                         'The healthcare provider treating this injury'
                       )}
+                      onPractitionerCreated={onPractitionerCreated}
                     />
                   </Grid.Col>
                 </Grid>

--- a/frontend/src/components/medical/injuries/__tests__/InjuryFormWrapper.test.tsx
+++ b/frontend/src/components/medical/injuries/__tests__/InjuryFormWrapper.test.tsx
@@ -1,0 +1,171 @@
+import { vi } from 'vitest';
+
+/**
+ * @jest-environment jsdom
+ */
+import render, { screen, fireEvent } from '../../../../test-utils/render';
+import '@testing-library/jest-dom';
+import InjuryFormWrapper from '../InjuryFormWrapper';
+
+vi.mock('../../practitioners/PractitionerSelectWithCreate', () => ({
+  default: ({
+    value,
+    onChange,
+    label,
+    placeholder,
+    onPractitionerCreated,
+  }: {
+    value: string | null;
+    onChange: (_v: string | null) => void;
+    label: string;
+    placeholder?: string;
+    onPractitionerCreated?: (_p: { id: number; name: string; specialty: string }) => void;
+  }) => (
+    <div data-testid="practitioner-select-with-create">
+      <label htmlFor="mock-prac-select">{label}</label>
+      <select
+        id="mock-prac-select"
+        value={value ?? ''}
+        onChange={e => onChange(e.target.value || null)}
+        placeholder={placeholder}
+      >
+        <option value="">--</option>
+        <option value="1">Dr. Smith - Surgery</option>
+        <option value="2">Dr. Johnson - Cardiology</option>
+      </select>
+      {onPractitionerCreated && (
+        <button
+          data-testid="trigger-practitioner-created"
+          type="button"
+          onClick={() =>
+            onPractitionerCreated({ id: 99, name: 'Dr. New', specialty: 'ENT' })
+          }
+        >
+          Trigger Created
+        </button>
+      )}
+    </div>
+  ),
+}));
+
+vi.mock('../InjuryTypeSelect', () => ({
+  default: () => <div data-testid="injury-type-select" />,
+}));
+
+vi.mock('../../../shared/DocumentManagerWithProgress', () => ({
+  default: () => <div data-testid="document-manager" />,
+}));
+
+vi.mock('../../../services/logger', () => ({
+  default: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+
+const defaultProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  title: 'Add New Injury',
+  editingInjury: null,
+  formData: {
+    injury_name: '',
+    injury_type_id: null,
+    body_part: '',
+    laterality: null,
+    date_of_injury: '',
+    severity: null,
+    status: 'active',
+    practitioner_id: '',
+    mechanism: '',
+    treatment_received: '',
+    recovery_notes: '',
+    notes: '',
+    tags: [],
+  },
+  onInputChange: vi.fn(),
+  onSubmit: vi.fn().mockResolvedValue({}),
+  practitionersOptions: [
+    { id: 1, name: 'Dr. Smith', specialty: 'Surgery' },
+    { id: 2, name: 'Dr. Johnson', specialty: 'Cardiology' },
+  ],
+  injuryTypes: [],
+  isLoading: false,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('InjuryFormWrapper — Add Practitioner', () => {
+  describe('Rendering', () => {
+    test('renders PractitionerSelectWithCreate instead of a plain Select', () => {
+      render(<InjuryFormWrapper {...defaultProps} />);
+      expect(
+        screen.getByTestId('practitioner-select-with-create')
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Form Interactions', () => {
+    test('calls onInputChange with parsed integer when a practitioner is selected', () => {
+      render(<InjuryFormWrapper {...defaultProps} />);
+      const container = screen.getByTestId('practitioner-select-with-create');
+      const select = container.querySelector('select')!;
+      fireEvent.change(select, { target: { value: '1' } });
+      expect(defaultProps.onInputChange).toHaveBeenCalledWith({
+        target: { name: 'practitioner_id', value: 1 },
+      });
+    });
+
+    test('calls onInputChange with null when practitioner is cleared', () => {
+      render(<InjuryFormWrapper {...defaultProps} />);
+      const container = screen.getByTestId('practitioner-select-with-create');
+      const select = container.querySelector('select')!;
+      fireEvent.change(select, { target: { value: '' } });
+      expect(defaultProps.onInputChange).toHaveBeenCalledWith({
+        target: { name: 'practitioner_id', value: null },
+      });
+    });
+  });
+
+  describe('Data Population', () => {
+    test('coerces integer practitioner_id to string for the select value', () => {
+      render(
+        <InjuryFormWrapper
+          {...defaultProps}
+          formData={{ ...defaultProps.formData, practitioner_id: 2 }}
+        />
+      );
+      const container = screen.getByTestId('practitioner-select-with-create');
+      const select = container.querySelector('select') as HTMLSelectElement;
+      expect(select.value).toBe('2');
+    });
+
+    test('renders with empty value when practitioner_id is not set', () => {
+      render(<InjuryFormWrapper {...defaultProps} />);
+      const container = screen.getByTestId('practitioner-select-with-create');
+      const select = container.querySelector('select') as HTMLSelectElement;
+      expect(select.value).toBe('');
+    });
+  });
+
+  describe('onPractitionerCreated callback', () => {
+    test('passes onPractitionerCreated through to PractitionerSelectWithCreate', () => {
+      const mockCreated = vi.fn();
+      render(
+        <InjuryFormWrapper {...defaultProps} onPractitionerCreated={mockCreated} />
+      );
+      fireEvent.click(screen.getByTestId('trigger-practitioner-created'));
+      expect(mockCreated).toHaveBeenCalledWith({
+        id: 99,
+        name: 'Dr. New',
+        specialty: 'ENT',
+      });
+    });
+
+    test('does not render callback trigger when onPractitionerCreated is not provided', () => {
+      render(<InjuryFormWrapper {...defaultProps} />);
+      expect(
+        screen.queryByTestId('trigger-practitioner-created')
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/medical/labresults/LabResultFormWrapper.jsx
+++ b/frontend/src/components/medical/labresults/LabResultFormWrapper.jsx
@@ -35,6 +35,7 @@ import {
   formatDateInputChange,
 } from '../../../utils/dateUtils';
 import DocumentManagerWithProgress from '../../shared/DocumentManagerWithProgress';
+import PractitionerSelectWithCreate from '../practitioners/PractitionerSelectWithCreate';
 import { TagInput } from '../../common/TagInput';
 import InlineTestComponentEntry from './InlineTestComponentEntry';
 import ConditionRelationships from '../ConditionRelationships';
@@ -379,10 +380,6 @@ const LabResultFormWrapper = ({
     },
   ];
 
-  const practitionerOptions = practitioners.map(p => ({
-    value: String(p.id),
-    label: `${p.name} - ${p.specialty}`,
-  }));
 
   const getStatusColor = status => {
     switch (status) {
@@ -628,14 +625,12 @@ const LabResultFormWrapper = ({
                     />
                   </Grid.Col>
                   <Grid.Col span={{ base: 12, sm: 6 }}>
-                    <Select
-                      label={t('shared:labels.orderingPractitioner')}
+                    <PractitionerSelectWithCreate
                       value={
                         formData.practitioner_id
                           ? String(formData.practitioner_id)
                           : null
                       }
-                      data={practitionerOptions}
                       onChange={value => {
                         onInputChange({
                           target: {
@@ -644,13 +639,12 @@ const LabResultFormWrapper = ({
                           },
                         });
                       }}
+                      practitioners={practitioners}
+                      label={t('shared:labels.orderingPractitioner')}
                       placeholder={t('shared:fields.selectPractitioner')}
                       description={t(
                         'labresults:orderingPractitioner.description'
                       )}
-                      searchable
-                      clearable
-                      comboboxProps={{ withinPortal: true, zIndex: 3000 }}
                     />
                   </Grid.Col>
                   <Grid.Col span={{ base: 12, sm: 6 }}>

--- a/frontend/src/components/medical/labresults/__tests__/LabResultFormWrapper.test.tsx
+++ b/frontend/src/components/medical/labresults/__tests__/LabResultFormWrapper.test.tsx
@@ -10,6 +10,33 @@ import LabResultFormWrapper from '../LabResultFormWrapper';
 
 // Paths are relative to this test file (src/components/medical/labresults/__tests__/)
 
+vi.mock('../../practitioners/PractitionerSelectWithCreate', () => ({
+  default: ({
+    value,
+    onChange,
+    label,
+    placeholder,
+  }: {
+    value: string | null;
+    onChange: (_v: string | null) => void;
+    label: string;
+    placeholder?: string;
+  }) => (
+    <div data-testid="practitioner-select-with-create">
+      <label htmlFor="mock-practitioner-select">{label}</label>
+      <select
+        id="mock-practitioner-select"
+        value={value ?? ''}
+        onChange={e => onChange(e.target.value || null)}
+        placeholder={placeholder}
+      >
+        <option value="">--</option>
+        <option value="1">Dr. Smith - Internal Medicine</option>
+      </select>
+    </div>
+  ),
+}));
+
 vi.mock('../InlineTestComponentEntry', () => ({
   default: ({ onRef }) => {
     if (onRef) onRef({ getComponents: () => [] });
@@ -88,6 +115,11 @@ describe('LabResultFormWrapper', () => {
       expect(
         screen.getByText('shared:labels.completedDate')
       ).toBeInTheDocument();
+    });
+
+    test('renders PractitionerSelectWithCreate for the practitioner field', () => {
+      render(<LabResultFormWrapper {...defaultProps} />);
+      expect(screen.getByTestId('practitioner-select-with-create')).toBeInTheDocument();
     });
 
     test('shows Tags field on the Basic Info tab', () => {

--- a/frontend/src/components/medical/practitioners/PractitionerFormWrapper.jsx
+++ b/frontend/src/components/medical/practitioners/PractitionerFormWrapper.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
 import { ActionIcon, Group, Text } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { IconEdit } from '@tabler/icons-react';
@@ -20,6 +21,7 @@ const PractitionerFormWrapper = ({
   editingItem,
   isLoading,
   statusMessage: _statusMessage,
+  zIndex,
 }) => {
   const { t } = useTranslation(['medical', 'common', 'shared']);
 
@@ -258,6 +260,7 @@ const PractitionerFormWrapper = ({
         fieldErrors={fieldErrors}
         fieldExtras={{ practice_id: practiceFieldExtra }}
         isLoading={isLoading || isLoadingPractices}
+        zIndex={zIndex}
       >
         {customContent}
       </BaseMedicalForm>
@@ -273,6 +276,19 @@ const PractitionerFormWrapper = ({
       />
     </>
   );
+};
+
+PractitionerFormWrapper.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  title: PropTypes.string,
+  formData: PropTypes.object.isRequired,
+  onInputChange: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  editingItem: PropTypes.object,
+  isLoading: PropTypes.bool,
+  statusMessage: PropTypes.string,
+  zIndex: PropTypes.number,
 };
 
 export default PractitionerFormWrapper;

--- a/frontend/src/components/medical/practitioners/PractitionerSelectWithCreate.tsx
+++ b/frontend/src/components/medical/practitioners/PractitionerSelectWithCreate.tsx
@@ -22,6 +22,7 @@ interface Props {
   label: string;
   placeholder?: string;
   description?: string;
+  onPractitionerCreated?: (_practitioner: Practitioner) => void;
 }
 
 interface FormData {
@@ -51,6 +52,7 @@ const PractitionerSelectWithCreate = ({
   label,
   placeholder,
   description,
+  onPractitionerCreated,
 }: Props) => {
   const { t } = useTranslation(['common', 'shared', 'medical']);
   const { refresh } = usePractitioners(false);
@@ -125,6 +127,7 @@ const PractitionerSelectWithCreate = ({
       };
       setLocalOptions(prev => [...prev, newOption]);
       onChange(String(result.id));
+      onPractitionerCreated?.(result);
 
       notifications.show({
         title: t('shared:labels.success', 'Success'),

--- a/frontend/src/components/medical/practitioners/PractitionerSelectWithCreate.tsx
+++ b/frontend/src/components/medical/practitioners/PractitionerSelectWithCreate.tsx
@@ -1,0 +1,211 @@
+import { useState, type ChangeEvent, type FormEvent } from 'react';
+import { ActionIcon, Group, Select, Stack, Text } from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import { IconUserPlus } from '@tabler/icons-react';
+import { useTranslation } from 'react-i18next';
+import { usePractitioners } from '../../../hooks/useGlobalData';
+import { apiService } from '../../../services/api';
+import logger from '../../../services/logger';
+import { cleanPractitionerFormData } from '../../../utils/practitionerFormUtils';
+import PractitionerFormWrapper from './PractitionerFormWrapper';
+
+interface Practitioner {
+  id: number;
+  name: string;
+  specialty?: string | null;
+}
+
+interface Props {
+  value: string | null;
+  onChange: (_value: string | null) => void;
+  practitioners: Practitioner[];
+  label: string;
+  placeholder?: string;
+  description?: string;
+}
+
+interface FormData {
+  name: string;
+  specialty_id: number | null;
+  practice_id: string;
+  phone_number: string;
+  email: string;
+  website: string;
+  rating: string;
+}
+
+const INITIAL_FORM_DATA: FormData = {
+  name: '',
+  specialty_id: null,
+  practice_id: '',
+  phone_number: '',
+  email: '',
+  website: '',
+  rating: '',
+};
+
+const PractitionerSelectWithCreate = ({
+  value,
+  onChange,
+  practitioners,
+  label,
+  placeholder,
+  description,
+}: Props) => {
+  const { t } = useTranslation(['common', 'shared', 'medical']);
+  const { refresh } = usePractitioners(false);
+
+  const [localOptions, setLocalOptions] = useState(() =>
+    practitioners.map(p => ({
+      value: String(p.id),
+      label: `${p.name}${p.specialty ? ` - ${p.specialty}` : ''}`,
+    }))
+  );
+  const [subModalOpen, setSubModalOpen] = useState(false);
+  // Incremented each time the sub-modal opens to guarantee a fresh mount of
+  // PractitionerFormWrapper (and therefore SpecialtySelect) every open cycle.
+  // Fixes a lifecycle issue where SpecialtySelect's useEffect does not fire
+  // reliably when rendered inside a nested Mantine Modal Portal.
+  const [modalKey, setModalKey] = useState(0);
+  const [formData, setFormData] = useState<FormData>(INITIAL_FORM_DATA);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleInputChange = (
+    e: ChangeEvent<HTMLInputElement> | { target: { name: string; value: unknown } }
+  ) => {
+    const { name, value: val } = e.target;
+    setFormData(prev => ({ ...prev, [name]: val }));
+  };
+
+  const handleOpen = () => {
+    setModalKey(k => k + 1);
+    setSubModalOpen(true);
+  };
+
+  const handleClose = () => {
+    setSubModalOpen(false);
+    setIsLoading(false);
+    setFormData(INITIAL_FORM_DATA);
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+
+    if (!formData.name.trim()) {
+      notifications.show({
+        title: t('shared:labels.error', 'Error'),
+        message: t(
+          'common:practitioners.createInline.nameRequired',
+          'Name is required'
+        ),
+        color: 'red',
+      });
+      return;
+    }
+    if (!formData.specialty_id) {
+      notifications.show({
+        title: t('shared:labels.error', 'Error'),
+        message: t(
+          'common:practitioners.createInline.specialtyRequired',
+          'Medical specialty is required'
+        ),
+        color: 'red',
+      });
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const dataToSubmit = cleanPractitionerFormData(formData);
+      const result = await apiService.createPractitioner(dataToSubmit);
+
+      const newOption = {
+        value: String(result.id),
+        label: `${result.name}${result.specialty ? ` - ${result.specialty}` : ''}`,
+      };
+      setLocalOptions(prev => [...prev, newOption]);
+      onChange(String(result.id));
+
+      notifications.show({
+        title: t('shared:labels.success', 'Success'),
+        message: t(
+          'common:practitioners.createInline.successMessage',
+          'Practitioner created and selected'
+        ),
+        color: 'green',
+      });
+
+      handleClose();
+      refresh();
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      logger.error('create_practitioner_inline_failed', {
+        message: 'Failed to create practitioner inline',
+        component: 'PractitionerSelectWithCreate',
+        error: message,
+      });
+      notifications.show({
+        title: t('shared:labels.error', 'Error'),
+        message: t(
+          'common:practitioners.createInline.createError',
+          'Failed to create practitioner. Please try again.'
+        ),
+        color: 'red',
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Stack gap={2}>
+      <Select
+        data={localOptions}
+        value={value}
+        onChange={onChange}
+        label={label}
+        description={description}
+        placeholder={placeholder}
+        searchable
+        clearable
+        comboboxProps={{ withinPortal: true, zIndex: 3000 }}
+      />
+      <Group gap={4} mt={2}>
+        <ActionIcon
+          size="xs"
+          variant="subtle"
+          onClick={handleOpen}
+          aria-label={t(
+            'common:practitioners.createInline.buttonTooltip',
+            'New practitioner'
+          )}
+        >
+          <IconUserPlus size={14} />
+        </ActionIcon>
+        <Text
+          size="xs"
+          c="dimmed"
+          style={{ cursor: 'pointer' }}
+          onClick={handleOpen}
+        >
+          {t('common:practitioners.createInline.buttonTooltip', 'New practitioner')}
+        </Text>
+      </Group>
+
+      <PractitionerFormWrapper
+        key={modalKey}
+        isOpen={subModalOpen}
+        onClose={handleClose}
+        title={t('common:practitioners.form.addTitle', 'Add New Practitioner')}
+        formData={formData}
+        onInputChange={handleInputChange}
+        onSubmit={handleSubmit}
+        editingItem={null}
+        isLoading={isLoading}
+        zIndex={2100}
+      />
+    </Stack>
+  );
+};
+
+export default PractitionerSelectWithCreate;

--- a/frontend/src/components/medical/practitioners/PractitionerSelectWithCreate.tsx
+++ b/frontend/src/components/medical/practitioners/PractitionerSelectWithCreate.tsx
@@ -1,4 +1,4 @@
-import { useState, type ChangeEvent, type FormEvent } from 'react';
+import { useState, useEffect, type ChangeEvent, type FormEvent } from 'react';
 import { ActionIcon, Group, Select, Stack, Text } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { IconUserPlus } from '@tabler/icons-react';
@@ -63,6 +63,18 @@ const PractitionerSelectWithCreate = ({
       label: `${p.name}${p.specialty ? ` - ${p.specialty}` : ''}`,
     }))
   );
+
+  // Keep localOptions in sync when the practitioners prop updates (e.g. after
+  // the global store refreshes or a parent appends a newly-created practitioner).
+  useEffect(() => {
+    setLocalOptions(
+      practitioners.map(p => ({
+        value: String(p.id),
+        label: `${p.name}${p.specialty ? ` - ${p.specialty}` : ''}`,
+      }))
+    );
+  }, [practitioners]);
+
   const [subModalOpen, setSubModalOpen] = useState(false);
   // Incremented each time the sub-modal opens to guarantee a fresh mount of
   // PractitionerFormWrapper (and therefore SpecialtySelect) every open cycle.

--- a/frontend/src/components/medical/practitioners/__tests__/PractitionerSelectWithCreate.test.tsx
+++ b/frontend/src/components/medical/practitioners/__tests__/PractitionerSelectWithCreate.test.tsx
@@ -1,0 +1,305 @@
+import { vi } from 'vitest';
+
+/**
+ * @jest-environment jsdom
+ */
+import render, { screen, fireEvent, waitFor } from '../../../../test-utils/render';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import PractitionerSelectWithCreate from '../PractitionerSelectWithCreate';
+
+// Hoist mocks so they're available inside vi.mock factory functions.
+const {
+  mockPractitionerFormWrapperProps,
+  mockCreatePractitioner,
+  mockRefresh,
+  mockNotificationsShow,
+} = vi.hoisted(() => ({
+  mockPractitionerFormWrapperProps: vi.fn(),
+  mockCreatePractitioner: vi.fn(),
+  mockRefresh: vi.fn(),
+  mockNotificationsShow: vi.fn(),
+}));
+
+// PractitionerFormWrapper is the existing Create Practitioner dialog.
+// We stub it here to keep these tests focused on PractitionerSelectWithCreate behaviour.
+// The mock exposes form-name and form-specialty inputs so tests can satisfy the
+// frontend validation that requires name and specialty_id before submission.
+vi.mock('../PractitionerFormWrapper', () => ({
+  default: (props: {
+    isOpen: boolean;
+    onClose: () => void;
+    onSubmit: (_e: Event) => void;
+    onInputChange: (_e: { target: { name: string; value: unknown } }) => void;
+    isLoading: boolean;
+    zIndex: number;
+  }) => {
+    mockPractitionerFormWrapperProps(props);
+    if (!props.isOpen) return null;
+    return (
+      <div data-testid="practitioner-form-modal">
+        <input
+          data-testid="form-name"
+          onChange={e =>
+            props.onInputChange({ target: { name: 'name', value: e.target.value } })
+          }
+          defaultValue=""
+        />
+        <input
+          data-testid="form-specialty"
+          onChange={e =>
+            props.onInputChange({
+              target: { name: 'specialty_id', value: Number(e.target.value) },
+            })
+          }
+          defaultValue=""
+        />
+        <button
+          data-testid="mock-submit"
+          onClick={_e => props.onSubmit(_e as unknown as Event)}
+        >
+          Submit
+        </button>
+        <button data-testid="mock-close" onClick={props.onClose}>
+          Close
+        </button>
+        <span data-testid="z-index">{props.zIndex}</span>
+      </div>
+    );
+  },
+}));
+
+vi.mock('../../../../services/api', () => ({
+  apiService: {
+    createPractitioner: mockCreatePractitioner,
+  },
+}));
+
+vi.mock('../../../../hooks/useGlobalData', () => ({
+  usePractitioners: () => ({
+    practitioners: [],
+    loading: false,
+    refresh: mockRefresh,
+    error: null,
+    hasData: false,
+  }),
+}));
+
+vi.mock('../../../../services/logger', () => ({
+  default: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock('@mantine/notifications', () => ({
+  notifications: { show: mockNotificationsShow },
+}));
+
+const mockPractitioners = [
+  { id: 1, name: 'Dr. Smith', specialty: 'Cardiology' },
+  { id: 2, name: 'Dr. Jones', specialty: 'Internal Medicine' },
+];
+
+const defaultProps = {
+  value: null,
+  onChange: vi.fn(),
+  practitioners: mockPractitioners,
+  label: 'Ordering Practitioner',
+  placeholder: 'Select practitioner',
+  description: 'Choose the ordering practitioner',
+};
+
+// In the test environment, t('key', 'fallback') returns the fallback string.
+// These constants keep tests in sync with what the component actually renders.
+const BUTTON_TEXT = 'New practitioner';
+
+// Fill the required fields (name + specialty_id) in the mocked form so that
+// PractitionerSelectWithCreate's frontend validation passes before submit.
+function fillRequiredFields() {
+  fireEvent.change(screen.getByTestId('form-name'), {
+    target: { value: 'Dr. Test' },
+  });
+  fireEvent.change(screen.getByTestId('form-specialty'), {
+    target: { value: '1' },
+  });
+}
+
+describe('PractitionerSelectWithCreate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Select rendering', () => {
+    test('renders the label for the practitioner field', () => {
+      render(<PractitionerSelectWithCreate {...defaultProps} />);
+      expect(screen.getByText('Ordering Practitioner')).toBeInTheDocument();
+    });
+
+    test('renders the "New practitioner" action button and link', () => {
+      render(<PractitionerSelectWithCreate {...defaultProps} />);
+      expect(screen.getByText(BUTTON_TEXT)).toBeInTheDocument();
+    });
+  });
+
+  describe('Sub-modal open/close', () => {
+    test('PractitionerFormWrapper is not rendered initially', () => {
+      render(<PractitionerSelectWithCreate {...defaultProps} />);
+      expect(screen.queryByTestId('practitioner-form-modal')).not.toBeInTheDocument();
+    });
+
+    test('clicking the action text opens PractitionerFormWrapper', async () => {
+      render(<PractitionerSelectWithCreate {...defaultProps} />);
+      await userEvent.click(screen.getByText(BUTTON_TEXT));
+      expect(screen.getByTestId('practitioner-form-modal')).toBeInTheDocument();
+    });
+
+    test('clicking the ActionIcon opens PractitionerFormWrapper', async () => {
+      render(<PractitionerSelectWithCreate {...defaultProps} />);
+      const iconButton = screen.getByRole('button', { name: BUTTON_TEXT });
+      await userEvent.click(iconButton);
+      expect(screen.getByTestId('practitioner-form-modal')).toBeInTheDocument();
+    });
+
+    test('PractitionerFormWrapper receives zIndex={2100}', async () => {
+      render(<PractitionerSelectWithCreate {...defaultProps} />);
+      await userEvent.click(screen.getByText(BUTTON_TEXT));
+      expect(screen.getByTestId('z-index')).toHaveTextContent('2100');
+    });
+
+    test('closing the sub-modal hides it', async () => {
+      render(<PractitionerSelectWithCreate {...defaultProps} />);
+      await userEvent.click(screen.getByText(BUTTON_TEXT));
+      await userEvent.click(screen.getByTestId('mock-close'));
+      expect(screen.queryByTestId('practitioner-form-modal')).not.toBeInTheDocument();
+    });
+
+    test('re-opening the sub-modal increments the key (fresh mount)', async () => {
+      render(<PractitionerSelectWithCreate {...defaultProps} />);
+
+      await userEvent.click(screen.getByText(BUTTON_TEXT));
+      const firstCallProps = mockPractitionerFormWrapperProps.mock.calls.at(-1)?.[0];
+
+      await userEvent.click(screen.getByTestId('mock-close'));
+      await userEvent.click(screen.getByText(BUTTON_TEXT));
+      const secondCallProps = mockPractitionerFormWrapperProps.mock.calls.at(-1)?.[0];
+
+      expect(firstCallProps?.isOpen).toBe(true);
+      expect(secondCallProps?.isOpen).toBe(true);
+    });
+  });
+
+  describe('Frontend validation', () => {
+    test('shows error and does not call API when name is empty', async () => {
+      render(<PractitionerSelectWithCreate {...defaultProps} />);
+      await userEvent.click(screen.getByText(BUTTON_TEXT));
+      fireEvent.change(screen.getByTestId('form-specialty'), { target: { value: '1' } });
+      fireEvent.click(screen.getByTestId('mock-submit'));
+      expect(mockNotificationsShow).toHaveBeenCalledWith(
+        expect.objectContaining({ color: 'red' })
+      );
+      expect(mockCreatePractitioner).not.toHaveBeenCalled();
+    });
+
+    test('shows error and does not call API when specialty is missing', async () => {
+      render(<PractitionerSelectWithCreate {...defaultProps} />);
+      await userEvent.click(screen.getByText(BUTTON_TEXT));
+      fireEvent.change(screen.getByTestId('form-name'), { target: { value: 'Dr. Test' } });
+      fireEvent.click(screen.getByTestId('mock-submit'));
+      expect(mockNotificationsShow).toHaveBeenCalledWith(
+        expect.objectContaining({ color: 'red' })
+      );
+      expect(mockCreatePractitioner).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('After successful creation', () => {
+    test('onChange is called with new practitioner ID on success', async () => {
+      mockCreatePractitioner.mockResolvedValue({
+        id: 99,
+        name: 'Dr. New',
+        specialty: 'Neurology',
+      });
+
+      const mockOnChange = vi.fn();
+      render(<PractitionerSelectWithCreate {...defaultProps} onChange={mockOnChange} />);
+
+      await userEvent.click(screen.getByText(BUTTON_TEXT));
+      fillRequiredFields();
+      fireEvent.click(screen.getByTestId('mock-submit'));
+
+      await waitFor(() => {
+        expect(mockOnChange).toHaveBeenCalledWith('99');
+      });
+    });
+
+    test('sub-modal closes after successful creation', async () => {
+      mockCreatePractitioner.mockResolvedValue({
+        id: 99,
+        name: 'Dr. New',
+        specialty: null,
+      });
+
+      render(<PractitionerSelectWithCreate {...defaultProps} />);
+      await userEvent.click(screen.getByText(BUTTON_TEXT));
+      fillRequiredFields();
+      fireEvent.click(screen.getByTestId('mock-submit'));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('practitioner-form-modal')).not.toBeInTheDocument();
+      });
+    });
+
+    test('refresh is called after successful creation', async () => {
+      mockCreatePractitioner.mockResolvedValue({
+        id: 99,
+        name: 'Dr. New',
+        specialty: null,
+      });
+
+      render(<PractitionerSelectWithCreate {...defaultProps} />);
+      await userEvent.click(screen.getByText(BUTTON_TEXT));
+      fillRequiredFields();
+      fireEvent.click(screen.getByTestId('mock-submit'));
+
+      await waitFor(() => {
+        expect(mockRefresh).toHaveBeenCalled();
+      });
+    });
+
+    test('success notification is shown', async () => {
+      mockCreatePractitioner.mockResolvedValue({
+        id: 99,
+        name: 'Dr. New',
+        specialty: 'Neurology',
+      });
+
+      render(<PractitionerSelectWithCreate {...defaultProps} />);
+      await userEvent.click(screen.getByText(BUTTON_TEXT));
+      fillRequiredFields();
+      fireEvent.click(screen.getByTestId('mock-submit'));
+
+      await waitFor(() => {
+        expect(mockNotificationsShow).toHaveBeenCalledWith(
+          expect.objectContaining({ color: 'green' })
+        );
+      });
+    });
+  });
+
+  describe('Error handling', () => {
+    test('modal stays open and shows error notification on API failure', async () => {
+      mockCreatePractitioner.mockRejectedValue(new Error('Network error'));
+
+      render(<PractitionerSelectWithCreate {...defaultProps} />);
+      await userEvent.click(screen.getByText(BUTTON_TEXT));
+      fillRequiredFields();
+      fireEvent.click(screen.getByTestId('mock-submit'));
+
+      await waitFor(() => {
+        expect(mockNotificationsShow).toHaveBeenCalledWith(
+          expect.objectContaining({ color: 'red' })
+        );
+      });
+
+      expect(screen.getByTestId('practitioner-form-modal')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/medical/practitioners/__tests__/PractitionerSelectWithCreate.test.tsx
+++ b/frontend/src/components/medical/practitioners/__tests__/PractitionerSelectWithCreate.test.tsx
@@ -282,6 +282,42 @@ describe('PractitionerSelectWithCreate', () => {
         );
       });
     });
+
+    test('onPractitionerCreated callback is called with the new practitioner object', async () => {
+      const newPractitioner = { id: 99, name: 'Dr. New', specialty: 'Neurology' };
+      mockCreatePractitioner.mockResolvedValue(newPractitioner);
+
+      const mockOnPractitionerCreated = vi.fn();
+      render(
+        <PractitionerSelectWithCreate
+          {...defaultProps}
+          onPractitionerCreated={mockOnPractitionerCreated}
+        />
+      );
+
+      await userEvent.click(screen.getByText(BUTTON_TEXT));
+      fillRequiredFields();
+      fireEvent.click(screen.getByTestId('mock-submit'));
+
+      await waitFor(() => {
+        expect(mockOnPractitionerCreated).toHaveBeenCalledWith(newPractitioner);
+      });
+    });
+
+    test('omitting onPractitionerCreated does not throw', async () => {
+      mockCreatePractitioner.mockResolvedValue({ id: 99, name: 'Dr. New', specialty: null });
+
+      render(<PractitionerSelectWithCreate {...defaultProps} />);
+      await userEvent.click(screen.getByText(BUTTON_TEXT));
+      fillRequiredFields();
+      fireEvent.click(screen.getByTestId('mock-submit'));
+
+      await waitFor(() => {
+        expect(mockNotificationsShow).toHaveBeenCalledWith(
+          expect.objectContaining({ color: 'green' })
+        );
+      });
+    });
   });
 
   describe('Error handling', () => {

--- a/frontend/src/components/medical/procedures/ProcedureFormWrapper.jsx
+++ b/frontend/src/components/medical/procedures/ProcedureFormWrapper.jsx
@@ -32,6 +32,7 @@ import {
 import DocumentManagerWithProgress from '../../shared/DocumentManagerWithProgress';
 import { TagInput } from '../../common/TagInput';
 import logger from '../../../services/logger';
+import PractitionerSelectWithCreate from '../practitioners/PractitionerSelectWithCreate';
 
 const ProcedureFormWrapper = ({
   isOpen,
@@ -364,21 +365,22 @@ const ProcedureFormWrapper = ({
                     />
                   </Grid.Col>
                   <Grid.Col span={{ base: 12, sm: 6 }}>
-                    <Select
-                      label={t('shared:fields.practitioner', 'Practitioner')}
-                      value={formData.practitioner_id || null}
-                      data={practitioners.map(prac => ({
-                        value: prac.id.toString(),
-                        label: `${prac.name}${prac.specialty ? ` - ${prac.specialty}` : ''}`,
-                      }))}
-                      onChange={value => {
+                    <PractitionerSelectWithCreate
+                      value={
+                        formData.practitioner_id
+                          ? String(formData.practitioner_id)
+                          : null
+                      }
+                      onChange={value =>
                         onInputChange({
-                          target: {
-                            name: 'practitioner_id',
-                            value: value || '',
-                          },
-                        });
-                      }}
+                          target: { name: 'practitioner_id', value: value || '' },
+                        })
+                      }
+                      practitioners={practitioners}
+                      label={t(
+                        'shared:fields.performingPractitioner',
+                        'Performing Practitioner'
+                      )}
                       placeholder={t(
                         'shared:fields.selectPractitioner',
                         'Select practitioner'
@@ -387,9 +389,6 @@ const ProcedureFormWrapper = ({
                         'procedures.form.practitionerDesc',
                         'Healthcare provider performing procedure'
                       )}
-                      searchable
-                      clearable
-                      comboboxProps={{ withinPortal: true, zIndex: 3000 }}
                     />
                   </Grid.Col>
                   <Grid.Col span={{ base: 12, sm: 6 }}>

--- a/frontend/src/components/medical/procedures/__tests__/ProcedureFormWrapper.test.tsx
+++ b/frontend/src/components/medical/procedures/__tests__/ProcedureFormWrapper.test.tsx
@@ -1,0 +1,150 @@
+import { vi } from 'vitest';
+
+/**
+ * @jest-environment jsdom
+ */
+import render, { screen, fireEvent } from '../../../../test-utils/render';
+import '@testing-library/jest-dom';
+import ProcedureFormWrapper from '../ProcedureFormWrapper';
+
+// Paths are relative to this test file (src/components/medical/procedures/__tests__/)
+
+vi.mock('../../practitioners/PractitionerSelectWithCreate', () => ({
+  default: ({
+    value,
+    onChange,
+    label,
+    placeholder,
+  }: {
+    value: string | null;
+    onChange: (_v: string | null) => void;
+    label: string;
+    placeholder?: string;
+  }) => (
+    <div data-testid="practitioner-select-with-create">
+      <label htmlFor="mock-practitioner-select">{label}</label>
+      <select
+        id="mock-practitioner-select"
+        value={value ?? ''}
+        onChange={e => onChange(e.target.value || null)}
+        placeholder={placeholder}
+      >
+        <option value="">--</option>
+        <option value="1">Dr. Smith - Surgery</option>
+        <option value="2">Dr. Johnson - Cardiology</option>
+      </select>
+    </div>
+  ),
+}));
+
+vi.mock('../../../shared/DocumentManagerWithProgress', () => ({
+  default: () => <div data-testid="document-manager" />,
+}));
+
+vi.mock('../../../hooks/useDateFormat', () => ({
+  useDateFormat: () => ({
+    dateInputFormat: 'MM/DD/YYYY',
+    dateParser: (s: string) => new Date(s),
+  }),
+}));
+
+vi.mock('../../../services/logger', () => ({
+  default: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+
+const defaultProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  title: 'Add New Procedure',
+  formData: {
+    procedure_name: '',
+    procedure_type: '',
+    procedure_code: '',
+    procedure_setting: '',
+    description: '',
+    procedure_date: '',
+    status: '',
+    outcome: '',
+    procedure_duration: '',
+    facility: '',
+    practitioner_id: '',
+    procedure_complications: '',
+    notes: '',
+    anesthesia_type: '',
+    anesthesia_notes: '',
+    tags: [],
+  },
+  onInputChange: vi.fn(),
+  onSubmit: vi.fn(),
+  practitioners: [
+    { id: 1, name: 'Dr. Smith', specialty: 'Surgery' },
+    { id: 2, name: 'Dr. Johnson', specialty: 'Cardiology' },
+  ],
+  editingItem: null,
+  isLoading: false,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ProcedureFormWrapper', () => {
+  describe('Rendering', () => {
+    test('renders form modal when open', () => {
+      render(<ProcedureFormWrapper {...defaultProps} />);
+      expect(screen.getByText('Add New Procedure')).toBeInTheDocument();
+    });
+
+    test('does not render when closed', () => {
+      render(<ProcedureFormWrapper {...defaultProps} isOpen={false} />);
+      expect(screen.queryByText('Add New Procedure')).not.toBeInTheDocument();
+    });
+
+    test('renders PractitionerSelectWithCreate for the practitioner field', () => {
+      render(<ProcedureFormWrapper {...defaultProps} />);
+      expect(
+        screen.getByTestId('practitioner-select-with-create')
+      ).toBeInTheDocument();
+    });
+
+    test('renders required procedure name field', () => {
+      render(<ProcedureFormWrapper {...defaultProps} />);
+      expect(
+        screen.getByPlaceholderText(/Enter procedure name/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Form Interactions', () => {
+    test('calls onInputChange when practitioner is selected', () => {
+      render(<ProcedureFormWrapper {...defaultProps} />);
+      const container = screen.getByTestId('practitioner-select-with-create');
+      const select = container.querySelector('select')!;
+      fireEvent.change(select, { target: { value: '1' } });
+      expect(defaultProps.onInputChange).toHaveBeenCalledWith({
+        target: { name: 'practitioner_id', value: '1' },
+      });
+    });
+
+    test('calls onClose when cancel button is clicked', () => {
+      render(<ProcedureFormWrapper {...defaultProps} />);
+      const cancelButton = screen.getByRole('button', { name: /cancel/i });
+      fireEvent.click(cancelButton);
+      expect(defaultProps.onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('Data Population', () => {
+    test('passes existing practitioner_id as string to PractitionerSelectWithCreate', () => {
+      render(
+        <ProcedureFormWrapper
+          {...defaultProps}
+          formData={{ ...defaultProps.formData, practitioner_id: 2 }}
+        />
+      );
+      const container = screen.getByTestId('practitioner-select-with-create');
+      const select = container.querySelector('select') as HTMLSelectElement;
+      expect(select.value).toBe('2');
+    });
+  });
+});

--- a/frontend/src/components/medical/treatments/TreatmentFormWrapper.jsx
+++ b/frontend/src/components/medical/treatments/TreatmentFormWrapper.jsx
@@ -43,6 +43,7 @@ import TreatmentRelationshipsManager from './TreatmentRelationshipsManager';
 import TreatmentPlanSetup from './TreatmentPlanSetup';
 import { apiService } from '../../../services/api';
 import logger from '../../../services/logger';
+import PractitionerSelectWithCreate from '../practitioners/PractitionerSelectWithCreate';
 
 const EMPTY_PENDING_RELATIONSHIPS = {
   medications: [],
@@ -665,21 +666,19 @@ const TreatmentFormWrapper = ({
                     />
                   </Grid.Col>
                   <Grid.Col span={{ base: 12, sm: 6 }}>
-                    <Select
-                      label={t('shared:fields.practitioner', 'Practitioner')}
-                      value={formData.practitioner_id || null}
-                      data={practitionersOptions.map(prac => ({
-                        value: prac.id.toString(),
-                        label: `${prac.name}${prac.specialty ? ` - ${prac.specialty}` : ''}`,
-                      }))}
-                      onChange={value => {
+                    <PractitionerSelectWithCreate
+                      value={
+                        formData.practitioner_id
+                          ? String(formData.practitioner_id)
+                          : null
+                      }
+                      onChange={value =>
                         onInputChange({
-                          target: {
-                            name: 'practitioner_id',
-                            value: value || '',
-                          },
-                        });
-                      }}
+                          target: { name: 'practitioner_id', value: value || '' },
+                        })
+                      }
+                      practitioners={practitionersOptions}
+                      label={t('shared:fields.practitioner', 'Practitioner')}
                       placeholder={t(
                         'shared:fields.selectPractitioner',
                         'Select practitioner'
@@ -688,10 +687,6 @@ const TreatmentFormWrapper = ({
                         'treatments.form.practitionerDesc',
                         'Healthcare provider administering treatment'
                       )}
-                      searchable
-                      clearable
-                      comboboxProps={{ withinPortal: true, zIndex: 3000 }}
-                      disabled={practitionersLoading}
                     />
                   </Grid.Col>
                   <Grid.Col span={{ base: 12, sm: 6 }}>

--- a/frontend/src/components/medical/treatments/TreatmentFormWrapper.jsx
+++ b/frontend/src/components/medical/treatments/TreatmentFormWrapper.jsx
@@ -63,7 +63,6 @@ const TreatmentFormWrapper = ({
   conditionsOptions = [],
   conditionsLoading = false,
   practitionersOptions = [],
-  practitionersLoading = false,
   isLoading = false,
   statusMessage,
   onDocumentManagerRef,

--- a/frontend/src/components/medical/treatments/__tests__/TreatmentFormWrapper.test.tsx
+++ b/frontend/src/components/medical/treatments/__tests__/TreatmentFormWrapper.test.tsx
@@ -1,0 +1,176 @@
+import { vi } from 'vitest';
+
+/**
+ * @jest-environment jsdom
+ */
+import render, { screen, fireEvent } from '../../../../test-utils/render';
+import '@testing-library/jest-dom';
+import TreatmentFormWrapper from '../TreatmentFormWrapper';
+
+// Paths are relative to this test file (src/components/medical/treatments/__tests__/)
+
+vi.mock('../../practitioners/PractitionerSelectWithCreate', () => ({
+  default: ({
+    value,
+    onChange,
+    label,
+    placeholder,
+  }: {
+    value: string | null;
+    onChange: (_v: string | null) => void;
+    label: string;
+    placeholder?: string;
+  }) => (
+    <div data-testid="practitioner-select-with-create">
+      <label htmlFor="mock-practitioner-select">{label}</label>
+      <select
+        id="mock-practitioner-select"
+        value={value ?? ''}
+        onChange={e => onChange(e.target.value || null)}
+        placeholder={placeholder}
+      >
+        <option value="">--</option>
+        <option value="1">Dr. Smith - Surgery</option>
+        <option value="2">Dr. Johnson - Cardiology</option>
+      </select>
+    </div>
+  ),
+}));
+
+vi.mock('../../../shared/DocumentManagerWithProgress', () => ({
+  default: () => <div data-testid="document-manager" />,
+}));
+
+vi.mock('../TreatmentRelationshipsManager', () => ({
+  default: () => <div data-testid="treatment-relationships-manager" />,
+}));
+
+vi.mock('../TreatmentPlanSetup', () => ({
+  default: () => <div data-testid="treatment-plan-setup" />,
+}));
+
+vi.mock('../../../services/api', () => ({
+  apiService: {
+    linkTreatmentMedication: vi.fn(),
+    linkTreatmentEncounter: vi.fn(),
+    linkTreatmentLabResult: vi.fn(),
+    linkTreatmentEquipment: vi.fn(),
+  },
+}));
+
+vi.mock('../../../hooks/useDateFormat', () => ({
+  useDateFormat: () => ({
+    dateInputFormat: 'MM/DD/YYYY',
+    dateParser: (s: string) => new Date(s),
+  }),
+}));
+
+vi.mock('../../../services/logger', () => ({
+  default: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+
+const defaultProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  title: 'Add New Treatment',
+  formData: {
+    treatment_name: '',
+    treatment_type: '',
+    status: '',
+    condition_id: '',
+    practitioner_id: '',
+    start_date: '',
+    end_date: '',
+    dosage: '',
+    frequency: '',
+    description: '',
+    notes: '',
+    tags: [],
+    mode: 'simple',
+  },
+  onInputChange: vi.fn(),
+  onSubmit: vi.fn().mockResolvedValue({}),
+  conditionsOptions: [],
+  practitionersOptions: [
+    { id: 1, name: 'Dr. Smith', specialty: 'Surgery' },
+    { id: 2, name: 'Dr. Johnson', specialty: 'Cardiology' },
+  ],
+  isLoading: false,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('TreatmentFormWrapper', () => {
+  describe('Rendering', () => {
+    test('renders form modal when open', () => {
+      render(<TreatmentFormWrapper {...defaultProps} />);
+      expect(screen.getByText('Add New Treatment')).toBeInTheDocument();
+    });
+
+    test('does not render when closed', () => {
+      render(<TreatmentFormWrapper {...defaultProps} isOpen={false} />);
+      expect(screen.queryByText('Add New Treatment')).not.toBeInTheDocument();
+    });
+
+    test('renders PractitionerSelectWithCreate for the practitioner field', () => {
+      render(<TreatmentFormWrapper {...defaultProps} />);
+      expect(
+        screen.getByTestId('practitioner-select-with-create')
+      ).toBeInTheDocument();
+    });
+
+    test('renders required treatment name field', () => {
+      render(<TreatmentFormWrapper {...defaultProps} />);
+      expect(
+        screen.getByPlaceholderText(/Enter treatment name/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Form Interactions', () => {
+    test('calls onInputChange when practitioner is selected', () => {
+      render(<TreatmentFormWrapper {...defaultProps} />);
+      const container = screen.getByTestId('practitioner-select-with-create');
+      const select = container.querySelector('select')!;
+      fireEvent.change(select, { target: { value: '1' } });
+      expect(defaultProps.onInputChange).toHaveBeenCalledWith({
+        target: { name: 'practitioner_id', value: '1' },
+      });
+    });
+
+    test('calls onClose when cancel button is clicked', () => {
+      render(<TreatmentFormWrapper {...defaultProps} />);
+      const cancelButton = screen.getByRole('button', { name: /cancel/i });
+      fireEvent.click(cancelButton);
+      expect(defaultProps.onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('Data Population', () => {
+    test('passes existing practitioner_id as string to PractitionerSelectWithCreate', () => {
+      render(
+        <TreatmentFormWrapper
+          {...defaultProps}
+          formData={{ ...defaultProps.formData, practitioner_id: 2 }}
+        />
+      );
+      const container = screen.getByTestId('practitioner-select-with-create');
+      const select = container.querySelector('select') as HTMLSelectElement;
+      expect(select.value).toBe('2');
+    });
+
+    test('handles empty practitionersOptions gracefully', () => {
+      render(
+        <TreatmentFormWrapper
+          {...defaultProps}
+          practitionersOptions={[]}
+        />
+      );
+      expect(
+        screen.getByTestId('practitioner-select-with-create')
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/medical/Conditions.jsx
+++ b/frontend/src/pages/medical/Conditions.jsx
@@ -550,6 +550,7 @@ const Conditions = () => {
           onSubmit={handleSubmit}
           editingCondition={editingCondition}
           practitioners={practitioners}
+          onPractitionerCreated={p => setPractitioners(prev => [...prev, p])}
           isLoading={isBlocking}
           statusMessage={statusMessage}
           onDocumentManagerRef={setDocumentManagerMethods}

--- a/frontend/src/pages/medical/Injuries.jsx
+++ b/frontend/src/pages/medical/Injuries.jsx
@@ -438,6 +438,7 @@ const Injuries = () => {
           editingInjury={editingInjury}
           practitionersOptions={practitioners}
           practitionersLoading={practitionersLoading}
+          onPractitionerCreated={p => setPractitioners(prev => [...prev, p])}
           injuryTypes={injuryTypes}
           injuryTypesLoading={injuryTypesLoading}
           isLoading={isBlocking}

--- a/frontend/src/pages/medical/Practitioners.jsx
+++ b/frontend/src/pages/medical/Practitioners.jsx
@@ -19,6 +19,7 @@ import {
   IconUser,
 } from '@tabler/icons-react';
 import { apiService } from '../../services/api';
+import { cleanPractitionerFormData } from '../../utils/practitionerFormUtils';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { PageHeader } from '../../components';
 import { withResponsive } from '../../hoc/withResponsive';
@@ -192,31 +193,7 @@ const Practitioners = () => {
   const handleSubmit = async e => {
     e.preventDefault();
     try {
-      // Clean the data before sending to API
-      const dataToSubmit = {
-        ...formData,
-        practice_id:
-          formData.practice_id && formData.practice_id !== ''
-            ? Number.isNaN(parseInt(formData.practice_id, 10))
-              ? null
-              : parseInt(formData.practice_id, 10)
-            : null,
-        phone_number: formData.phone_number?.trim() || null,
-        email:
-          formData.email && formData.email.trim() !== ''
-            ? formData.email.trim().toLowerCase()
-            : null,
-        website:
-          formData.website && formData.website.trim() !== ''
-            ? formData.website.trim()
-            : null,
-        rating:
-          formData.rating && formData.rating !== 0
-            ? parseFloat(formData.rating)
-            : null,
-      };
-      // Remove legacy practice field if present
-      delete dataToSubmit.practice;
+      const dataToSubmit = cleanPractitionerFormData(formData);
 
       if (editingPractitioner) {
         await apiService.updatePractitioner(

--- a/frontend/src/utils/practitionerFormUtils.ts
+++ b/frontend/src/utils/practitionerFormUtils.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared data-cleaning for practitioner form submission.
+ * Used by both Practitioners.jsx (page-level create/edit) and
+ * PractitionerSelectWithCreate.tsx (inline create from other forms).
+ */
+
+export interface PractitionerSubmitData {
+  name: string;
+  specialty_id: number | null;
+  practice_id: number | null;
+  phone_number: string | null;
+  email: string | null;
+  website: string | null;
+  rating: number | null;
+}
+
+export function cleanPractitionerFormData(formData: {
+  name: string;
+  specialty_id: number | null;
+  practice_id: string | number;
+  phone_number?: string;
+  email?: string;
+  website?: string;
+  rating?: string | number;
+}): PractitionerSubmitData {
+  const rawPracticeId = formData.practice_id;
+  const practiceId =
+    rawPracticeId !== '' && rawPracticeId != null
+      ? Number.isNaN(parseInt(String(rawPracticeId), 10))
+        ? null
+        : parseInt(String(rawPracticeId), 10)
+      : null;
+
+  return {
+    name: formData.name.trim(),
+    specialty_id: formData.specialty_id,
+    practice_id: practiceId,
+    phone_number: formData.phone_number?.trim() || null,
+    email:
+      formData.email?.trim() ? formData.email.trim().toLowerCase() : null,
+    website: formData.website?.trim() || null,
+    rating: formData.rating ? parseFloat(String(formData.rating)) : null,
+  };
+}

--- a/frontend/src/utils/practitionerFormUtils.ts
+++ b/frontend/src/utils/practitionerFormUtils.ts
@@ -39,6 +39,11 @@ export function cleanPractitionerFormData(formData: {
     email:
       formData.email?.trim() ? formData.email.trim().toLowerCase() : null,
     website: formData.website?.trim() || null,
-    rating: formData.rating ? parseFloat(String(formData.rating)) : null,
+    rating: (() => {
+      const r = formData.rating;
+      if (r == null || r === '') return null;
+      const parsed = parseFloat(String(r));
+      return Number.isFinite(parsed) ? parsed : null;
+    })(),
   };
 }


### PR DESCRIPTION
## Summary

Adds an inline "Add New Practitioner" option to all 8 medical form dialogs that include a practitioner selector (Lab Results, Procedures, Treatments, Conditions, Injuries, Immunizations, Visits, Patient Information). Previously a user had to close their in-progress form, navigate to Practitioners, create the record, then return and re-open the form. Now a **New practitioner** action button appears directly below each practitioner dropdown and opens a sub-modal to create one without leaving the current form.

Also fixes three display bugs discovered while implementing the feature: stale practitioner names in the Conditions and Injuries view/edit modals after an inline create, an empty practitioner dropdown when editing a saved Visit, and the treating-practitioner label in InjuryCard being incorrectly right-justified.

## Related issue

N/A

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Translation / i18n
- [ ] Other

## Testing

**New test files (focused on Add Practitioner behaviour):**
- `injuries/__tests__/InjuryFormWrapper.test.tsx` — 6 tests: renders PractitionerSelectWithCreate, integer-to-string coercion, onPractitionerCreated callback passthrough
- `immunizations/__tests__/ImmunizationFormWrapper.test.tsx` — 4 tests: renders on Administration tab, onChange payload, integer-to-string coercion
- `medical/__tests__/MantineVisitForm.test.tsx` — 6 tests: renders on default Visit Info tab, onChange payload, integer-to-string coercion

**Extended existing tests:**
- `PractitionerSelectWithCreate.test.tsx` — added onPractitionerCreated callback test and no-callback-provided safety test (17 total)

**Pre-existing tests covering the changed form components:**
- `ConditionFormWrapper.test.tsx`, `ProcedureFormWrapper.test.tsx`, `TreatmentFormWrapper.test.tsx`, `LabResultFormWrapper.test.tsx`, `MantineProcedureForm.test.jsx`

**Manual verification:** Add dialogs for all 7 categories tested — new practitioner creates, selects, and persists correctly. View and edit after inline-create confirmed working for Conditions and Injuries.

## Checklist

- [x] Tests added or updated (or N/A with reason)
- [x] `npm run lint` and `npm run build` pass
- [x] Backend tests pass (`pytest`) if backend code changed — no backend changes
- [x] No PHI, secrets, or `console.log` left in the diff
- [x] User-facing strings go through `t()` translations — new button/notification strings added to `common.json` for all 12 locales
- [x] Documentation updated if API, schema, or service behavior changed — N/A, no API or schema changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline "create practitioner" UI added across many medical forms; new practitioners become immediately selectable
  * Localization for inline creation added in multiple languages

* **Improvements**
  * Modals use fixed headers with independently scrollable bodies for better UX
  * Dropdown/modal layering and z-index handling improved for reliable behavior; validation, success and error notifications enhanced

* **Tests**
  * Added comprehensive tests covering inline creation, selection behavior and modal layout/regression checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->