### PR TITLE
fix: persist relationship_to_self and normalize gender values in patient management

### DIFF
--- a/alembic/migrations/versions/20260706_1247_255a32acfe39_backfill_legacy_patient_gender_values.py
+++ b/alembic/migrations/versions/20260706_1247_255a32acfe39_backfill_legacy_patient_gender_values.py
@@ -1,0 +1,61 @@
+"""backfill legacy patient gender values
+
+Revision ID: 255a32acfe39
+Revises: 6516f72a9320
+Create Date: 2026-07-06 12:47:19.333036
+
+Issue #913: the /patient-management PUT endpoint's gender validator
+normalizes submitted values to canonical short codes (M, F, OTHER, U), but
+the corresponding POST (create) endpoint had no such validator at all until
+this fix, so patients created before this fix may have full-word or
+non-canonical gender values (e.g. "Male", "Female", "Unknown", or the old
+frontend's "Prefer not to say" literal) stored as-is. Both frontend Select
+components only offer canonical M/F/OTHER/U values, so these legacy rows
+render as "no gender selected" when editing, and as "Not specified" in the
+read-only patient view. This is a one-time, idempotent normalization pass
+so existing patients display and edit correctly without requiring a re-save.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '255a32acfe39'
+down_revision = '6516f72a9320'
+branch_labels = None
+depends_on = None
+
+
+GENDER_BACKFILL_MAP = {
+    "MALE": "M",
+    "FEMALE": "F",
+    "UNKNOWN": "U",
+    "PREFER NOT TO SAY": "U",
+}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    total_updated = 0
+    for old_value, new_value in GENDER_BACKFILL_MAP.items():
+        result = bind.execute(
+            sa.text(
+                "UPDATE patients SET gender = :new_value "
+                "WHERE UPPER(gender) = :old_value"
+            ),
+            {"new_value": new_value, "old_value": old_value},
+        )
+        total_updated += result.rowcount or 0
+
+    print(
+        f"[patient gender backfill migration] Normalized {total_updated} "
+        f"patient row(s) with legacy gender values to canonical codes."
+    )
+
+
+def downgrade() -> None:
+    # Data-only migration. Left intentionally inert: the original full-word
+    # vs. abbreviation distinction carried no meaning worth preserving, and
+    # re-expanding "M" back to "Male" could incorrectly touch rows that were
+    # created with the canonical short code from the start.
+    pass

--- a/app/api/v1/endpoints/patient_management.py
+++ b/app/api/v1/endpoints/patient_management.py
@@ -59,6 +59,12 @@ class PatientCreateRequest(BaseModel):
         """Validate and normalize gender, consistent with PatientUpdateRequest."""
         return _validate_gender(v, allow_empty_string=True)
 
+    @field_validator("relationship_to_self")
+    @classmethod
+    def validate_relationship_to_self(cls, v):
+        """Convert empty string to None, consistent with PatientUpdateRequest."""
+        return None if v == "" else v
+
 
 class PatientUpdateRequest(BaseModel):
     """Request model for updating a patient"""

--- a/app/api/v1/endpoints/patient_management.py
+++ b/app/api/v1/endpoints/patient_management.py
@@ -20,6 +20,7 @@ from app.core.http.error_handling import (
 from app.core.logging.config import get_logger
 from app.core.logging.helpers import log_data_access, log_endpoint_access
 from app.models.models import Patient, User
+from app.schemas.validators import validate_gender as _validate_gender
 from app.services.patient_access import PatientAccessService
 from app.services.patient_management import PatientManagementService
 
@@ -46,6 +47,17 @@ class PatientCreateRequest(BaseModel):
     is_self_record: bool = Field(
         False, description="Whether this is the user's own medical record"
     )
+    relationship_to_self: Optional[str] = Field(
+        None,
+        max_length=30,
+        description="Relationship of this record to the account owner (e.g. self, spouse, child)",
+    )
+
+    @field_validator("gender")
+    @classmethod
+    def validate_gender(cls, v):
+        """Validate and normalize gender, consistent with PatientUpdateRequest."""
+        return _validate_gender(v, allow_empty_string=True)
 
 
 class PatientUpdateRequest(BaseModel):
@@ -66,6 +78,7 @@ class PatientUpdateRequest(BaseModel):
     physician_id: Optional[int] = Field(
         None, gt=0, description="Primary care physician ID"
     )
+    relationship_to_self: Optional[str] = Field(None, max_length=30)
 
     @model_validator(mode="before")
     @classmethod
@@ -82,6 +95,7 @@ class PatientUpdateRequest(BaseModel):
                 "weight",
                 "address",
                 "physician_id",
+                "relationship_to_self",
             ]:
                 if field in values and values[field] == "":
                     values[field] = None
@@ -122,16 +136,8 @@ class PatientUpdateRequest(BaseModel):
     @field_validator("gender")
     @classmethod
     def validate_gender(cls, v):
-        """Validate gender"""
-        if v is not None and v.strip():
-            allowed = ["M", "F", "MALE", "FEMALE", "OTHER", "U", "UNKNOWN"]
-            gender_upper = v.upper()
-            if gender_upper not in allowed:
-                raise ValueError(f"Gender must be one of: {', '.join(allowed)}")
-            # Normalize common values
-            gender_map = {"MALE": "M", "FEMALE": "F", "UNKNOWN": "U"}
-            return gender_map.get(gender_upper, gender_upper)
-        return v
+        """Validate and normalize gender"""
+        return _validate_gender(v)
 
 
 class PatientResponse(BaseModel):

--- a/app/services/patient_management.py
+++ b/app/services/patient_management.py
@@ -197,6 +197,7 @@ class PatientManagementService:
             "weight",
             "address",
             "physician_id",
+            "relationship_to_self",
         ]
 
         for field, value in patient_data.items():

--- a/frontend/src/components/medical/MantinePatientForm.jsx
+++ b/frontend/src/components/medical/MantinePatientForm.jsx
@@ -31,6 +31,7 @@ import {
   convertForStorage,
 } from '../../utils/unitConversion';
 import { RELATIONSHIP_OPTIONS } from '../../constants/relationshipOptions';
+import { getGenderOptions } from '../../constants/genderOptions';
 import PatientPhotoUpload from './PatientPhotoUpload';
 import PractitionerSelectWithCreate from './practitioners/PractitionerSelectWithCreate';
 import patientApi from '../../services/api/patientApi';
@@ -248,11 +249,7 @@ const MantinePatientForm = ({
                 value={formData.gender}
                 onChange={handleSelectChange('gender')}
                 disabled={saving}
-                data={[
-                  { value: 'M', label: t('shared:fields.male') },
-                  { value: 'F', label: t('shared:fields.female') },
-                  { value: 'OTHER', label: t('shared:fields.other') },
-                ]}
+                data={getGenderOptions(t)}
                 clearable
                 radius="md"
               />

--- a/frontend/src/components/medical/PatientForm.jsx
+++ b/frontend/src/components/medical/PatientForm.jsx
@@ -40,6 +40,7 @@ import {
   convertForDisplay,
   convertForStorage,
 } from '../../utils/unitConversion';
+import { getGenderOptions } from '../../constants/genderOptions';
 
 /**
  * Parse a YYYY-MM-DD string as a local Date to avoid UTC timezone shift.
@@ -243,16 +244,7 @@ const PatientForm = ({
     { value: 'O-', label: 'O-' },
   ];
 
-  const genderOptions = [
-    { value: '', label: t('shared:fields.selectGender') },
-    { value: 'Male', label: t('shared:fields.male') },
-    { value: 'Female', label: t('shared:fields.female') },
-    { value: 'Other', label: t('shared:fields.other') },
-    {
-      value: 'Prefer not to say',
-      label: t('patients.form.gender.options.preferNotToSay'),
-    },
-  ];
+  const genderOptions = getGenderOptions(t);
 
   const relationshipOptions = [
     { value: '', label: t('patients.form.relationship.options.select') },

--- a/frontend/src/components/medical/__tests__/MantinePatientForm.translations.test.jsx
+++ b/frontend/src/components/medical/__tests__/MantinePatientForm.translations.test.jsx
@@ -3,7 +3,12 @@ import { vi } from 'vitest';
 /**
  * @jest-environment jsdom
  */
-import render, { screen, fireEvent, waitFor } from '../../../test-utils/render';
+import render, {
+  screen,
+  fireEvent,
+  waitFor,
+  within,
+} from '../../../test-utils/render';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import MantinePatientForm from '../MantinePatientForm';
@@ -94,9 +99,23 @@ describe('MantinePatientForm - Translations', () => {
     vi.clearAllMocks();
   });
 
-  // Helper for Select inputs (Mantine renders both input + listbox)
+  // Mantine's Select associates the same label with both the visible <input>
+  // and its (always-mounted, CSS-hidden-when-closed) options listbox <div>, and
+  // their relative order in getAllByLabelText's results is not guaranteed, so
+  // filter for the actual <input> rather than assuming index [0].
   function getSelectInput(labelRegex) {
-    return screen.getAllByLabelText(labelRegex)[0];
+    return screen
+      .getAllByLabelText(labelRegex)
+      .find(el => el.tagName === 'INPUT');
+  }
+
+  // Scope option queries to the specific Select's listbox: gender's "Other"
+  // option and RELATIONSHIP_OPTIONS' "Other" label both render the same text,
+  // and Mantine mounts all listboxes in the DOM regardless of open state.
+  function getListboxFor(input) {
+    return document.querySelector(
+      `[role="listbox"][aria-labelledby="${input.id}-label"]`
+    );
   }
 
   describe('English Translations', () => {
@@ -143,12 +162,15 @@ describe('MantinePatientForm - Translations', () => {
       await userEvent.click(genderInput);
 
       await waitFor(() => {
-        expect(screen.getByText('shared:fields.male')).toBeInTheDocument();
-        expect(screen.getByText('shared:fields.female')).toBeInTheDocument();
-        expect(screen.getByText('shared:fields.other')).toBeInTheDocument();
-        expect(
-          screen.getByText('patients.form.gender.options.preferNotToSay')
-        ).toBeInTheDocument();
+        // Gender options now pass a fallback default to t(), so the global
+        // test mock renders the fallback text rather than the raw i18n key.
+        // Scoped to the gender listbox since "Other" also appears as a plain
+        // RELATIONSHIP_OPTIONS label, and Mantine mounts all listboxes at once.
+        const listbox = within(getListboxFor(genderInput));
+        expect(listbox.getByText('Male')).toBeInTheDocument();
+        expect(listbox.getByText('Female')).toBeInTheDocument();
+        expect(listbox.getByText('Other')).toBeInTheDocument();
+        expect(listbox.getByText('Prefer not to say')).toBeInTheDocument();
       });
     });
 
@@ -215,7 +237,8 @@ describe('MantinePatientForm - Translations', () => {
       const genderInput = getSelectInput(/shared:fields\.gender/);
       await userEvent.click(genderInput);
 
-      const maleOption = await screen.findByText('shared:fields.male');
+      const genderListbox = within(getListboxFor(genderInput));
+      const maleOption = await genderListbox.findByText('Male');
       await userEvent.click(maleOption);
 
       expect(defaultProps.onInputChange).toHaveBeenCalledWith({
@@ -229,9 +252,9 @@ describe('MantinePatientForm - Translations', () => {
       const genderInput = getSelectInput(/shared:fields\.gender/);
       await userEvent.click(genderInput);
 
-      const preferNotToSayOption = await screen.findByText(
-        'patients.form.gender.options.preferNotToSay'
-      );
+      const genderListbox = within(getListboxFor(genderInput));
+      const preferNotToSayOption =
+        await genderListbox.findByText('Prefer not to say');
       await userEvent.click(preferNotToSayOption);
 
       expect(defaultProps.onInputChange).toHaveBeenCalledWith({

--- a/frontend/src/components/medical/__tests__/MantinePatientForm.translations.test.jsx
+++ b/frontend/src/components/medical/__tests__/MantinePatientForm.translations.test.jsx
@@ -146,6 +146,9 @@ describe('MantinePatientForm - Translations', () => {
         expect(screen.getByText('shared:fields.male')).toBeInTheDocument();
         expect(screen.getByText('shared:fields.female')).toBeInTheDocument();
         expect(screen.getByText('shared:fields.other')).toBeInTheDocument();
+        expect(
+          screen.getByText('patients.form.gender.options.preferNotToSay')
+        ).toBeInTheDocument();
       });
     });
 
@@ -217,6 +220,22 @@ describe('MantinePatientForm - Translations', () => {
 
       expect(defaultProps.onInputChange).toHaveBeenCalledWith({
         target: { name: 'gender', value: 'M' },
+      });
+    });
+
+    it('should handle gender select changes to prefer-not-to-say (U)', async () => {
+      render(<MantinePatientForm {...defaultProps} />);
+
+      const genderInput = getSelectInput(/shared:fields\.gender/);
+      await userEvent.click(genderInput);
+
+      const preferNotToSayOption = await screen.findByText(
+        'patients.form.gender.options.preferNotToSay'
+      );
+      await userEvent.click(preferNotToSayOption);
+
+      expect(defaultProps.onInputChange).toHaveBeenCalledWith({
+        target: { name: 'gender', value: 'U' },
       });
     });
 

--- a/frontend/src/components/medical/__tests__/PatientForm.test.jsx
+++ b/frontend/src/components/medical/__tests__/PatientForm.test.jsx
@@ -1,0 +1,197 @@
+import { vi } from 'vitest';
+
+/**
+ * @jest-environment jsdom
+ */
+import render, { screen, waitFor, within, cleanup } from '../../../test-utils/render';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import PatientForm from '../PatientForm';
+import patientApi from '../../../services/api/patientApi';
+
+// Explicit cleanup between tests: this file's Select instances re-generate
+// Mantine's auto ids (mantine-xxxxx) per test, and stale portal/listbox nodes
+// left over from a prior test's render can otherwise collide with the current
+// test's id-based queries.
+afterEach(cleanup);
+
+// Mock DateInput component (via @mantine/dates, same pattern as MantinePatientForm tests)
+vi.mock('@mantine/dates', () => ({
+  DateInput: ({ label, value, onChange, required, ...props }) => {
+    const {
+      firstDayOfWeek: _firstDayOfWeek,
+      maxDate: _maxDate,
+      minDate: _minDate,
+      popoverProps: _popoverProps,
+      valueFormat: _valueFormat,
+      dateParser: _dateParser,
+      ...domProps
+    } = props;
+    return (
+      <div>
+        <label htmlFor={`date-${label}`}>
+          {label}
+          {required && ' *'}
+        </label>
+        <input
+          id={`date-${label}`}
+          type="date"
+          value={
+            value
+              ? value instanceof Date
+                ? value.toISOString().split('T')[0]
+                : value
+              : ''
+          }
+          onChange={e =>
+            onChange(e.target.value ? new Date(e.target.value) : null)
+          }
+          {...domProps}
+        />
+      </div>
+    );
+  },
+}));
+
+vi.mock('../../../services/api/patientApi', () => ({
+  default: {
+    createPatient: vi.fn(),
+    updatePatient: vi.fn(),
+  },
+}));
+
+vi.mock('@mantine/notifications', () => ({
+  notifications: { show: vi.fn() },
+}));
+
+// Mock scrollIntoView for Mantine Select/Combobox
+Element.prototype.scrollIntoView = vi.fn();
+
+describe('PatientForm', () => {
+  const basePatient = {
+    id: 5,
+    first_name: 'John',
+    last_name: 'Doe',
+    birth_date: '1990-01-01',
+    gender: 'M',
+    relationship_to_self: 'child',
+    address: '',
+    blood_type: '',
+    height: null,
+    weight: null,
+    physician_id: null,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    patientApi.updatePatient.mockResolvedValue({
+      ...basePatient,
+      first_name: 'John',
+      last_name: 'Doe',
+    });
+    patientApi.createPatient.mockResolvedValue({
+      ...basePatient,
+      id: 6,
+    });
+  });
+
+  // Mantine's Select associates the same label with both the visible <input>
+  // and its (always-mounted, CSS-hidden-when-closed) options listbox <div>, and
+  // their relative order in getAllByLabelText's results is not guaranteed, so
+  // filter for the actual <input> rather than assuming index [0].
+  function getSelectInput(labelRegex) {
+    return screen
+      .getAllByLabelText(labelRegex)
+      .find(el => el.tagName === 'INPUT');
+  }
+
+  // Mantine's Select mounts its option listbox in the DOM at all times (visibility
+  // is CSS-driven, not conditional rendering), so queries must be scoped to the
+  // specific listbox via its `aria-labelledby` -> input `id` relationship. This also
+  // matters because PatientForm.jsx's gender and relationship option lists both use
+  // the shared `shared:fields.other` translation key for their "Other" entries.
+  function getListboxFor(input) {
+    return document.querySelector(
+      `[role="listbox"][aria-labelledby="${input.id}-label"]`
+    );
+  }
+
+  it('renders gender options using canonical backend values (M/F/OTHER/U)', () => {
+    render(<PatientForm onSuccess={vi.fn()} onCancel={vi.fn()} />);
+
+    const genderInput = getSelectInput(/shared:fields\.gender/);
+    const listbox = within(getListboxFor(genderInput));
+
+    expect(listbox.getByText('shared:fields.male')).toBeInTheDocument();
+    expect(listbox.getByText('shared:fields.female')).toBeInTheDocument();
+    expect(listbox.getByText('shared:fields.other')).toBeInTheDocument();
+    expect(
+      listbox.getByText('patients.form.gender.options.preferNotToSay')
+    ).toBeInTheDocument();
+  });
+
+  it('re-selects the correct gender option when editing a patient with gender "M"', () => {
+    render(
+      <PatientForm patient={basePatient} onSuccess={vi.fn()} onCancel={vi.fn()} />
+    );
+
+    // Mantine Select displays the label of the option matching the current value
+    expect(screen.getByDisplayValue('shared:fields.male')).toBeInTheDocument();
+  });
+
+  it('sends the canonical gender value on submit, not the label', async () => {
+    render(<PatientForm onSuccess={vi.fn()} onCancel={vi.fn()} />);
+
+    await userEvent.type(screen.getByLabelText(/shared:labels\.firstName/), 'Jane');
+    await userEvent.type(screen.getByLabelText(/shared:labels\.lastName/), 'Smith');
+
+    const dateInput = screen.getByLabelText(/patients\.form\.birthDate\.label/);
+    await userEvent.type(dateInput, '1990-01-15');
+
+    const genderInput = getSelectInput(/shared:fields\.gender/);
+    await userEvent.click(genderInput);
+    const genderListbox = within(getListboxFor(genderInput));
+    await userEvent.click(genderListbox.getByText('shared:fields.female'));
+
+    const submitButton = screen.getByText(
+      'patients.form.buttons.createPatient'
+    );
+    await userEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(patientApi.createPatient).toHaveBeenCalled();
+    });
+    const submittedData = patientApi.createPatient.mock.calls[0][0];
+    expect(submittedData.gender).toBe('F');
+  });
+
+  it('sends relationship_to_self on submit', async () => {
+    render(<PatientForm onSuccess={vi.fn()} onCancel={vi.fn()} />);
+
+    await userEvent.type(screen.getByLabelText(/shared:labels\.firstName/), 'Jane');
+    await userEvent.type(screen.getByLabelText(/shared:labels\.lastName/), 'Smith');
+
+    const dateInput = screen.getByLabelText(/patients\.form\.birthDate\.label/);
+    await userEvent.type(dateInput, '1990-01-15');
+
+    const relationshipInput = getSelectInput(
+      /patients\.form\.relationship\.label/
+    );
+    await userEvent.click(relationshipInput);
+    const relationshipListbox = within(getListboxFor(relationshipInput));
+    await userEvent.click(
+      relationshipListbox.getByText('patients.form.relationship.options.spouse')
+    );
+
+    const submitButton = screen.getByText(
+      'patients.form.buttons.createPatient'
+    );
+    await userEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(patientApi.createPatient).toHaveBeenCalled();
+    });
+    const submittedData = patientApi.createPatient.mock.calls[0][0];
+    expect(submittedData.relationship_to_self).toBe('spouse');
+  });
+});

--- a/frontend/src/components/medical/__tests__/PatientForm.test.jsx
+++ b/frontend/src/components/medical/__tests__/PatientForm.test.jsx
@@ -122,12 +122,12 @@ describe('PatientForm', () => {
     const genderInput = getSelectInput(/shared:fields\.gender/);
     const listbox = within(getListboxFor(genderInput));
 
-    expect(listbox.getByText('shared:fields.male')).toBeInTheDocument();
-    expect(listbox.getByText('shared:fields.female')).toBeInTheDocument();
-    expect(listbox.getByText('shared:fields.other')).toBeInTheDocument();
-    expect(
-      listbox.getByText('patients.form.gender.options.preferNotToSay')
-    ).toBeInTheDocument();
+    // Gender options pass a fallback default to t(), so the global test mock
+    // renders the fallback text rather than the raw i18n key.
+    expect(listbox.getByText('Male')).toBeInTheDocument();
+    expect(listbox.getByText('Female')).toBeInTheDocument();
+    expect(listbox.getByText('Other')).toBeInTheDocument();
+    expect(listbox.getByText('Prefer not to say')).toBeInTheDocument();
   });
 
   it('re-selects the correct gender option when editing a patient with gender "M"', () => {
@@ -136,7 +136,7 @@ describe('PatientForm', () => {
     );
 
     // Mantine Select displays the label of the option matching the current value
-    expect(screen.getByDisplayValue('shared:fields.male')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Male')).toBeInTheDocument();
   });
 
   it('sends the canonical gender value on submit, not the label', async () => {
@@ -151,7 +151,7 @@ describe('PatientForm', () => {
     const genderInput = getSelectInput(/shared:fields\.gender/);
     await userEvent.click(genderInput);
     const genderListbox = within(getListboxFor(genderInput));
-    await userEvent.click(genderListbox.getByText('shared:fields.female'));
+    await userEvent.click(genderListbox.getByText('Female'));
 
     const submitButton = screen.getByText(
       'patients.form.buttons.createPatient'

--- a/frontend/src/constants/__tests__/genderOptions.test.js
+++ b/frontend/src/constants/__tests__/genderOptions.test.js
@@ -17,4 +17,16 @@ describe('genderOptions', () => {
       expect(option.label).toBe(`translated:${GENDER_OPTIONS[index].labelKey}`);
     });
   });
+
+  it('passes each entry fallback string as the t() default value', () => {
+    const t = vi.fn((key, fallback) => fallback);
+    const options = getGenderOptions(t);
+
+    GENDER_OPTIONS.forEach(({ labelKey, fallback }) => {
+      expect(t).toHaveBeenCalledWith(labelKey, fallback);
+    });
+    options.forEach((option, index) => {
+      expect(option.label).toBe(GENDER_OPTIONS[index].fallback);
+    });
+  });
 });

--- a/frontend/src/constants/__tests__/genderOptions.test.js
+++ b/frontend/src/constants/__tests__/genderOptions.test.js
@@ -1,0 +1,20 @@
+import { vi } from 'vitest';
+import { GENDER_OPTIONS, getGenderOptions } from '../genderOptions';
+
+describe('genderOptions', () => {
+  it('defines canonical backend values matching validate_gender normalization', () => {
+    const values = GENDER_OPTIONS.map(option => option.value);
+    expect(values).toEqual(['', 'M', 'F', 'OTHER', 'U']);
+  });
+
+  it('maps every entry through the provided translation function', () => {
+    const t = vi.fn(key => `translated:${key}`);
+    const options = getGenderOptions(t);
+
+    expect(t).toHaveBeenCalledTimes(GENDER_OPTIONS.length);
+    options.forEach((option, index) => {
+      expect(option.value).toBe(GENDER_OPTIONS[index].value);
+      expect(option.label).toBe(`translated:${GENDER_OPTIONS[index].labelKey}`);
+    });
+  });
+});

--- a/frontend/src/constants/genderOptions.js
+++ b/frontend/src/constants/genderOptions.js
@@ -1,0 +1,25 @@
+/**
+ * Gender Options
+ *
+ * Canonical gender option values, matching the backend's normalized storage
+ * format (see app/schemas/validators.py validate_gender / GENDER_NORMALIZATION).
+ * Both patient forms must use these same values so a value saved by one form
+ * is correctly re-selected when read back by either form's Select.
+ */
+
+export const GENDER_OPTIONS = [
+  { value: '', labelKey: 'shared:fields.selectGender' },
+  { value: 'M', labelKey: 'shared:fields.male' },
+  { value: 'F', labelKey: 'shared:fields.female' },
+  { value: 'OTHER', labelKey: 'shared:fields.other' },
+  { value: 'U', labelKey: 'patients.form.gender.options.preferNotToSay' },
+];
+
+/**
+ * Build translated gender Select options.
+ *
+ * @param {Function} t - i18next translation function
+ * @returns {Array<{value: string, label: string}>}
+ */
+export const getGenderOptions = t =>
+  GENDER_OPTIONS.map(({ value, labelKey }) => ({ value, label: t(labelKey) }));

--- a/frontend/src/constants/genderOptions.js
+++ b/frontend/src/constants/genderOptions.js
@@ -8,11 +8,19 @@
  */
 
 export const GENDER_OPTIONS = [
-  { value: '', labelKey: 'shared:fields.selectGender' },
-  { value: 'M', labelKey: 'shared:fields.male' },
-  { value: 'F', labelKey: 'shared:fields.female' },
-  { value: 'OTHER', labelKey: 'shared:fields.other' },
-  { value: 'U', labelKey: 'patients.form.gender.options.preferNotToSay' },
+  {
+    value: '',
+    labelKey: 'shared:fields.selectGender',
+    fallback: 'Select gender',
+  },
+  { value: 'M', labelKey: 'shared:fields.male', fallback: 'Male' },
+  { value: 'F', labelKey: 'shared:fields.female', fallback: 'Female' },
+  { value: 'OTHER', labelKey: 'shared:fields.other', fallback: 'Other' },
+  {
+    value: 'U',
+    labelKey: 'patients.form.gender.options.preferNotToSay',
+    fallback: 'Prefer not to say',
+  },
 ];
 
 /**
@@ -22,4 +30,7 @@ export const GENDER_OPTIONS = [
  * @returns {Array<{value: string, label: string}>}
  */
 export const getGenderOptions = t =>
-  GENDER_OPTIONS.map(({ value, labelKey }) => ({ value, label: t(labelKey) }));
+  GENDER_OPTIONS.map(({ value, labelKey, fallback }) => ({
+    value,
+    label: t(labelKey, fallback),
+  }));

--- a/frontend/src/pages/medical/Patient-Info.jsx
+++ b/frontend/src/pages/medical/Patient-Info.jsx
@@ -352,6 +352,11 @@ const PatientInfo = () => {
         return t('shared:fields.female', 'Female');
       case 'OTHER':
         return t('shared:fields.other', 'Other');
+      case 'U':
+        return t(
+          'patients.form.gender.options.preferNotToSay',
+          'Prefer not to say'
+        );
       default:
         return t('shared:labels.notSpecified', 'Not specified');
     }

--- a/tests/api/test_patient_management.py
+++ b/tests/api/test_patient_management.py
@@ -313,6 +313,26 @@ class TestPatientManagementAPI:
         data = response.json()
         assert data["relationship_to_self"] == "spouse"
 
+    def test_create_patient_normalizes_empty_relationship_to_self(
+        self, authenticated_client: TestClient
+    ):
+        """Empty-string relationship_to_self must normalize to None on create,
+        consistent with the update path's convert_empty_strings_to_none."""
+        patient_data = {
+            "first_name": "Empty",
+            "last_name": "Relationship",
+            "birth_date": "1990-01-01",
+            "relationship_to_self": "",
+            "is_self_record": False,
+        }
+
+        response = authenticated_client.post(
+            "/api/v1/patient-management/", json=patient_data
+        )
+
+        assert response.status_code == 200
+        assert response.json()["relationship_to_self"] is None
+
     def test_update_patient_persists_relationship_to_self(
         self, authenticated_client: TestClient, test_patient: Patient
     ):
@@ -406,6 +426,17 @@ class TestPatientManagementAPI:
 
         response = authenticated_client.post(
             "/api/v1/patient-management/", json=patient_data
+        )
+
+        assert response.status_code == 422
+
+    def test_update_patient_invalid_gender_rejected(
+        self, authenticated_client: TestClient, test_patient: Patient
+    ):
+        """Invalid gender values must be rejected with a 422 on update too."""
+        response = authenticated_client.put(
+            f"/api/v1/patient-management/{test_patient.id}",
+            json={"gender": "not_a_real_gender"},
         )
 
         assert response.status_code == 422

--- a/tests/api/test_patient_management.py
+++ b/tests/api/test_patient_management.py
@@ -292,3 +292,120 @@ class TestPatientManagementAPI:
         assert patients_data["height"] == mgmt_data["height"] == 69.75
         assert patients_data["weight"] == mgmt_data["weight"] == 185.5
         assert patients_data["first_name"] == mgmt_data["first_name"] == "Consistency"
+
+    def test_create_patient_persists_relationship_to_self(
+        self, authenticated_client: TestClient
+    ):
+        """Regression test for #913: relationship_to_self must persist on create."""
+        patient_data = {
+            "first_name": "Relationship",
+            "last_name": "Test",
+            "birth_date": "1990-01-01",
+            "relationship_to_self": "spouse",
+            "is_self_record": False,
+        }
+
+        response = authenticated_client.post(
+            "/api/v1/patient-management/", json=patient_data
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["relationship_to_self"] == "spouse"
+
+    def test_update_patient_persists_relationship_to_self(
+        self, authenticated_client: TestClient, test_patient: Patient
+    ):
+        """Regression test for #913: relationship_to_self must persist on update."""
+        response = authenticated_client.put(
+            f"/api/v1/patient-management/{test_patient.id}",
+            json={"relationship_to_self": "child"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["relationship_to_self"] == "child"
+
+        # Confirm it actually persisted, not just echoed back in the response
+        get_response = authenticated_client.get(
+            f"/api/v1/patient-management/{test_patient.id}"
+        )
+        assert get_response.status_code == 200
+        assert get_response.json()["relationship_to_self"] == "child"
+
+    @pytest.mark.parametrize(
+        "submitted_gender,expected_stored",
+        [
+            ("Male", "M"),
+            ("male", "M"),
+            ("MALE", "M"),
+            ("Female", "F"),
+            ("OTHER", "OTHER"),
+            ("Unknown", "U"),
+        ],
+    )
+    def test_create_patient_normalizes_gender(
+        self,
+        authenticated_client: TestClient,
+        submitted_gender,
+        expected_stored,
+    ):
+        """Regression test for #913: create must normalize gender the same way update does."""
+        patient_data = {
+            "first_name": "Gender",
+            "last_name": "Create",
+            "birth_date": "1990-01-01",
+            "gender": submitted_gender,
+            "is_self_record": False,
+        }
+
+        response = authenticated_client.post(
+            "/api/v1/patient-management/", json=patient_data
+        )
+
+        assert response.status_code == 200
+        assert response.json()["gender"] == expected_stored
+
+    @pytest.mark.parametrize(
+        "submitted_gender,expected_stored",
+        [
+            ("Male", "M"),
+            ("male", "M"),
+            ("MALE", "M"),
+            ("Female", "F"),
+            ("OTHER", "OTHER"),
+            ("Unknown", "U"),
+        ],
+    )
+    def test_update_patient_normalizes_gender(
+        self,
+        authenticated_client: TestClient,
+        test_patient: Patient,
+        submitted_gender,
+        expected_stored,
+    ):
+        """Regression test for #913: create and update must agree on normalized gender."""
+        response = authenticated_client.put(
+            f"/api/v1/patient-management/{test_patient.id}",
+            json={"gender": submitted_gender},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["gender"] == expected_stored
+
+    def test_create_patient_invalid_gender_rejected(
+        self, authenticated_client: TestClient
+    ):
+        """Invalid gender values must be rejected with a 422, not silently stored."""
+        patient_data = {
+            "first_name": "Invalid",
+            "last_name": "Gender",
+            "birth_date": "1990-01-01",
+            "gender": "not_a_real_gender",
+            "is_self_record": False,
+        }
+
+        response = authenticated_client.post(
+            "/api/v1/patient-management/", json=patient_data
+        )
+
+        assert response.status_code == 422


### PR DESCRIPTION
## Summary

This pull request standardizes patient gender handling across the backend and frontend, ensuring that all patient records use canonical short codes (M, F, OTHER, U) for gender, and updates both forms and display logic accordingly. It also introduces a new `relationship_to_self` field for patients, and provides a one-time migration to backfill legacy gender values in the database. Comprehensive tests are added to verify these changes.

**Backend changes:**

* **Canonical gender normalization and migration:**
  - Added an Alembic migration (`backfill_legacy_patient_gender_values.py`) to update existing patient records with non-canonical gender values (e.g., "Male", "Female", "Unknown", "Prefer not to say") to their canonical short codes (M, F, U) in the database. This ensures all patient records are consistent and compatible with the frontend.
  - Refactored backend gender validation to use a shared `validate_gender` function for both patient creation and update endpoints, guaranteeing consistent normalization and validation of gender values. [[1]](diffhunk://#diff-fcdef9148b0e53f8f31cfca0d8d3e58c7ac8cba589d111de06037ad9040bedb0R23) [[2]](diffhunk://#diff-fcdef9148b0e53f8f31cfca0d8d3e58c7ac8cba589d111de06037ad9040bedb0R50-R60) [[3]](diffhunk://#diff-fcdef9148b0e53f8f31cfca0d8d3e58c7ac8cba589d111de06037ad9040bedb0L125-R140)

* **Patient schema enhancements:**
  - Added a new optional `relationship_to_self` field to both `PatientCreateRequest` and `PatientUpdateRequest` schemas, and ensured empty string values are converted to `None` for this field. [[1]](diffhunk://#diff-fcdef9148b0e53f8f31cfca0d8d3e58c7ac8cba589d111de06037ad9040bedb0R50-R60) [[2]](diffhunk://#diff-fcdef9148b0e53f8f31cfca0d8d3e58c7ac8cba589d111de06037ad9040bedb0R81) [[3]](diffhunk://#diff-fcdef9148b0e53f8f31cfca0d8d3e58c7ac8cba589d111de06037ad9040bedb0R98) [[4]](diffhunk://#diff-b1b393e3959f23f11e9a85da714339c1efdbcf561f52ba93175c1a615186d226R200)

**Frontend changes:**

* **Unified gender options and translations:**
  - Introduced a single source of truth for gender options (`GENDER_OPTIONS` and `getGenderOptions` in `genderOptions.js`), matching backend canonical values, and updated both patient forms (`PatientForm.jsx` and `MantinePatientForm.jsx`) to use these options. This ensures values saved by one form are correctly interpreted by the other. [[1]](diffhunk://#diff-517cbf4a6df6e08401ed836dba35e838ad1282f6c5c5acb8332b28fddfef4138R1-R25) [[2]](diffhunk://#diff-a37a664071fefbfd05009425ed0000450b0bb80109f0f5a14bc3a58b1662c390R34) [[3]](diffhunk://#diff-a37a664071fefbfd05009425ed0000450b0bb80109f0f5a14bc3a58b1662c390L251-R252) [[4]](diffhunk://#diff-1b0a0dcec0ed80c2b0d444751a90ce7bb8982da569149ada0e4e997390f2b5a0R43) [[5]](diffhunk://#diff-1b0a0dcec0ed80c2b0d444751a90ce7bb8982da569149ada0e4e997390f2b5a0L246-R247)
  - Updated the patient info display component to support the new "Prefer not to say" gender value.

* **Testing improvements:**
  - Added/updated tests to verify correct gender option rendering, value submission, and translation, including handling of the "Prefer not to say" option and the new `relationship_to_self` field. [[1]](diffhunk://#diff-a5717028a5caffe2848bd61e975d907812a06ddf6c7eff35433ec5249c3aa144R1-R197) [[2]](diffhunk://#diff-bb35efe085d867cb8f0492b8aae05a8f64461590f3c8f7d0e763639b6043b7b1R149-R151) [[3]](diffhunk://#diff-bb35efe085d867cb8f0492b8aae05a8f64461590f3c8f7d0e763639b6043b7b1R226-R241) [[4]](diffhunk://#diff-c748609b14562c485ceaf304724583208a2004902ca6fdb191e414045c85daa0R1-R20)

These changes ensure robust, consistent handling of patient gender across the application and improve data quality and user experience.

## Related issue

#913 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Translation / i18n
- [ ] Other

## Testing

<!-- How did you verify this works? Manual steps, screenshots, or test names. -->

## Checklist

- [x] Tests added or updated (or N/A with reason)
- [x] `npm run lint` and `npm run build` pass
- [x] Backend tests pass (`pytest`) if backend code changed
- [x] No PHI, secrets, or `console.log` left in the diff
- [x] User-facing strings go through `t()` translations
- [x] Documentation updated if API, schema, or service behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **relationship-to-self** field to patient create and edit flows.
  * Expanded gender selection to support **“Prefer not to say.”**
* **Bug Fixes**
  * Ensured gender values are consistently **normalized** when saving and that **invalid** values are rejected.
  * Backfilled legacy patient gender data to the canonical format.
  * Normalize empty **relationship-to-self** submissions to no value.
* **UI Improvements**
  * Patient details now display **“Prefer not to say”** for unknown/prefer-not-to-say entries.
* **Tests**
  * Expanded automated coverage for relationship persistence and gender normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->