### PR TITLE
Fix/lab result advanced mode multi component

### DIFF
--- a/frontend/public/locales/en/labresults.json
+++ b/frontend/public/locales/en/labresults.json
@@ -80,6 +80,7 @@
     "withIssues_one": "{{count}} with issues",
     "withIssues_other": "{{count}} with issues"
   },
+  "bulkImport": "Bulk Import",
   "category": {
     "bloodWork": "Blood Work",
     "cardiology": "Cardiology",

--- a/frontend/src/components/medical/labresults/LabResultFormWrapper.jsx
+++ b/frontend/src/components/medical/labresults/LabResultFormWrapper.jsx
@@ -22,7 +22,7 @@ import {
   IconInfoCircle,
   IconChartBar,
   IconFileText,
-  IconFlask,
+  IconFileUpload,
   IconLink,
   IconNotes,
   IconPlus,
@@ -44,6 +44,7 @@ import LabResultMedicationRelationships from './LabResultMedicationRelationships
 import LabResultProcedureRelationships from './LabResultProcedureRelationships';
 import LabResultTreatmentRelationships from './LabResultTreatmentRelationships';
 import TestComponentsTab from './TestComponentsTab';
+import InlineTestComponentEntry from './InlineTestComponentEntry';
 import AdvancedModeSwitch from './AdvancedModeSwitch';
 import { PURPOSE_OPTIONS } from '../../../constants/encounterLabResultConstants';
 import {
@@ -254,7 +255,9 @@ const PendingRelationshipsPicker = ({
                     color="red"
                     size="sm"
                     onClick={() => onRemoveCondition(index)}
-                    aria-label={t('labresults:pendingRelationships.removeCondition')}
+                    aria-label={t(
+                      'labresults:pendingRelationships.removeCondition'
+                    )}
                   >
                     <IconTrash size={14} />
                   </ActionIcon>
@@ -332,7 +335,9 @@ const PendingRelationshipsPicker = ({
                     color="red"
                     size="sm"
                     onClick={() => onRemoveEncounter(index)}
-                    aria-label={t('labresults:pendingRelationships.removeVisit')}
+                    aria-label={t(
+                      'labresults:pendingRelationships.removeVisit'
+                    )}
                   >
                     <IconTrash size={14} />
                   </ActionIcon>
@@ -404,10 +409,7 @@ const PendingRelationshipsPicker = ({
         <Paper withBorder p="md">
           <Stack gap="sm">
             <Title order={6}>
-              {t(
-                'labresults:form.linkMedicationsTitle',
-                'Link to Medications'
-              )}
+              {t('labresults:form.linkMedicationsTitle', 'Link to Medications')}
             </Title>
 
             {/* Already-added pending medications */}
@@ -483,10 +485,7 @@ const PendingRelationshipsPicker = ({
         <Paper withBorder p="md">
           <Stack gap="sm">
             <Title order={6}>
-              {t(
-                'labresults:form.linkProceduresTitle',
-                'Link to Procedures'
-              )}
+              {t('labresults:form.linkProceduresTitle', 'Link to Procedures')}
             </Title>
 
             {/* Already-added pending procedures */}
@@ -545,9 +544,7 @@ const PendingRelationshipsPicker = ({
                   size="lg"
                   onClick={handleAddProcedure}
                   disabled={!selectedProcedure}
-                  aria-label={t(
-                    'labresults:pendingRelationships.addProcedure'
-                  )}
+                  aria-label={t('labresults:pendingRelationships.addProcedure')}
                 >
                   <IconPlus size={16} />
                 </ActionIcon>
@@ -562,10 +559,7 @@ const PendingRelationshipsPicker = ({
         <Paper withBorder p="md">
           <Stack gap="sm">
             <Title order={6}>
-              {t(
-                'labresults:form.linkTreatmentsTitle',
-                'Link to Treatments'
-              )}
+              {t('labresults:form.linkTreatmentsTitle', 'Link to Treatments')}
             </Title>
 
             {/* Already-added pending treatments */}
@@ -708,6 +702,8 @@ const LabResultFormWrapper = ({
   isLoading = false,
   onDocumentManagerRef,
   onPendingRelationshipsRef,
+  onPendingComponentsRef,
+  onSwitchToQuickImport,
   onFileUploadComplete,
   onError,
   // Condition relationship props
@@ -805,7 +801,6 @@ const LabResultFormWrapper = ({
       color: 'gray',
     },
   ];
-
 
   const getStatusColor = status => {
     switch (status) {
@@ -913,6 +908,26 @@ const LabResultFormWrapper = ({
       });
     }
   }, [onPendingRelationshipsRef]);
+
+  // InlineTestComponentEntry's onRef fires on every keystroke (its methods depend on
+  // component state), so hold the latest methods in a ref and expose a stable wrapper
+  // to the parent — same "read live, register once" approach as pendingRelationshipsRef
+  // below, avoiding a parent re-render on every pending test-row edit.
+  const inlineComponentsMethodsRef = useRef(null);
+  const handleInlineComponentsRef = useCallback(methods => {
+    inlineComponentsMethodsRef.current = methods;
+  }, []);
+
+  useEffect(() => {
+    if (onPendingComponentsRef) {
+      onPendingComponentsRef({
+        hasPendingComponents: () =>
+          inlineComponentsMethodsRef.current?.hasPendingComponents() ?? false,
+        getPendingComponents: () =>
+          inlineComponentsMethodsRef.current?.getPendingComponents() ?? [],
+      });
+    }
+  }, [onPendingComponentsRef]);
 
   // Pending condition helpers
   const addPendingCondition = useCallback((conditionId, relevanceNote) => {
@@ -1030,7 +1045,7 @@ const LabResultFormWrapper = ({
     >
       <form onSubmit={handleSubmit}>
         <Stack gap="lg">
-          <Tabs value={activeTab} onChange={setActiveTab}>
+          <Tabs value={activeTab} onChange={setActiveTab} keepMounted={false}>
             <Tabs.List>
               <Tabs.Tab
                 value="basic"
@@ -1038,22 +1053,12 @@ const LabResultFormWrapper = ({
               >
                 {t('shared:tabs.basicInfo')}
               </Tabs.Tab>
-              {isGroupedResult && editingItem && (
-                <Tabs.Tab
-                  value="test-results"
-                  leftSection={<IconFlask size={16} />}
-                >
-                  {t('labresults:modal.tabs.testComponents', 'Test Results')}
-                </Tabs.Tab>
-              )}
-              {!isGroupedResult && (
-                <Tabs.Tab
-                  value="results"
-                  leftSection={<IconChartBar size={16} />}
-                >
-                  {t('labresults:tabs.resultsStatus')}
-                </Tabs.Tab>
-              )}
+              <Tabs.Tab
+                value="results"
+                leftSection={<IconChartBar size={16} />}
+              >
+                {t('labresults:tabs.resultsStatus')}
+              </Tabs.Tab>
               <Tabs.Tab
                 value="documents"
                 leftSection={<IconFileText size={16} />}
@@ -1217,22 +1222,8 @@ const LabResultFormWrapper = ({
               </Box>
             </Tabs.Panel>
 
-            {/* Test Results Tab — panels only, edit mode only */}
-            {isGroupedResult && editingItem && (
-              <Tabs.Panel value="test-results">
-                <Box mt="md">
-                  <TestComponentsTab
-                    key={`test-components-${editingItem.id}`}
-                    labResultId={editingItem.id}
-                    isViewMode={false}
-                    onError={onError}
-                  />
-                </Box>
-              </Tabs.Panel>
-            )}
-
-            {/* Results & Status Tab — not shown for panels */}
-            {!isGroupedResult && <Tabs.Panel value="results">
+            {/* Results & Status Tab */}
+            <Tabs.Panel value="results">
               <Box mt="md">
                 <Grid>
                   <Grid.Col span={{ base: 12, sm: 6 }}>
@@ -1296,106 +1287,183 @@ const LabResultFormWrapper = ({
                       </Box>
                     </Grid.Col>
                   )}
-                  {/* Numeric result section — not applicable for grouped (PDF-master) results */}
-                  {!isGroupedResult && <Grid.Col span={12}>
-                    <Paper withBorder p="sm" radius="md">
-                      <Text size="sm" fw={500} mb="sm">
-                        {t('labresults:numericResult.sectionLabel', 'Numeric Result (optional)')}
-                      </Text>
-                      <Text size="xs" c="dimmed" mb="sm">
-                        {t(
-                          'labresults:numericResult.sectionDescription',
-                          'Enter a measured value and reference range to enable trend charting for stacked results.'
-                        )}
-                      </Text>
-                      <Grid>
-                        <Grid.Col span={{ base: 12, sm: 6 }}>
-                          <NumberInput
-                            label={t('labresults:numericResult.valueLabel', 'Value')}
-                            value={formData.value ?? ''}
-                            onChange={val =>
-                              onInputChange({
-                                target: {
-                                  name: 'value',
-                                  value: val === '' ? null : val,
-                                },
-                              })
-                            }
-                            placeholder={t('labresults:numericResult.valuePlaceholder', 'e.g. 6.2')}
-                            decimalScale={6}
-                            allowDecimal
-                            clearable
-                          />
+                  {editingItem ? (
+                    <>
+                      {/* API-backed components editor. Shown regardless of isGroupedResult
+                          so a singleton result can have its first component added —
+                          isGroupedResult only becomes true once components exist, so
+                          gating on it here would make it unreachable for singletons. */}
+                      <Grid.Col span={12}>
+                        <TestComponentsTab
+                          key={`test-components-${editingItem.id}`}
+                          labResultId={editingItem.id}
+                          isViewMode={false}
+                          onError={onError}
+                        />
+                      </Grid.Col>
+                      {/* Singleton results (non-panel): direct numeric value editing */}
+                      {!isGroupedResult && (
+                        <Grid.Col span={12}>
+                          <Paper withBorder p="sm" radius="md">
+                            <Text size="sm" fw={500} mb="sm">
+                              {t(
+                                'labresults:numericResult.sectionLabel',
+                                'Numeric Result (optional)'
+                              )}
+                            </Text>
+                            <Text size="xs" c="dimmed" mb="sm">
+                              {t(
+                                'labresults:numericResult.sectionDescription',
+                                'Enter a measured value and reference range to enable trend charting for stacked results.'
+                              )}
+                            </Text>
+                            <Grid>
+                              <Grid.Col span={{ base: 12, sm: 6 }}>
+                                <NumberInput
+                                  label={t(
+                                    'labresults:numericResult.valueLabel',
+                                    'Value'
+                                  )}
+                                  value={formData.value ?? ''}
+                                  onChange={val =>
+                                    onInputChange({
+                                      target: {
+                                        name: 'value',
+                                        value: val === '' ? null : val,
+                                      },
+                                    })
+                                  }
+                                  placeholder={t(
+                                    'labresults:numericResult.valuePlaceholder',
+                                    'e.g. 6.2'
+                                  )}
+                                  decimalScale={6}
+                                  allowDecimal
+                                  clearable
+                                />
+                              </Grid.Col>
+                              <Grid.Col span={{ base: 12, sm: 6 }}>
+                                <TextInput
+                                  label={t(
+                                    'labresults:numericResult.unitLabel',
+                                    'Unit'
+                                  )}
+                                  value={formData.unit || ''}
+                                  onChange={e =>
+                                    onInputChange({
+                                      target: {
+                                        name: 'unit',
+                                        value: e.target.value,
+                                      },
+                                    })
+                                  }
+                                  placeholder={t(
+                                    'labresults:numericResult.unitPlaceholder',
+                                    'e.g. mg/dL, mmol/L'
+                                  )}
+                                  maxLength={50}
+                                />
+                              </Grid.Col>
+                              <Grid.Col span={{ base: 12, sm: 4 }}>
+                                <NumberInput
+                                  label={t(
+                                    'labresults:numericResult.refMinLabel',
+                                    'Range min'
+                                  )}
+                                  value={formData.ref_range_min ?? ''}
+                                  onChange={val =>
+                                    onInputChange({
+                                      target: {
+                                        name: 'ref_range_min',
+                                        value: val === '' ? null : val,
+                                      },
+                                    })
+                                  }
+                                  placeholder={t(
+                                    'labresults:numericResult.refMinPlaceholder',
+                                    'e.g. 4.0'
+                                  )}
+                                  decimalScale={6}
+                                  allowDecimal
+                                  clearable
+                                />
+                              </Grid.Col>
+                              <Grid.Col span={{ base: 12, sm: 4 }}>
+                                <NumberInput
+                                  label={t(
+                                    'labresults:numericResult.refMaxLabel',
+                                    'Range max'
+                                  )}
+                                  value={formData.ref_range_max ?? ''}
+                                  onChange={val =>
+                                    onInputChange({
+                                      target: {
+                                        name: 'ref_range_max',
+                                        value: val === '' ? null : val,
+                                      },
+                                    })
+                                  }
+                                  placeholder={t(
+                                    'labresults:numericResult.refMaxPlaceholder',
+                                    'e.g. 5.6'
+                                  )}
+                                  decimalScale={6}
+                                  allowDecimal
+                                  clearable
+                                />
+                              </Grid.Col>
+                              <Grid.Col span={{ base: 12, sm: 4 }}>
+                                <TextInput
+                                  label={t(
+                                    'labresults:numericResult.refTextLabel',
+                                    'Range text'
+                                  )}
+                                  value={formData.ref_range_text || ''}
+                                  onChange={e =>
+                                    onInputChange({
+                                      target: {
+                                        name: 'ref_range_text',
+                                        value: e.target.value,
+                                      },
+                                    })
+                                  }
+                                  placeholder={t(
+                                    'labresults:numericResult.refTextPlaceholder',
+                                    'e.g. 4.0-5.6 or <200'
+                                  )}
+                                  description={t(
+                                    'labresults:numericResult.refTextDescription',
+                                    'Overrides min/max in display'
+                                  )}
+                                  maxLength={100}
+                                />
+                              </Grid.Col>
+                            </Grid>
+                          </Paper>
                         </Grid.Col>
-                        <Grid.Col span={{ base: 12, sm: 6 }}>
-                          <TextInput
-                            label={t('labresults:numericResult.unitLabel', 'Unit')}
-                            value={formData.unit || ''}
-                            onChange={e =>
-                              onInputChange({
-                                target: { name: 'unit', value: e.target.value },
-                              })
-                            }
-                            placeholder={t('labresults:numericResult.unitPlaceholder', 'e.g. mg/dL, mmol/L')}
-                            maxLength={50}
-                          />
-                        </Grid.Col>
-                        <Grid.Col span={{ base: 12, sm: 4 }}>
-                          <NumberInput
-                            label={t('labresults:numericResult.refMinLabel', 'Range min')}
-                            value={formData.ref_range_min ?? ''}
-                            onChange={val =>
-                              onInputChange({
-                                target: {
-                                  name: 'ref_range_min',
-                                  value: val === '' ? null : val,
-                                },
-                              })
-                            }
-                            placeholder={t('labresults:numericResult.refMinPlaceholder', 'e.g. 4.0')}
-                            decimalScale={6}
-                            allowDecimal
-                            clearable
-                          />
-                        </Grid.Col>
-                        <Grid.Col span={{ base: 12, sm: 4 }}>
-                          <NumberInput
-                            label={t('labresults:numericResult.refMaxLabel', 'Range max')}
-                            value={formData.ref_range_max ?? ''}
-                            onChange={val =>
-                              onInputChange({
-                                target: {
-                                  name: 'ref_range_max',
-                                  value: val === '' ? null : val,
-                                },
-                              })
-                            }
-                            placeholder={t('labresults:numericResult.refMaxPlaceholder', 'e.g. 5.6')}
-                            decimalScale={6}
-                            allowDecimal
-                            clearable
-                          />
-                        </Grid.Col>
-                        <Grid.Col span={{ base: 12, sm: 4 }}>
-                          <TextInput
-                            label={t('labresults:numericResult.refTextLabel', 'Range text')}
-                            value={formData.ref_range_text || ''}
-                            onChange={e =>
-                              onInputChange({
-                                target: { name: 'ref_range_text', value: e.target.value },
-                              })
-                            }
-                            placeholder={t('labresults:numericResult.refTextPlaceholder', 'e.g. 4.0-5.6 or <200')}
-                            description={t('labresults:numericResult.refTextDescription', 'Overrides min/max in display')}
-                            maxLength={100}
-                          />
-                        </Grid.Col>
-                      </Grid>
-                    </Paper>
-                  </Grid.Col>}
+                      )}
+                    </>
+                  ) : (
+                    /* New (create mode): stage components locally before the record exists */
+                    <Grid.Col span={12}>
+                      <InlineTestComponentEntry
+                        onRef={handleInlineComponentsRef}
+                      />
+                      {onSwitchToQuickImport && (
+                        <Button
+                          variant="subtle"
+                          mt="sm"
+                          leftSection={<IconFileUpload size={16} />}
+                          onClick={onSwitchToQuickImport}
+                        >
+                          {t('labresults:bulkImport', 'Bulk Import')}
+                        </Button>
+                      )}
+                    </Grid.Col>
+                  )}
                 </Grid>
               </Box>
-            </Tabs.Panel>}
+            </Tabs.Panel>
 
             {/* Documents Tab */}
             <Tabs.Panel value="documents">
@@ -1432,7 +1500,9 @@ const LabResultFormWrapper = ({
                               labResultId={editingItem.id}
                               labResultConditions={labResultConditions}
                               conditions={conditions}
-                              fetchLabResultConditions={fetchLabResultConditions}
+                              fetchLabResultConditions={
+                                fetchLabResultConditions
+                              }
                               navigate={navigate}
                             />
                           </Stack>
@@ -1457,7 +1527,9 @@ const LabResultFormWrapper = ({
                               labResultId={editingItem.id}
                               labResultEncounters={labResultEncounters}
                               encounters={encounters}
-                              fetchLabResultEncounters={fetchLabResultEncounters}
+                              fetchLabResultEncounters={
+                                fetchLabResultEncounters
+                              }
                               navigate={navigate}
                             />
                           </Stack>
@@ -1588,7 +1660,6 @@ const LabResultFormWrapper = ({
                 </Box>
               </Tabs.Panel>
             )}
-
           </Tabs>
 
           {/* Form Actions */}

--- a/frontend/src/components/medical/labresults/LabResultFormWrapper.jsx
+++ b/frontend/src/components/medical/labresults/LabResultFormWrapper.jsx
@@ -16,11 +16,14 @@ import {
   Title,
   Badge,
   ActionIcon,
+  Collapse,
 } from '@mantine/core';
 import { DateInput } from '../../adapters/DateInput';
 import {
   IconInfoCircle,
   IconChartBar,
+  IconChevronDown,
+  IconChevronUp,
   IconFileText,
   IconFileUpload,
   IconLink,
@@ -737,6 +740,9 @@ const LabResultFormWrapper = ({
   const { dateInputFormat, dateParser } = useDateFormat();
   const [activeTab, setActiveTab] = useState('basic');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  // Collapsible numeric-result section (edit mode, non-panel): expanded by default
+  // since it's the leading section when there's no component data yet.
+  const [numericResultExpanded, setNumericResultExpanded] = useState(true);
   const { handleTextInputChange } = useFormHandlers(onInputChange);
 
   // Pending relationships for create mode (stored locally until lab result is saved)
@@ -1289,6 +1295,165 @@ const LabResultFormWrapper = ({
                   )}
                   {editingItem ? (
                     <>
+                      {/* Singleton results (non-panel): direct numeric value editing,
+                          collapsible. Leads when there's no component data yet; hidden
+                          entirely once the result has components (isGroupedResult) —
+                          components take over as the sole editor at that point. */}
+                      {!isGroupedResult && (
+                        <Grid.Col span={12}>
+                          <Paper withBorder p="sm" radius="md">
+                            <Group
+                              justify="space-between"
+                              style={{ cursor: 'pointer' }}
+                              onClick={() =>
+                                setNumericResultExpanded(prev => !prev)
+                              }
+                            >
+                              <Text size="sm" fw={500}>
+                                {t(
+                                  'labresults:numericResult.sectionLabel',
+                                  'Numeric Result (optional)'
+                                )}
+                              </Text>
+                              {numericResultExpanded ? (
+                                <IconChevronUp size={18} />
+                              ) : (
+                                <IconChevronDown size={18} />
+                              )}
+                            </Group>
+                            <Collapse in={numericResultExpanded}>
+                              <Text size="xs" c="dimmed" mb="sm" mt="sm">
+                                {t(
+                                  'labresults:numericResult.sectionDescription',
+                                  'Enter a measured value and reference range to enable trend charting for stacked results.'
+                                )}
+                              </Text>
+                              <Grid>
+                                <Grid.Col span={{ base: 12, sm: 6 }}>
+                                  <NumberInput
+                                    label={t(
+                                      'labresults:numericResult.valueLabel',
+                                      'Value'
+                                    )}
+                                    value={formData.value ?? ''}
+                                    onChange={val =>
+                                      onInputChange({
+                                        target: {
+                                          name: 'value',
+                                          value: val === '' ? null : val,
+                                        },
+                                      })
+                                    }
+                                    placeholder={t(
+                                      'labresults:numericResult.valuePlaceholder',
+                                      'e.g. 6.2'
+                                    )}
+                                    decimalScale={6}
+                                    allowDecimal
+                                    clearable
+                                  />
+                                </Grid.Col>
+                                <Grid.Col span={{ base: 12, sm: 6 }}>
+                                  <TextInput
+                                    label={t(
+                                      'labresults:numericResult.unitLabel',
+                                      'Unit'
+                                    )}
+                                    value={formData.unit || ''}
+                                    onChange={e =>
+                                      onInputChange({
+                                        target: {
+                                          name: 'unit',
+                                          value: e.target.value,
+                                        },
+                                      })
+                                    }
+                                    placeholder={t(
+                                      'labresults:numericResult.unitPlaceholder',
+                                      'e.g. mg/dL, mmol/L'
+                                    )}
+                                    maxLength={50}
+                                  />
+                                </Grid.Col>
+                                <Grid.Col span={{ base: 12, sm: 4 }}>
+                                  <NumberInput
+                                    label={t(
+                                      'labresults:numericResult.refMinLabel',
+                                      'Range min'
+                                    )}
+                                    value={formData.ref_range_min ?? ''}
+                                    onChange={val =>
+                                      onInputChange({
+                                        target: {
+                                          name: 'ref_range_min',
+                                          value: val === '' ? null : val,
+                                        },
+                                      })
+                                    }
+                                    placeholder={t(
+                                      'labresults:numericResult.refMinPlaceholder',
+                                      'e.g. 4.0'
+                                    )}
+                                    decimalScale={6}
+                                    allowDecimal
+                                    clearable
+                                  />
+                                </Grid.Col>
+                                <Grid.Col span={{ base: 12, sm: 4 }}>
+                                  <NumberInput
+                                    label={t(
+                                      'labresults:numericResult.refMaxLabel',
+                                      'Range max'
+                                    )}
+                                    value={formData.ref_range_max ?? ''}
+                                    onChange={val =>
+                                      onInputChange({
+                                        target: {
+                                          name: 'ref_range_max',
+                                          value: val === '' ? null : val,
+                                        },
+                                      })
+                                    }
+                                    placeholder={t(
+                                      'labresults:numericResult.refMaxPlaceholder',
+                                      'e.g. 5.6'
+                                    )}
+                                    decimalScale={6}
+                                    allowDecimal
+                                    clearable
+                                  />
+                                </Grid.Col>
+                                <Grid.Col span={{ base: 12, sm: 4 }}>
+                                  <TextInput
+                                    label={t(
+                                      'labresults:numericResult.refTextLabel',
+                                      'Range text'
+                                    )}
+                                    value={formData.ref_range_text || ''}
+                                    onChange={e =>
+                                      onInputChange({
+                                        target: {
+                                          name: 'ref_range_text',
+                                          value: e.target.value,
+                                        },
+                                      })
+                                    }
+                                    placeholder={t(
+                                      'labresults:numericResult.refTextPlaceholder',
+                                      'e.g. 4.0-5.6 or <200'
+                                    )}
+                                    description={t(
+                                      'labresults:numericResult.refTextDescription',
+                                      'Overrides min/max in display'
+                                    )}
+                                    maxLength={100}
+                                  />
+                                </Grid.Col>
+                              </Grid>
+                            </Collapse>
+                          </Paper>
+                        </Grid.Col>
+                      )}
                       {/* API-backed components editor. Shown regardless of isGroupedResult
                           so a singleton result can have its first component added —
                           isGroupedResult only becomes true once components exist, so
@@ -1301,147 +1466,6 @@ const LabResultFormWrapper = ({
                           onError={onError}
                         />
                       </Grid.Col>
-                      {/* Singleton results (non-panel): direct numeric value editing */}
-                      {!isGroupedResult && (
-                        <Grid.Col span={12}>
-                          <Paper withBorder p="sm" radius="md">
-                            <Text size="sm" fw={500} mb="sm">
-                              {t(
-                                'labresults:numericResult.sectionLabel',
-                                'Numeric Result (optional)'
-                              )}
-                            </Text>
-                            <Text size="xs" c="dimmed" mb="sm">
-                              {t(
-                                'labresults:numericResult.sectionDescription',
-                                'Enter a measured value and reference range to enable trend charting for stacked results.'
-                              )}
-                            </Text>
-                            <Grid>
-                              <Grid.Col span={{ base: 12, sm: 6 }}>
-                                <NumberInput
-                                  label={t(
-                                    'labresults:numericResult.valueLabel',
-                                    'Value'
-                                  )}
-                                  value={formData.value ?? ''}
-                                  onChange={val =>
-                                    onInputChange({
-                                      target: {
-                                        name: 'value',
-                                        value: val === '' ? null : val,
-                                      },
-                                    })
-                                  }
-                                  placeholder={t(
-                                    'labresults:numericResult.valuePlaceholder',
-                                    'e.g. 6.2'
-                                  )}
-                                  decimalScale={6}
-                                  allowDecimal
-                                  clearable
-                                />
-                              </Grid.Col>
-                              <Grid.Col span={{ base: 12, sm: 6 }}>
-                                <TextInput
-                                  label={t(
-                                    'labresults:numericResult.unitLabel',
-                                    'Unit'
-                                  )}
-                                  value={formData.unit || ''}
-                                  onChange={e =>
-                                    onInputChange({
-                                      target: {
-                                        name: 'unit',
-                                        value: e.target.value,
-                                      },
-                                    })
-                                  }
-                                  placeholder={t(
-                                    'labresults:numericResult.unitPlaceholder',
-                                    'e.g. mg/dL, mmol/L'
-                                  )}
-                                  maxLength={50}
-                                />
-                              </Grid.Col>
-                              <Grid.Col span={{ base: 12, sm: 4 }}>
-                                <NumberInput
-                                  label={t(
-                                    'labresults:numericResult.refMinLabel',
-                                    'Range min'
-                                  )}
-                                  value={formData.ref_range_min ?? ''}
-                                  onChange={val =>
-                                    onInputChange({
-                                      target: {
-                                        name: 'ref_range_min',
-                                        value: val === '' ? null : val,
-                                      },
-                                    })
-                                  }
-                                  placeholder={t(
-                                    'labresults:numericResult.refMinPlaceholder',
-                                    'e.g. 4.0'
-                                  )}
-                                  decimalScale={6}
-                                  allowDecimal
-                                  clearable
-                                />
-                              </Grid.Col>
-                              <Grid.Col span={{ base: 12, sm: 4 }}>
-                                <NumberInput
-                                  label={t(
-                                    'labresults:numericResult.refMaxLabel',
-                                    'Range max'
-                                  )}
-                                  value={formData.ref_range_max ?? ''}
-                                  onChange={val =>
-                                    onInputChange({
-                                      target: {
-                                        name: 'ref_range_max',
-                                        value: val === '' ? null : val,
-                                      },
-                                    })
-                                  }
-                                  placeholder={t(
-                                    'labresults:numericResult.refMaxPlaceholder',
-                                    'e.g. 5.6'
-                                  )}
-                                  decimalScale={6}
-                                  allowDecimal
-                                  clearable
-                                />
-                              </Grid.Col>
-                              <Grid.Col span={{ base: 12, sm: 4 }}>
-                                <TextInput
-                                  label={t(
-                                    'labresults:numericResult.refTextLabel',
-                                    'Range text'
-                                  )}
-                                  value={formData.ref_range_text || ''}
-                                  onChange={e =>
-                                    onInputChange({
-                                      target: {
-                                        name: 'ref_range_text',
-                                        value: e.target.value,
-                                      },
-                                    })
-                                  }
-                                  placeholder={t(
-                                    'labresults:numericResult.refTextPlaceholder',
-                                    'e.g. 4.0-5.6 or <200'
-                                  )}
-                                  description={t(
-                                    'labresults:numericResult.refTextDescription',
-                                    'Overrides min/max in display'
-                                  )}
-                                  maxLength={100}
-                                />
-                              </Grid.Col>
-                            </Grid>
-                          </Paper>
-                        </Grid.Col>
-                      )}
                     </>
                   ) : (
                     /* New (create mode): stage components locally before the record exists */

--- a/frontend/src/components/medical/labresults/LabResultFormWrapper.jsx
+++ b/frontend/src/components/medical/labresults/LabResultFormWrapper.jsx
@@ -1051,7 +1051,7 @@ const LabResultFormWrapper = ({
     >
       <form onSubmit={handleSubmit}>
         <Stack gap="lg">
-          <Tabs value={activeTab} onChange={setActiveTab} keepMounted={false}>
+          <Tabs value={activeTab} onChange={setActiveTab}>
             <Tabs.List>
               <Tabs.Tab
                 value="basic"

--- a/frontend/src/components/medical/labresults/TestPanelCreateDialog.tsx
+++ b/frontend/src/components/medical/labresults/TestPanelCreateDialog.tsx
@@ -31,9 +31,7 @@ import InlineTestComponentEntry, {
 } from './InlineTestComponentEntry';
 import AdvancedModeSwitch from './AdvancedModeSwitch';
 import { apiService } from '../../../services/api';
-import { labTestComponentApi } from '../../../services/api/labTestComponentApi';
-import { sanitizeComponentForApi, hasFilledValue, createEmptyRow, ComponentRowData } from '../../../utils/labTestComponentUtils';
-import { notifications } from '@mantine/notifications';
+import { hasFilledValue, createEmptyRow, submitPendingTestComponents, ComponentRowData } from '../../../utils/labTestComponentUtils';
 import logger from '../../../services/logger';
 
 interface Practitioner {
@@ -178,38 +176,13 @@ const TestPanelCreateDialog: React.FC<TestPanelCreateDialogProps> = ({
 
       const labResult = await apiService.createLabResult(payload);
 
-      let componentSaveError: 'partial' | 'total' | null = null;
-
-      if (pendingComponents.length > 0) {
-        const apiComponents = pendingComponents.map(row =>
-          sanitizeComponentForApi(row, labResult.id)
-        );
-        try {
-          const bulkResult = await labTestComponentApi.createBulkForLabResult(
-            labResult.id,
-            apiComponents,
-            currentPatient.id
-          );
-          if (bulkResult.errors?.length > 0) {
-            componentSaveError = 'partial';
-            logger.error('test_panel_component_partial_failure', {
-              message: 'Some test components failed to save',
-              labResultId: labResult.id,
-              errors: bulkResult.errors,
-              component: 'TestPanelCreateDialog',
-            });
-          }
-        } catch (bulkErr: unknown) {
-          componentSaveError = 'total';
-          const bulkMessage = bulkErr instanceof Error ? bulkErr.message : String(bulkErr);
-          logger.error('test_panel_component_bulk_failure', {
-            message: 'Bulk component creation failed after panel was created',
-            labResultId: labResult.id,
-            error: bulkMessage,
-            component: 'TestPanelCreateDialog',
-          });
-        }
-      }
+      await submitPendingTestComponents(
+        labResult.id,
+        pendingComponents,
+        currentPatient.id,
+        'TestPanelCreateDialog',
+        t
+      );
 
       logger.info('test_panel_created', {
         message: 'Test panel created',
@@ -217,28 +190,6 @@ const TestPanelCreateDialog: React.FC<TestPanelCreateDialogProps> = ({
         componentCount: pendingComponents.length,
         component: 'TestPanelCreateDialog',
       });
-
-      if (componentSaveError === 'total') {
-        notifications.show({
-          title: t('medical:labResults.addPanel.componentSaveFailedTitle', 'Test components not saved'),
-          message: t(
-            'medical:labResults.addPanel.componentSaveFailedMessage',
-            'The panel was created but test components could not be saved. Edit the panel to add them.'
-          ),
-          color: 'red',
-          autoClose: 8000,
-        });
-      } else if (componentSaveError === 'partial') {
-        notifications.show({
-          title: t('medical:labResults.addPanel.componentPartialSaveTitle', 'Some components not saved'),
-          message: t(
-            'medical:labResults.addPanel.componentPartialSaveMessage',
-            'The panel was created but some test components failed to save. Edit the panel to review.'
-          ),
-          color: 'yellow',
-          autoClose: 8000,
-        });
-      }
 
       setFormData(EMPTY_FORM);
       setError(null);

--- a/frontend/src/pages/medical/LabResults.jsx
+++ b/frontend/src/pages/medical/LabResults.jsx
@@ -40,6 +40,7 @@ import LabResultStackCard from '../../components/medical/labresults/LabResultSta
 import LabResultStackPanel from '../../components/medical/labresults/LabResultStackPanel';
 import { notifications } from '@mantine/notifications';
 import { labTestComponentApi } from '../../services/api/labTestComponentApi';
+import { submitPendingTestComponents } from '../../utils/labTestComponentUtils';
 import { useFormSubmissionWithUploads } from '../../hooks/useFormSubmissionWithUploads';
 import { Button, Container, Stack, Paper } from '@mantine/core';
 import { IconFileUpload, IconTable, IconLayoutGrid, IconStack2 } from '@tabler/icons-react';
@@ -700,6 +701,10 @@ const LabResults = () => {
   const [pendingRelationshipsMethods, setPendingRelationshipsMethods] =
     useState(null);
 
+  // Pending test components state (advanced create mode only)
+  const [pendingComponentsMethods, setPendingComponentsMethods] =
+    useState(null);
+
   // Advanced create mode: bypasses the quick TestPanelCreateDialog and opens the
   // full tabbed form (relationships, notes, files) directly. Persisted per browser.
   const [advancedCreateMode, setAdvancedCreateMode] = usePersistedToggle(
@@ -771,6 +776,7 @@ const LabResults = () => {
     setEditingLabResult(null);
     setDocumentManagerMethods(null);
     setPendingRelationshipsMethods(null);
+    setPendingComponentsMethods(null);
     setFormData(EMPTY_FORM_DATA);
     setShowModal(true);
   }, [resetSubmission]);
@@ -991,6 +997,16 @@ const LabResults = () => {
         completed_date: formData.completed_date || null,
       };
 
+      // Staged test components (advanced create mode only). Computed once and reused
+      // both to flag the record as a panel and to submit them after it's created.
+      const pendingComponents = editingLabResult
+        ? []
+        : (pendingComponentsMethods?.getPendingComponents?.() ?? []);
+
+      if (pendingComponents.length > 0) {
+        labResultData.is_panel = true;
+      }
+
       try {
         let success;
         let resultId;
@@ -1017,11 +1033,15 @@ const LabResults = () => {
         completeFormSubmission(success, resultId);
 
         if (success && resultId) {
-          // Submit pending relationships (advanced create mode only)
-          if (
-            !editingLabResult &&
-            pendingRelationshipsMethods?.hasPendingRelationships?.()
-          ) {
+          // Submit pending relationships and pending test components (advanced create
+          // mode only) concurrently — neither depends on the other, only on resultId.
+          const submitPendingRelationships = async () => {
+            if (
+              editingLabResult ||
+              !pendingRelationshipsMethods?.hasPendingRelationships?.()
+            ) {
+              return;
+            }
             try {
               const pending =
                 pendingRelationshipsMethods.getPendingRelationships();
@@ -1102,7 +1122,29 @@ const LabResults = () => {
                 autoClose: 8000,
               });
             }
-          }
+          };
+
+          const submitComponents = async () => {
+            if (pendingComponents.length === 0) return;
+            await submitPendingTestComponents(
+              resultId,
+              pendingComponents,
+              currentPatient.id,
+              'LabResults',
+              t
+            );
+            logger.info('pending_components_created', {
+              message: 'Pending test components created with lab result',
+              labResultId: resultId,
+              componentCount: pendingComponents.length,
+              component: 'LabResults',
+            });
+          };
+
+          await Promise.allSettled([
+            submitPendingRelationships(),
+            submitComponents(),
+          ]);
 
           // Check if we have files to upload
           const hasPendingFiles = documentManagerMethods?.hasPendingFiles?.();
@@ -1164,6 +1206,7 @@ const LabResults = () => {
       createItem,
       documentManagerMethods,
       pendingRelationshipsMethods,
+      pendingComponentsMethods,
       startSubmission,
       setError,
       completeFormSubmission,
@@ -1240,10 +1283,27 @@ const LabResults = () => {
     }
     setDocumentManagerMethods(null); // Reset document manager methods
     setPendingRelationshipsMethods(null); // Reset pending relationships
+    setPendingComponentsMethods(null); // Reset pending test components
     // Sync the components table — tests may have been added via TestComponentsTab
     refreshPatientComponents();
     setFormData(EMPTY_FORM_DATA);
   }, [isBlocking, resetSubmission, refreshPatientComponents]);
+
+  // Shared by handleAdvancedModeToggle and handleSwitchToQuickImport: whether the
+  // advanced create form has anything a user would lose by abandoning it.
+  const hasUnsavedAdvancedFormData = useCallback(
+    () =>
+      !!formData.test_name?.trim() ||
+      pendingRelationshipsMethods?.hasPendingRelationships?.() ||
+      pendingComponentsMethods?.hasPendingComponents?.() ||
+      documentManagerMethods?.hasPendingFiles?.(),
+    [
+      formData.test_name,
+      pendingRelationshipsMethods,
+      pendingComponentsMethods,
+      documentManagerMethods,
+    ]
+  );
 
   // Lets the user swap between the quick panel-creation dialog and the full
   // tabbed form from within whichever create modal is currently open.
@@ -1253,17 +1313,12 @@ const LabResults = () => {
   // needed switching in that direction.
   const handleAdvancedModeToggle = useCallback(
     checked => {
-      if (!checked) {
-        const hasEnteredData =
-          !!formData.test_name?.trim() ||
-          pendingRelationshipsMethods?.hasPendingRelationships?.() ||
-          documentManagerMethods?.hasPendingFiles?.();
-        if (
-          hasEnteredData &&
-          !window.confirm(t('labresults:messages.confirmDiscardAdvancedForm'))
-        ) {
-          return;
-        }
+      if (
+        !checked &&
+        hasUnsavedAdvancedFormData() &&
+        !window.confirm(t('labresults:messages.confirmDiscardAdvancedForm'))
+      ) {
+        return;
       }
       setAdvancedCreateMode(checked);
       if (checked) {
@@ -1275,15 +1330,26 @@ const LabResults = () => {
       }
     },
     [
-      formData.test_name,
-      pendingRelationshipsMethods,
-      documentManagerMethods,
+      hasUnsavedAdvancedFormData,
       openAdvancedForm,
       handleCloseModal,
       setAdvancedCreateMode,
       t,
     ]
   );
+
+  // Abandons the advanced create form (confirming first if there's anything to
+  // lose) and opens the separate Quick PDF Import flow instead.
+  const handleSwitchToQuickImport = useCallback(() => {
+    if (
+      hasUnsavedAdvancedFormData() &&
+      !window.confirm(t('labresults:messages.confirmDiscardAdvancedForm'))
+    ) {
+      return;
+    }
+    handleCloseModal();
+    setShowQuickImportModal(true);
+  }, [hasUnsavedAdvancedFormData, handleCloseModal, t]);
 
   const renderViewContent = () => {
     if (viewMode === 'components') {
@@ -1682,6 +1748,8 @@ const LabResults = () => {
           navigate={navigate}
           onDocumentManagerRef={setDocumentManagerMethods}
           onPendingRelationshipsRef={setPendingRelationshipsMethods}
+          onPendingComponentsRef={setPendingComponentsMethods}
+          onSwitchToQuickImport={handleSwitchToQuickImport}
           postCreate={postCreateMode}
           advancedCreate={advancedCreateMode}
           onAdvancedModeChange={handleAdvancedModeToggle}

--- a/frontend/src/utils/labTestComponentUtils.ts
+++ b/frontend/src/utils/labTestComponentUtils.ts
@@ -4,11 +4,14 @@
  */
 
 import sanitizeHtml from 'sanitize-html';
+import { notifications } from '@mantine/notifications';
 import {
   LabTestComponentCreate,
   QualitativeValue,
+  labTestComponentApi,
 } from '../services/api/labTestComponentApi';
 import { ComponentCategory, ComponentStatus } from '../constants/labCategories';
+import logger from '../services/logger';
 
 /**
  * Maximum length for the alternative reference range text.
@@ -177,4 +180,72 @@ export function sanitizeComponentForApi(
       : null,
     textual_value: isTextual ? sanitizeInput(component.textual_value) : null,
   };
+}
+
+/**
+ * Bulk-create staged component rows against a lab result that already exists,
+ * logging and notifying on partial/total failure. Shared by every "create a lab
+ * result, then attach its pending test components" flow (advanced create form,
+ * simple-mode panel dialog) so they don't each reimplement the same error handling.
+ */
+export async function submitPendingTestComponents(
+  labResultId: number,
+  pendingComponents: ComponentRowData[],
+  patientId: number | null | undefined,
+  source: string,
+  t: (_key: string, _fallback: string) => string
+): Promise<void> {
+  if (pendingComponents.length === 0) return;
+
+  const apiComponents = pendingComponents.map(row =>
+    sanitizeComponentForApi(row, labResultId)
+  );
+
+  try {
+    const bulkResult = await labTestComponentApi.createBulkForLabResult(
+      labResultId,
+      apiComponents,
+      patientId
+    );
+
+    if (bulkResult.errors?.length > 0) {
+      logger.error('test_component_partial_save_failure', {
+        message: 'Some test components failed to save',
+        labResultId,
+        errors: bulkResult.errors,
+        component: source,
+      });
+      notifications.show({
+        title: t(
+          'medical:labResults.addPanel.componentPartialSaveTitle',
+          'Some components not saved'
+        ),
+        message: t(
+          'medical:labResults.addPanel.componentPartialSaveMessage',
+          'The panel was created but some test components failed to save. Edit the panel to review.'
+        ),
+        color: 'yellow',
+        autoClose: 8000,
+      });
+    }
+  } catch (err: unknown) {
+    logger.error('test_component_bulk_save_failure', {
+      message: 'Bulk component creation failed after lab result was created',
+      labResultId,
+      error: err instanceof Error ? err.message : String(err),
+      component: source,
+    });
+    notifications.show({
+      title: t(
+        'medical:labResults.addPanel.componentSaveFailedTitle',
+        'Test components not saved'
+      ),
+      message: t(
+        'medical:labResults.addPanel.componentSaveFailedMessage',
+        'The panel was created but test components could not be saved. Edit the panel to add them.'
+      ),
+      color: 'red',
+      autoClose: 8000,
+    });
+  }
 }


### PR DESCRIPTION
## Summary

This pull request updates the `LabResultFormWrapper` component to improve the handling and editing experience of numeric lab results, especially for non-panel (singleton) lab results. It introduces a collapsible numeric result section, streamlines the tab structure, and enhances accessibility and code clarity. The most important changes are grouped below.

**UI/UX Improvements for Numeric Results:**

* Added a collapsible section for editing numeric results in singleton (non-panel) lab results, which is expanded by default and hidden when component data exists, improving clarity and reducing clutter. (`LabResultFormWrapper.jsx`) [[1]](diffhunk://#diff-2e360f6d33afc5cf3b867ccc96e3b260b1c4b796a9b5dc99c84425ca610430a6R743-R745) [[2]](diffhunk://#diff-2e360f6d33afc5cf3b867ccc96e3b260b1c4b796a9b5dc99c84425ca610430a6L1299-R1325)
* Replaced the previous static numeric result fields with a `Collapse` component and toggle icons for better user interaction. (`LabResultFormWrapper.jsx`)
* Updated all numeric result input fields to use consistent translation patterns and improved placeholder and label clarity. (`LabResultFormWrapper.jsx`) [[1]](diffhunk://#diff-2e360f6d33afc5cf3b867ccc96e3b260b1c4b796a9b5dc99c84425ca610430a6L1314-R1337) [[2]](diffhunk://#diff-2e360f6d33afc5cf3b867ccc96e3b260b1c4b796a9b5dc99c84425ca610430a6L1324-R1383) [[3]](diffhunk://#diff-2e360f6d33afc5cf3b867ccc96e3b260b1c4b796a9b5dc99c84425ca610430a6L1355-R1407)

**Tab Structure and Logic Simplification:**

* Simplified the tab logic: removed the "Test Results" tab for grouped results in edit mode, and unified the "Results & Status" tab for all result types, streamlining the user experience. (`LabResultFormWrapper.jsx`) [[1]](diffhunk://#diff-2e360f6d33afc5cf3b867ccc96e3b260b1c4b796a9b5dc99c84425ca610430a6L1033-L1056) [[2]](diffhunk://#diff-2e360f6d33afc5cf3b867ccc96e3b260b1c4b796a9b5dc99c84425ca610430a6L1220-R1232)

**Accessibility and Code Quality:**

* Improved accessibility by ensuring all `aria-label` attributes use consistent translation calls and formatting. (`LabResultFormWrapper.jsx`) [[1]](diffhunk://#diff-2e360f6d33afc5cf3b867ccc96e3b260b1c4b796a9b5dc99c84425ca610430a6L257-R263) [[2]](diffhunk://#diff-2e360f6d33afc5cf3b867ccc96e3b260b1c4b796a9b5dc99c84425ca610430a6L335-R343) [[3]](diffhunk://#diff-2e360f6d33afc5cf3b867ccc96e3b260b1c4b796a9b5dc99c84425ca610430a6L548-R550)
* Cleaned up and clarified translation usage for section titles and labels. (`LabResultFormWrapper.jsx`) [[1]](diffhunk://#diff-2e360f6d33afc5cf3b867ccc96e3b260b1c4b796a9b5dc99c84425ca610430a6L407-R415) [[2]](diffhunk://#diff-2e360f6d33afc5cf3b867ccc96e3b260b1c4b796a9b5dc99c84425ca610430a6L486-R491) [[3]](diffhunk://#diff-2e360f6d33afc5cf3b867ccc96e3b260b1c4b796a9b5dc99c84425ca610430a6L565-R565)

**Component and Reference Handling:**

* Added support for a new prop `onPendingComponentsRef` and implemented a stable ref pattern for exposing inline test component methods to the parent, mirroring the approach used for pending relationships. (`LabResultFormWrapper.jsx`) [[1]](diffhunk://#diff-2e360f6d33afc5cf3b867ccc96e3b260b1c4b796a9b5dc99c84425ca610430a6R708-R709) [[2]](diffhunk://#diff-2e360f6d33afc5cf3b867ccc96e3b260b1c4b796a9b5dc99c84425ca610430a6R918-R937)

**Miscellaneous:**

* Added "Bulk Import" translation key to the English locale file. (`labresults.json`)
* Updated imports to include new icons and the `Collapse` component. (`LabResultFormWrapper.jsx`)
* Added `InlineTestComponentEntry` import for future/related inline editing features. (`LabResultFormWrapper.jsx`)

## Related issue


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Translation / i18n
- [ ] Other

## Testing

manual testing

## Checklist

- [x] Tests added or updated (or N/A with reason)
- [x] `npm run lint` and `npm run build` pass
- [x] Backend tests pass (`pytest`) if backend code changed
- [x] No PHI, secrets, or `console.log` left in the diff
- [x] User-facing strings go through `t()` translations
- [x] Documentation updated if API, schema, or service behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added staging and saving of inline test components during advanced lab result creation.
  * Added a quick-import option and “Bulk Import” label.
  * Added a collapsible optional “Numeric Result” editor in the results area.
  * Pending components are saved alongside pending relationships on final submission.
* **Bug Fixes**
  * Improved handling and user notifications for partial or failed test-component saves.
  * Enhanced unsaved-data protection for the advanced create form, including staged components, when switching or closing.
* **Refactor**
  * Simplified the lab results panel/tabs layout so edit and create flows share a consistent “results” area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->