### PR TITLE
fix: fixed print button and styles for lab results table

### DIFF
--- a/frontend/src/components/medical/labresults/LabResultsComponentTable.tsx
+++ b/frontend/src/components/medical/labresults/LabResultsComponentTable.tsx
@@ -456,7 +456,7 @@ const LabResultsComponentTable: React.FC<Props> = ({
       </Card>
 
       {/* Table */}
-      <Paper withBorder radius="md" style={{ overflow: 'auto' }}>
+      <Paper withBorder radius="md" className="lab-components-table-wrapper" style={{ overflow: 'auto' }}>
         <Table striped highlightOnHover>
           <Table.Thead>
             <Table.Tr>
@@ -592,6 +592,7 @@ const LabResultsComponentTable: React.FC<Props> = ({
                               <Table.Tr
                                 key={comp.id}
                                 data-testid={`history-row-${comp.id}`}
+                                className="lab-history-row"
                                 style={{ backgroundColor: 'var(--mantine-color-gray-0)' }}
                               >
                                 <Table.Td />

--- a/frontend/src/pages/medical/LabResults.jsx
+++ b/frontend/src/pages/medical/LabResults.jsx
@@ -43,7 +43,7 @@ import { labTestComponentApi } from '../../services/api/labTestComponentApi';
 import { submitPendingTestComponents } from '../../utils/labTestComponentUtils';
 import { useFormSubmissionWithUploads } from '../../hooks/useFormSubmissionWithUploads';
 import { Button, Container, Stack, Paper } from '@mantine/core';
-import { IconFileUpload, IconTable, IconLayoutGrid, IconStack2 } from '@tabler/icons-react';
+import { IconFileUpload, IconTable, IconLayoutGrid, IconStack2, IconPrinter } from '@tabler/icons-react';
 import LabResultsComponentTable from '../../components/medical/labresults/LabResultsComponentTable';
 import TestComponentEditModal from '../../components/medical/labresults/TestComponentEditModal';
 import { usePatientPermissions } from '../../hooks/usePatientPermissions';
@@ -1615,34 +1615,47 @@ const LabResults = () => {
             viewToggleSize="sm"
             mb={0}
             rightChildren={
-              <Button.Group>
-                <Button
-                  size="sm"
-                  variant={viewMode !== 'stacked' && !tableLayout ? 'filled' : 'default'}
-                  leftSection={<IconLayoutGrid size={14} />}
-                  onClick={() => { setTableLayout(false); if (viewMode === 'stacked') handleViewModeChange('panels'); }}
-                >
-                  {t('common:viewToggle.cards', 'Cards')}
-                </Button>
-                <Button
-                  size="sm"
-                  variant={viewMode !== 'stacked' && tableLayout ? 'filled' : 'default'}
-                  leftSection={<IconTable size={14} />}
-                  onClick={() => { setTableLayout(true); if (viewMode === 'stacked') handleViewModeChange('panels'); }}
-                >
-                  {t('common:viewToggle.table', 'Table')}
-                </Button>
-                {hasStackableResults && (
+              <>
+                <Button.Group>
                   <Button
                     size="sm"
-                    variant={viewMode === 'stacked' ? 'filled' : 'default'}
-                    leftSection={<IconStack2 size={14} />}
-                    onClick={() => handleViewModeChange('stacked')}
+                    variant={viewMode !== 'stacked' && !tableLayout ? 'filled' : 'default'}
+                    leftSection={<IconLayoutGrid size={14} />}
+                    onClick={() => { setTableLayout(false); if (viewMode === 'stacked') handleViewModeChange('panels'); }}
                   >
-                    {t('common:viewToggle.stacked', 'Stacked')}
+                    {t('common:viewToggle.cards', 'Cards')}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant={viewMode !== 'stacked' && tableLayout ? 'filled' : 'default'}
+                    leftSection={<IconTable size={14} />}
+                    onClick={() => { setTableLayout(true); if (viewMode === 'stacked') handleViewModeChange('panels'); }}
+                  >
+                    {t('common:viewToggle.table', 'Table')}
+                  </Button>
+                  {hasStackableResults && (
+                    <Button
+                      size="sm"
+                      variant={viewMode === 'stacked' ? 'filled' : 'default'}
+                      leftSection={<IconStack2 size={14} />}
+                      onClick={() => handleViewModeChange('stacked')}
+                    >
+                      {t('common:viewToggle.stacked', 'Stacked')}
+                    </Button>
+                  )}
+                </Button.Group>
+                {viewMode !== 'stacked' && tableLayout && (
+                  <Button
+                    className="print-button"
+                    size="sm"
+                    variant="light"
+                    leftSection={<IconPrinter size={14} />}
+                    onClick={() => window.print()}
+                  >
+                    {t('common:buttons.print', 'Print')}
                   </Button>
                 )}
-              </Button.Group>
+              </>
             }
           />
 

--- a/frontend/src/pages/medical/LabResults.jsx
+++ b/frontend/src/pages/medical/LabResults.jsx
@@ -101,6 +101,7 @@ const LabResults = () => {
   const responsive = useResponsive();
   const [viewMode, setViewMode] = usePersistedViewMode('lab-results');
   const [tableLayout, setTableLayout] = useState(() => viewMode === 'table');
+  const [isPrintingAll, setIsPrintingAll] = useState(false);
   const {
     page,
     setPage,
@@ -688,6 +689,23 @@ const LabResults = () => {
       viewMode === 'stacked' ? stackedViewItems.length : filteredLabResults.length;
     clampPage(count);
   }, [filteredLabResults.length, stackedViewItems.length, viewMode, clampPage]);
+
+  // Restore normal pagination after the browser print dialog closes (covers
+  // both completed prints and cancellations).
+  useEffect(() => {
+    const handleAfterPrint = () => setIsPrintingAll(false);
+    window.addEventListener('afterprint', handleAfterPrint);
+    return () => window.removeEventListener('afterprint', handleAfterPrint);
+  }, []);
+
+  const handlePrintTable = () => {
+    setIsPrintingAll(true);
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        window.print();
+      });
+    });
+  };
 
   // Combined loading state — include component fetch when in stacked or results-table view to avoid content flash.
   // For the components table specifically, only block on initial load (empty array); subsequent refreshes must not
@@ -1474,7 +1492,7 @@ const LabResults = () => {
       <Paper shadow="sm" radius="md" withBorder>
         <ResponsiveTable
           persistKey="lab-results"
-          data={paginatedLabResults}
+          data={isPrintingAll ? filteredLabResults : paginatedLabResults}
           pagination={false}
           disableEdit={isViewOnly}
           disableDelete={isViewOnly}
@@ -1650,7 +1668,7 @@ const LabResults = () => {
                     size="sm"
                     variant="light"
                     leftSection={<IconPrinter size={14} />}
-                    onClick={() => window.print()}
+                    onClick={handlePrintTable}
                   >
                     {t('common:buttons.print', 'Print')}
                   </Button>

--- a/frontend/src/styles/print.css
+++ b/frontend/src/styles/print.css
@@ -32,13 +32,16 @@
   .header-center,
   nav,
   header,
+  footer,
+  .app-footer,
   .back-button,
   /* Hide any elements with settings or theme in class names */
   [class*="settings"],
   [class*="theme"],
   [class*="logout"],
   [class*="header-action"],
-  [class*="nav-"] {
+  [class*="nav-"],
+  [class*="navigation-toggle"] {
     display: none !important;
   }
 
@@ -61,6 +64,19 @@
     background: white !important;
     padding: 0 !important;
     margin: 0 !important;
+  }
+
+  /* Prevent scrollable table containers from clipping printed content */
+  .lab-components-table-wrapper,
+  [class*='mantine-Paper'] {
+    overflow: visible !important;
+  }
+
+  /* Expanded history rows use a smaller font on screen for visual hierarchy;
+     bump them up for print so they stay legible on paper. */
+  .lab-history-row [class*='mantine-Text-root'],
+  .lab-history-row [class*='mantine-Badge-root'] {
+    font-size: 10px !important;
   }
 
   /* Ensure the main container takes full width */


### PR DESCRIPTION
## Summary

This pull request adds print support for the lab results table, improving both user experience and print formatting. The main changes include adding a print button to the lab results page, adjusting print styles to ensure tables and expanded rows render correctly on paper, and assigning class names to key table elements for targeted styling.

**Print feature and UI enhancements:**

* Added a print button (`IconPrinter`) to the lab results page toolbar, visible when the table layout is active and not in stacked view. Clicking the button triggers the browser print dialog. [[1]](diffhunk://#diff-0cdeb56d6ea4b5b0cc95cf27641cd050674dabe2adce3a84861b6c149bb46724L46-R46) [[2]](diffhunk://#diff-0cdeb56d6ea4b5b0cc95cf27641cd050674dabe2adce3a84861b6c149bb46724R1618) [[3]](diffhunk://#diff-0cdeb56d6ea4b5b0cc95cf27641cd050674dabe2adce3a84861b6c149bb46724R1647-R1658)

**Styling and print formatting improvements:**

* Updated `print.css` to hide footers, navigation, and other non-essential UI elements when printing, ensuring only relevant content appears on paper.
* Modified print styles so that scrollable table containers (like `.lab-components-table-wrapper`) display all content without clipping during printing.
* Increased the font size of expanded history rows in the table when printing to improve legibility.

**Class name assignments for styling:**

* Added the `lab-components-table-wrapper` class to the table container and `lab-history-row` to expanded history rows for more precise print styling. [[1]](diffhunk://#diff-6c44e9796b9cec3b240df5e347fb801ab4251564499f5b27d4c75a268f9a8f64L459-R459) [[2]](diffhunk://#diff-6c44e9796b9cec3b240df5e347fb801ab4251564499f5b27d4c75a268f9a8f64R595)

## Related issue

#900 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Translation / i18n
- [ ] Other

## Testing



## Checklist

- [x] Tests added or updated (or N/A with reason)
- [x] `npm run lint` and `npm run build` pass
- [x] Backend tests pass (`pytest`) if backend code changed
- [x] No PHI, secrets, or `console.log` left in the diff
- [x] User-facing strings go through `t()` translations
- [x] Documentation updated if API, schema, or service behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Print** button for lab results in Table view.
* **Bug Fixes**
  * Improved printing to prevent lab content from being clipped in table/scrollable layouts.
  * Enhanced styling for expanded history rows to improve readability in print.
* **Chores**
  * Updated print rules to hide additional navigation and footer elements for cleaner printouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->