### PR TITLE
fix: Severity value for family conditions to 'life-threatening'

### DIFF
--- a/frontend/src/utils/medicalFormFields/familyCondition.js
+++ b/frontend/src/utils/medicalFormFields/familyCondition.js
@@ -95,7 +95,7 @@ export const familyConditionFormFields = [
         labelKey: 'medical:familyHistory.form.condition.severityOptions.severe',
       },
       {
-        value: 'critical',
+        value: 'life-threatening',
         labelKey:
           'medical:familyHistory.form.condition.severityOptions.critical',
       },


### PR DESCRIPTION
Fix family condition severity dropdown mismatch (bug #869)

Issue: Creating/editing a family medical condition with severity "Critical" fails with VAL-422: "Severity must be one of: mild, moderate, severe, life-threatening"

Root cause: The family condition dropdown in frontend/src/utils/medicalFormFields/familyCondition.js sent value: 'critical', but the backend validates against the shared SeverityLevel enum which only accepts 'life-threatening'.

Fix: Changed the dropdown value from 'critical' to 'life-threatening' to align with backend validation.

Testing: Verified personal conditions and injuries already use 'life-threatening' correctly; this fix applies the same to family conditions.

Changes:
- frontend/src/utils/medicalFormFields/familyCondition.js (line 98): 'critical' → 'life-threatening'


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the family medical history form’s severity option from “Critical” to “Life-threatening.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->