### PR TITLE
fix: corrected migration file id overlap

### DIFF
--- a/alembic/migrations/versions/20260609_1000_b3f7c1d9e2a4_add_reminders_to_medications.py
+++ b/alembic/migrations/versions/20260609_1000_b3f7c1d9e2a4_add_reminders_to_medications.py
@@ -1,7 +1,7 @@
 """Add reminder_enabled and reminder_times columns to medications
 
-Revision ID: e8f9a0b1c2d3
-Revises: d7e8f9a0b1c2
+Revision ID: b3f7c1d9e2a4
+Revises: becc1fa4e5ab
 Create Date: 2026-06-09 10:00:00.000000
 
 Adds storage for per-medication reminder configuration so users can be notified
@@ -19,8 +19,8 @@ from alembic import op
 import sqlalchemy as sa
 
 
-revision = "e8f9a0b1c2d3"
-down_revision = "d7e8f9a0b1c2"
+revision = "b3f7c1d9e2a4"
+down_revision = "becc1fa4e5ab"
 branch_labels = None
 depends_on = None
 

--- a/tests/unit/test_medication_reminder_migration.py
+++ b/tests/unit/test_medication_reminder_migration.py
@@ -31,7 +31,7 @@ MIGRATION_FILE = (
     / "alembic"
     / "migrations"
     / "versions"
-    / "20260609_1000_e8f9a0b1c2d3_add_reminders_to_medications.py"
+    / "20260609_1000_b3f7c1d9e2a4_add_reminders_to_medications.py"
 )
 
 


### PR DESCRIPTION
This pull request updates the migration for adding medication reminders by renaming the migration file and updating its revision references to maintain correct Alembic migration history. The test code is also updated to reference the new migration filename.

Migration file and reference updates:

* Renamed the migration file from `20260609_1000_e8f9a0b1c2d3_add_reminders_to_medications.py` to `20260609_1000_b3f7c1d9e2a4_add_reminders_to_medications.py` and updated the `revision` and `down_revision` identifiers to preserve the correct migration order. [[1]](diffhunk://#diff-23ad7b52ae85c9dd2063d3d81d2452a673520ec2d9760a80ffc3a34e2ebe7cd7L3-R4) [[2]](diffhunk://#diff-23ad7b52ae85c9dd2063d3d81d2452a673520ec2d9760a80ffc3a34e2ebe7cd7L22-R23)
* Updated the test `test_medication_reminder_migration.py` to reference the new migration filename.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database migration chain versioning and related test configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->