### PR TITLE
fix: enhance search query validation to support non-ASCII characters

### DIFF
--- a/app/api/v1/endpoints/utils.py
+++ b/app/api/v1/endpoints/utils.py
@@ -609,14 +609,18 @@ def validate_search_input(query: str, max_length: int = None) -> str:
             detail="Search query must be at least 1 character long",
         )
 
-    # Remove or replace potentially problematic characters
-    # Allow alphanumeric, spaces, hyphens, underscores, periods, commas, parentheses, forward slashes, percent signs
+    # Reject control characters and characters with no legitimate use in a search
+    # term (quotes, semicolons, angle brackets, backslashes, backticks). We rely on
+    # parameterized queries for SQL injection protection, so this is just a sanity
+    # filter - it deliberately does NOT restrict to ASCII, since test/component
+    # names are user-defined and may be in any of the app's supported languages
+    # (e.g. Chinese, Thai, Cyrillic, accented Latin characters).
     import re
 
-    if not re.match(r"^[a-zA-Z0-9\s\-_.,()\/\%]+$", query):
+    if re.search(r"[\x00-\x1f\x7f'\"`;<>\\]", query):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Search query contains invalid characters. Only letters, numbers, spaces, hyphens, underscores, periods, commas, parentheses, forward slashes, and percent signs are allowed.",
+            detail="Search query contains invalid characters.",
         )
 
     # Note: We allow % in test names (e.g., "% Free Testosterone") since we use parameterized queries

--- a/app/api/v1/endpoints/utils.py
+++ b/app/api/v1/endpoints/utils.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 from typing import Any, Optional
 
@@ -615,8 +616,6 @@ def validate_search_input(query: str, max_length: int = None) -> str:
     # filter - it deliberately does NOT restrict to ASCII, since test/component
     # names are user-defined and may be in any of the app's supported languages
     # (e.g. Chinese, Thai, Cyrillic, accented Latin characters).
-    import re
-
     if re.search(r"[\x00-\x1f\x7f'\"`;<>\\]", query):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/tests/api/test_lab_test_component_trends.py
+++ b/tests/api/test_lab_test_component_trends.py
@@ -1,0 +1,117 @@
+"""
+Tests for the lab test component trends endpoint.
+
+Regression coverage for GitHub issue #916: trend lookups for test names
+containing non-ASCII characters (e.g. Chinese, Thai, Cyrillic) were rejected
+by an overly strict search-query validator.
+"""
+
+import pytest
+from datetime import date
+from sqlalchemy.orm import Session
+
+from app.crud.patient import patient as patient_crud
+from app.schemas.patient import PatientCreate
+from tests.utils.user import create_random_user, create_user_token_headers
+
+
+class TestLabTestComponentTrendsAPI:
+    """Test the /lab-test-components/patient/{id}/trends endpoint."""
+
+    @pytest.fixture
+    def user_with_patient(self, db_session: Session):
+        user_data = create_random_user(db_session)
+        patient_data = PatientCreate(
+            first_name="Jane",
+            last_name="Trends",
+            birth_date=date(1985, 6, 15),
+            gender="F",
+            address="456 Lab Ave",
+        )
+        patient = patient_crud.create_for_user(
+            db_session, user_id=user_data["user"].id, patient_data=patient_data
+        )
+        user_data["user"].active_patient_id = patient.id
+        db_session.commit()
+        db_session.refresh(user_data["user"])
+        return {**user_data, "patient": patient}
+
+    @pytest.fixture
+    def authenticated_headers(self, user_with_patient):
+        return create_user_token_headers(user_with_patient["user"].username)
+
+    def _create_component(self, client, headers, patient_id, test_name):
+        lr_resp = client.post(
+            "/api/v1/lab-results/",
+            json={
+                "patient_id": patient_id,
+                "test_name": "Panel",
+                "status": "completed",
+                "completed_date": "2024-06-01",
+            },
+            headers=headers,
+        )
+        assert lr_resp.status_code == 201
+        lab_result_id = lr_resp.json()["id"]
+
+        bulk_resp = client.post(
+            f"/api/v1/lab-test-components/lab-result/{lab_result_id}/components/bulk",
+            json={
+                "lab_result_id": lab_result_id,
+                "components": [
+                    {
+                        "test_name": test_name,
+                        "value": 170.0,
+                        "unit": "cm",
+                        "status": "normal",
+                        "lab_result_id": lab_result_id,
+                        "result_type": "quantitative",
+                    }
+                ],
+            },
+            headers=headers,
+        )
+        assert bulk_resp.status_code == 201
+        return lab_result_id
+
+    def test_trends_accepts_chinese_test_name(
+        self, client, user_with_patient, authenticated_headers
+    ):
+        """Trend lookup for a test name in Chinese should succeed (issue #916)."""
+        patient_id = user_with_patient["patient"].id
+        test_name = "身高"  # "height" in Chinese
+
+        self._create_component(client, authenticated_headers, patient_id, test_name)
+
+        response = client.get(
+            f"/api/v1/lab-test-components/patient/{patient_id}/trends",
+            params={"test_name": test_name},
+            headers=authenticated_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["test_name"] == test_name
+        assert len(data["data_points"]) == 1
+
+    @pytest.mark.parametrize(
+        "malicious_query",
+        [
+            "'; DROP TABLE lab_test_components; --",
+            "<script>alert(1)</script>",
+            "test\x00name",
+        ],
+    )
+    def test_trends_rejects_injection_style_characters(
+        self, client, user_with_patient, authenticated_headers, malicious_query
+    ):
+        """Search-input validation still blocks control/quote/angle-bracket characters."""
+        patient_id = user_with_patient["patient"].id
+
+        response = client.get(
+            f"/api/v1/lab-test-components/patient/{patient_id}/trends",
+            params={"test_name": malicious_query},
+            headers=authenticated_headers,
+        )
+
+        assert response.status_code == 400


### PR DESCRIPTION
## Summary

This pull request improves the search input validation logic for lab test component trends, allowing non-ASCII characters (such as Chinese, Thai, or Cyrillic) in test names while still blocking potentially malicious characters. It also adds regression tests to ensure correct behavior for both valid non-ASCII and malicious inputs.

**Validation logic improvements:**

* Loosened the search input validator in `validate_search_input` to allow any Unicode character except for control characters and a specific set of potentially dangerous symbols (quotes, semicolons, angle brackets, backslashes, backticks), thus supporting test names in any language used by the app. The validator now uses a negative match (`re.search`) for forbidden characters instead of a restrictive positive match.

**Test coverage:**

* Added a new test module `tests/api/test_lab_test_component_trends.py`:
  - Includes regression tests to verify that test names with non-ASCII characters (e.g., Chinese) are accepted by the trends endpoint.
  - Adds parameterized tests to confirm that queries containing control or injection-style characters are correctly rejected, maintaining security.

## Related issue

#916 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Translation / i18n
- [ ] Other


## Checklist

- [x] Tests added or updated (or N/A with reason)
- [x] `npm run lint` and `npm run build` pass
- [x] Backend tests pass (`pytest`) if backend code changed
- [x] No PHI, secrets, or `console.log` left in the diff
- [x] User-facing strings go through `t()` translations
- [x] Documentation updated if API, schema, or service behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search query validation to reject unsafe characters and return a clearer “invalid characters” message.
  * Fixed an issue where valid, non-Latin (e.g., Chinese) trend lookups could fail.
* **Tests**
  * Added automated coverage for the lab test component trends endpoint, including multilingual queries and rejection of injection-like strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->