### PR TITLE
refactor: derive allergy severity from the SeverityLevel enum

### DIFF
--- a/app/schemas/allergy.py
+++ b/app/schemas/allergy.py
@@ -3,7 +3,10 @@ from typing import List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from app.models.enums import get_all_severity_levels
 from app.schemas.base_tags import TaggedEntityMixin
+
+VALID_SEVERITY_LEVELS = get_all_severity_levels()
 
 
 class AllergyBase(TaggedEntityMixin):
@@ -29,9 +32,10 @@ class AllergyBase(TaggedEntityMixin):
     @field_validator("severity")
     @classmethod
     def validate_severity(cls, v):
-        valid_severities = ["mild", "moderate", "severe", "life-threatening"]
-        if v.lower() not in valid_severities:
-            raise ValueError(f"Severity must be one of: {', '.join(valid_severities)}")
+        if v.lower() not in VALID_SEVERITY_LEVELS:
+            raise ValueError(
+                f"Severity must be one of: {', '.join(VALID_SEVERITY_LEVELS)}"
+            )
         return v.lower()
 
     @field_validator("status")
@@ -68,10 +72,9 @@ class AllergyUpdate(BaseModel):
     @classmethod
     def validate_severity(cls, v):
         if v is not None:
-            valid_severities = ["mild", "moderate", "severe", "life-threatening"]
-            if v.lower() not in valid_severities:
+            if v.lower() not in VALID_SEVERITY_LEVELS:
                 raise ValueError(
-                    f"Severity must be one of: {', '.join(valid_severities)}"
+                    f"Severity must be one of: {', '.join(VALID_SEVERITY_LEVELS)}"
                 )
             return v.lower()
         return v


### PR DESCRIPTION
## Summary

`app/schemas/allergy.py` is the only schema in the codebase that validates `severity` against a hardcoded inline list instead of deriving it from the `SeverityLevel` enum in `app/models/enums.py`. Every sibling schema (`condition.py`, `injury.py`, `family_condition.py`, `symptom.py`) already reads from the enum, so the enum is effectively the single source of truth everywhere except this one file. This brings `allergy.py` in line with that pattern. There is no behavior change: the hardcoded list and the enum currently hold the same four values.

## Related issue

N/A. Found while working on #935.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code quality
- [ ] Documentation
- [ ] Translation / i18n
- [ ] Other

## What changed

One file, `app/schemas/allergy.py`:

- Added `from app.models.enums import get_all_severity_levels` and a module-level `VALID_SEVERITY_LEVELS = get_all_severity_levels()`, matching how `condition.py` does it.
- `AllergyBase.validate_severity` and `AllergyUpdate.validate_severity` now check against `VALID_SEVERITY_LEVELS` instead of each defining its own `valid_severities` list inline.

The list was duplicated across those two validators, so this also removes the copy-paste pair. Error message format and the `.lower()` normalization behavior are unchanged.

No migration needed. `Allergy.severity` is a plain SQLAlchemy `String` column with no CHECK constraint and no native DB enum type, so severity validation lives entirely in the schema layer.

## Why I think this is an oversight rather than a deliberate exception

**The model already declares the enum as the intent.** The `Allergy.severity` column in `app/models/clinical.py` carries the comment `# Use SeverityLevel enum: mild, moderate, severe, critical`. That is the same annotation `Condition.severity` carries. So the data layer already says allergy severity is governed by `SeverityLevel`, and only the schema layer disagreed.

**It looks like an incomplete refactor.** PR #400 (the Pydantic V1 to V2 migration) touched `allergy.py` and `condition.py` in the same commit. It rewrote `condition.py`'s validators into the enum-derived pattern, but in `allergy.py` it only did the mechanical decorator swap (`@validator` to `@field_validator` plus `@classmethod`) and left the hardcoded list untouched a few lines below. The semantic half of that refactor just did not reach this file.

**`allergy.py` has never referenced the enum**, going back to the initial commit. `git log -S get_all_severity_levels -- app/schemas/allergy.py` returns nothing. The hardcoding predates the helper existing at all.

**The two lists have never drifted apart.** Hardcoded: `["mild", "moderate", "severe", "life-threatening"]`. Enum: the same four values. If allergies were meant to have their own severity vocabulary, you would expect divergence by now, and there is none.

Please lmk if this hardcoding was intentional.

## How this interacts with PR #935

Worth calling out explicitly so it is not a surprise on review.

#935 adds `NONE = "none"` to `SeverityLevel`. Once both changes are in, allergies will start accepting `severity: "none"` automatically, with no further code edits. That is exactly what this refactor is for, but it does mean allergies inherit a severity level that is arguably an odd fit. An allergy that provokes no reaction at all is admittedly an unusual thing to record, and I would expect `none` to go mostly unused for allergies in practice.

I find this acceptable. Nothing forces the option to be selected, the existing four levels stay exactly as they are and will cover essentially every real allergy record, and an unused option in a dropdown does no harm. Weighed against that, the benefit is that severity levels stop being something you have to remember to update in two different styles across five files. Change the enum, and every entity picks it up. That is already true for four of the five entities, and this makes it true for the fifth.

The optional fallback would be filtering `NONE` out at the allergy schema level while still deriving the rest from the enum, so the file keeps a single source of truth and documents the exclusion deliberately instead of by accident.

## Testing

**Backend** (pytest): `tests/crud/test_allergy.py`, 10 passed. The 12 warnings are pre-existing (a deprecated `HTTP_422_UNPROCESSABLE_ENTITY` import, a `datetime.utcnow()` deprecation, and a SQLAlchemy table-sort warning from the test fixtures) and are unrelated to this change.

Also ran the validators directly against a scratch SQLite database to confirm:

- `VALID_SEVERITY_LEVELS` at import time is exactly `get_all_severity_levels()`.
- All four current severity values are accepted by both `AllergyCreate` and `AllergyUpdate`.
- Invalid values are still rejected. Checked were `"bogus"`, `""`, and `"critical"` specifically, that last one because it appears in a stale model comment but has never been a real enum member.
- Case normalization still works (`"MILD"` comes back as `"mild"`).
- `AllergyUpdate(severity=None)` still passes through as `None`, so the optional-field path is intact.

No frontend files are touched, so `npm run lint` and `npm run build` are not applicable here.

## Checklist

- [x] Tests added or updated (or N/A with reason): N/A. This is a no-op refactor against the current enum contents, and the existing `test_allergy.py` coverage of valid and invalid severity values already exercises both validators. Happy to add a test asserting the schema and enum stay in sync if we want a regression guard.
- [x] `npm run lint` and `npm run build` pass: N/A, backend-only change with no frontend files touched.
- [x] Backend tests pass (`pytest`)
- [x] No PHI, PII, secrets, or `console.log` left in the diff
- [x] User-facing strings go through `t()` translations: N/A, no user-facing strings changed. The validation error message keeps its existing format and was already English-only in this file.
- [x] Documentation updated if API, schema, or service behavior changed: N/A, no behavior change. #935 already documents the severity values themselves in the API reference and schema docs.

## Other notes

This does not add `none` as an allergy option. That belongs to #935. All this does is remove the divergent hardcoding so allergies track the enum like everything else already does.

Ordering between the two PRs does not matter. They touch different lines and will not conflict, and the end state is the same either way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Allergy severity validation now consistently reflects the currently supported severity levels.
  * Error messages for invalid severity values now provide accurate, up-to-date guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->