### PR TITLE
feat: add migration for merging lab result textual_value and vaccine backfill heads

### DIFF
--- a/alembic/migrations/versions/20260706_1222_6516f72a9320_merge_lab_result_textual_value_and_.py
+++ b/alembic/migrations/versions/20260706_1222_6516f72a9320_merge_lab_result_textual_value_and_.py
@@ -1,0 +1,24 @@
+"""merge lab result textual_value and vaccine backfill heads
+
+Revision ID: 6516f72a9320
+Revises: d4e5f6a7b8c9, a5b6c7d8e9f0
+Create Date: 2026-07-06 12:22:26.817611
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '6516f72a9320'
+down_revision = ('d4e5f6a7b8c9', 'a5b6c7d8e9f0')
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
This pull request introduces a new Alembic migration script to merge two database migration heads, ensuring the migration history remains consistent and linear.

Database migrations:

* Added a new migration file `alembic/migrations/versions/20260706_1222_6516f72a9320_merge_lab_result_textual_value_and_.py` to merge the `lab result textual_value` and `vaccine backfill` migration heads, preventing branching in the migration history.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a database migration to merge two schema branches and keep the upgrade path aligned.
  * No user-facing behavior or data changes are included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->