### PR TITLE
feat: Added 12 additional Laboratory tests

### DIFF
--- a/shared/data/test_library.json
+++ b/shared/data/test_library.json
@@ -2469,7 +2469,7 @@
       "abbreviation": "Prot Ur",
       "test_code": "2888-6",
       "default_unit": "mg/dL",
-      "category": "other",
+      "category": "chemistry",
       "common_names": [
         "Proteins in Urine"
       ],
@@ -2481,7 +2481,7 @@
       "test_name": "Glucose in Urine",
       "abbreviation": "Glucose Ur",
       "test_code": "2349-9",
-      "category": "other",
+      "category": "chemistry",
       "common_names": [
         "Glucose in Urine",
         "Glucose [Presence] in Urine"
@@ -2494,7 +2494,7 @@
       "test_name": "Ketones in Urine",
       "abbreviation": "Ketones Ur",
       "test_code": "33903-6",
-      "category": "other",
+      "category": "chemistry",
       "common_names": [
         "Ketones in Urine",
         "Ketones [Presence] in Urine"
@@ -2507,7 +2507,7 @@
       "test_name": "Bilirubin in Urine",
       "abbreviation": "Bilirubin Ur",
       "test_code": "1977-8",
-      "category": "other",
+      "category": "chemistry",
       "common_names": [
         "Bilirubin in Urine",
         "Bilirubin [Presence] in Urine"
@@ -2520,7 +2520,7 @@
       "test_name": "Erythrocytes [Presence] in Urine",
       "abbreviation": "RBC Ur",
       "test_code": "33051-4",
-      "category": "other",
+      "category": "chemistry",
       "common_names": [
         "Erythrocytes in Urine",
         "Erythrocytes [Presence] in Urine"
@@ -2533,7 +2533,7 @@
       "test_name": "Nitrite in Urine",
       "abbreviation": "Nitrite Ur",
       "test_code": "32710-6",
-      "category": "other",
+      "category": "chemistry",
       "common_names": [
         "Nitrite in Urine",
         "Nitrite [Presence] in Urine"
@@ -2547,7 +2547,7 @@
       "abbreviation": "WBC Ur",
       "test_code": "30405-5",
       "default_unit": "#/uL",
-      "category": "other",
+      "category": "chemistry",
       "common_names": [
         "Leukocytes in Urine",
         "Leukocytes [#/volume] in Urine"

--- a/shared/data/test_library.json
+++ b/shared/data/test_library.json
@@ -2457,6 +2457,7 @@
       "test_name": "Urine Color",
       "abbreviation": "Color Ur",
       "test_code": "5778-6",
+      "default_unit": "",
       "category": "chemistry",
       "common_names": [
         "Urine Color"
@@ -2482,6 +2483,7 @@
       "test_name": "Glucose in Urine",
       "abbreviation": "Glucose Ur",
       "test_code": "2349-9",
+      "default_unit": "",
       "category": "chemistry",
       "common_names": [
         "Glucose in Urine",
@@ -2495,6 +2497,7 @@
       "test_name": "Ketones in Urine",
       "abbreviation": "Ketones Ur",
       "test_code": "33903-6",
+      "default_unit": "",
       "category": "chemistry",
       "common_names": [
         "Ketones in Urine",
@@ -2508,6 +2511,7 @@
       "test_name": "Bilirubin in Urine",
       "abbreviation": "Bilirubin Ur",
       "test_code": "1977-8",
+      "default_unit": "",
       "category": "chemistry",
       "common_names": [
         "Bilirubin in Urine",
@@ -2521,6 +2525,7 @@
       "test_name": "Erythrocytes [Presence] in Urine",
       "abbreviation": "RBC Ur",
       "test_code": "33051-4",
+      "default_unit": "",
       "category": "chemistry",
       "common_names": [
         "Erythrocytes in Urine",
@@ -2534,6 +2539,7 @@
       "test_name": "Nitrite in Urine",
       "abbreviation": "Nitrite Ur",
       "test_code": "32710-6",
+      "default_unit": "",
       "category": "chemistry",
       "common_names": [
         "Nitrite in Urine",

--- a/shared/data/test_library.json
+++ b/shared/data/test_library.json
@@ -2430,7 +2430,7 @@
       "category": "hematology",
       "common_names": [
         "NeutsBand#",
-        "Band form neutrophils",
+        "Absolute band form neutrophils",
         "Neuts Band #"
       ],
       "is_common": false,

--- a/shared/data/test_library.json
+++ b/shared/data/test_library.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.8.0",
-  "lastUpdated": "2026-05-23",
+  "version": "1.8.1",
+  "lastUpdated": "2026-07-28",
   "tests": [
     {
       "test_name": "Alanine Aminotransferase",
@@ -2392,6 +2392,170 @@
       "is_common": false,
       "result_type": "qualitative",
       "display_order": 163
+    },
+    {
+      "test_name": "Plateletcrit",
+      "abbreviation": "PCT",
+      "test_code": "51637-7",
+      "default_unit": "%",
+      "category": "hematology",
+      "common_names": [
+        "Pct",
+        "PCT",
+        "Plateletcrit"
+      ],
+      "is_common": true,
+      "display_order": 164,
+      "result_type": "quantitative"
+    },
+    {
+      "test_name": "Platelet distribution width",
+      "abbreviation": "PDW",
+      "test_code": "32207-3",
+      "default_unit": "fL",
+      "category": "hematology",
+      "common_names": [
+        "PDW",
+        "Platelet distribution width"
+      ],
+      "is_common": true,
+      "display_order": 165,
+      "result_type": "quantitative"
+    },
+    {
+      "test_name": "Band form Neutrophils (Absolute)",
+      "abbreviation": "Neuts.Band#",
+      "test_code": "26507-4",
+      "default_unit": "k/uL",
+      "category": "hematology",
+      "common_names": [
+        "NeutsBand#",
+        "Band form neutrophils",
+        "Neuts Band #"
+      ],
+      "is_common": false,
+      "display_order": 166,
+      "result_type": "quantitative"
+    },
+     {
+      "test_name": "Band form Neutrophils",
+      "abbreviation": "Neuts.Band",
+      "test_code": "26508-2",
+      "default_unit": "%",
+      "category": "hematology",
+      "common_names": [
+        "NeutsBand",
+        "Band form neutrophils",
+        "Neuts Band"
+      ],
+      "is_common": false,
+      "display_order": 167,
+      "result_type": "quantitative"
+    },
+     {
+      "test_name": "Urine Color",
+      "abbreviation": "Color Ur",
+      "test_code": "5778-6",
+      "category": "chemistry",
+      "common_names": [
+        "Urine Color"
+      ],
+      "is_common": true,
+      "display_order": 168,
+      "result_type": "qualitative"
+    },
+    {
+      "test_name": "Proteins in Urine",
+      "abbreviation": "Prot Ur",
+      "test_code": "2888-6",
+      "default_unit": "mg/dL",
+      "category": "other",
+      "common_names": [
+        "Proteins in Urine",
+        "Proteins [Presence] in Urine"
+      ],
+      "is_common": false,
+      "display_order": 169,
+      "result_type": "quantitative"
+    },
+    {
+      "test_name": "Glucose in Urine",
+      "abbreviation": "Glucose Ur",
+      "test_code": "2349-9",
+      "category": "other",
+      "common_names": [
+        "Glucose in Urine",
+        "Glucose [Presence] in Urine"
+      ],
+      "is_common": false,
+      "display_order": 170,
+      "result_type": "qualitative"
+    },
+    {
+      "test_name": "Ketones in Urine",
+      "abbreviation": "Ketones Ur",
+      "test_code": "33903-6",
+      "category": "other",
+      "common_names": [
+        "Ketones in Urine",
+        "Ketones [Presence] in Urine"
+      ],
+      "is_common": false,
+      "display_order": 171,
+      "result_type": "qualitative"
+    },
+    {
+      "test_name": "Bilirubin in Urine",
+      "abbreviation": "Bilirubin Ur",
+      "test_code": "1977-8",
+      "category": "other",
+      "common_names": [
+        "Bilirubin in Urine",
+        "Bilirubin [Presence] in Urine"
+      ],
+      "is_common": false,
+      "display_order": 172,
+      "result_type": "qualitative"
+    },
+    {
+      "test_name": "Erythrocytes [Presence] in Urine",
+      "abbreviation": "RBC Ur",
+      "test_code": "33051-4",
+      "category": "other",
+      "common_names": [
+        "Erythrocytes in Urine",
+        "Erythrocytes [Presence] in Urine"
+      ],
+      "is_common": false,
+      "display_order": 173,
+      "result_type": "qualitative"
+    },
+    {
+      "test_name": "Nitrite in Urine",
+      "abbreviation": "Nitrite Ur",
+      "test_code": "32710-6",
+      "category": "other",
+      "common_names": [
+        "Nitrite in Urine",
+        "Nitrite [Presence] in Urine"
+      ],
+      "is_common": false,
+      "display_order": 174,
+      "result_type": "qualitative"
+    },
+    {
+      "test_name": "Leukocytes in Urine",
+      "abbreviation": "WBC Ur",
+      "test_code": "30405-5",
+      "default_unit": "#/uL",
+      "category": "other",
+      "common_names": [
+        "Leukocytes in Urine",
+        "Leukocytes [#/volume] in Urine"
+      ],
+      "is_common": false,
+      "display_order": 175,
+      "result_type": "quantitative"
     }
   ]
 }

--- a/shared/data/test_library.json
+++ b/shared/data/test_library.json
@@ -2522,7 +2522,7 @@
       "display_order": 172
     },
     {
-      "test_name": "Erythrocytes [Presence] in Urine",
+      "test_name": "Erythrocytes in Urine",
       "abbreviation": "RBC Ur",
       "test_code": "33051-4",
       "default_unit": "",

--- a/shared/data/test_library.json
+++ b/shared/data/test_library.json
@@ -2471,8 +2471,7 @@
       "default_unit": "mg/dL",
       "category": "other",
       "common_names": [
-        "Proteins in Urine",
-        "Proteins [Presence] in Urine"
+        "Proteins in Urine"
       ],
       "is_common": false,
       "display_order": 169,

--- a/shared/data/test_library.json
+++ b/shared/data/test_library.json
@@ -2293,8 +2293,8 @@
         "Lp(a)"
       ],
       "is_common": false,
-      "display_order": 156,
-      "result_type": "quantitative"
+      "result_type": "quantitative",
+      "display_order": 156
     },
     {
       "test_name": "Creatine Kinase-MB",
@@ -2308,8 +2308,8 @@
         "Creatine Phosphokinase-MB"
       ],
       "is_common": false,
-      "display_order": 157,
-      "result_type": "quantitative"
+      "result_type": "quantitative",
+      "display_order": 157
     },
     {
       "test_name": "Angiotensin Converting Enzyme",
@@ -2322,8 +2322,8 @@
         "SACE"
       ],
       "is_common": false,
-      "display_order": 158,
-      "result_type": "quantitative"
+      "result_type": "quantitative",
+      "display_order": 158
     },
     {
       "test_name": "Alpha-1 Globulin",
@@ -2336,8 +2336,8 @@
         "Alpha 1 globulin"
       ],
       "is_common": false,
-      "display_order": 159,
-      "result_type": "quantitative"
+      "result_type": "quantitative",
+      "display_order": 160
     },
     {
       "test_name": "Alpha-2 Globulin",
@@ -2350,8 +2350,8 @@
         "Alpha 2 globulin"
       ],
       "is_common": false,
-      "display_order": 160,
-      "result_type": "quantitative"
+      "result_type": "quantitative",
+      "display_order": 160
     },
     {
       "test_name": "Beta Globulin",
@@ -2364,8 +2364,8 @@
         "Beta globulin"
       ],
       "is_common": false,
-      "display_order": 161,
-      "result_type": "quantitative"
+      "result_type": "quantitative",
+      "display_order": 161
     },
     {
       "test_name": "Gamma Globulin",
@@ -2378,8 +2378,8 @@
         "Gamma globulin"
       ],
       "is_common": false,
-      "display_order": 162,
-      "result_type": "quantitative"
+      "result_type": "quantitative",
+      "display_order": 162
     },
     {
       "test_name": "Tuberculin Skin Test",

--- a/shared/data/test_library.json
+++ b/shared/data/test_library.json
@@ -2438,7 +2438,7 @@
       "result_type": "quantitative",
       "display_order": 166
     },
-     {
+    {
       "test_name": "Band form Neutrophils",
       "abbreviation": "Neuts.Band",
       "test_code": "26508-2",
@@ -2453,7 +2453,7 @@
       "result_type": "quantitative",
       "display_order": 167
     },
-     {
+    {
       "test_name": "Urine Color",
       "abbreviation": "Color Ur",
       "test_code": "5778-6",

--- a/shared/data/test_library.json
+++ b/shared/data/test_library.json
@@ -2405,8 +2405,8 @@
         "Plateletcrit"
       ],
       "is_common": true,
-      "display_order": 164,
-      "result_type": "quantitative"
+      "result_type": "quantitative",
+      "display_order": 164
     },
     {
       "test_name": "Platelet distribution width",
@@ -2419,8 +2419,8 @@
         "Platelet distribution width"
       ],
       "is_common": true,
-      "display_order": 165,
-      "result_type": "quantitative"
+      "result_type": "quantitative",
+      "display_order": 165
     },
     {
       "test_name": "Band form Neutrophils (Absolute)",
@@ -2434,8 +2434,9 @@
         "Neuts Band #"
       ],
       "is_common": false,
-      "display_order": 166,
-      "result_type": "quantitative"
+
+      "result_type": "quantitative",
+      "display_order": 166
     },
      {
       "test_name": "Band form Neutrophils",
@@ -2449,8 +2450,8 @@
         "Neuts Band"
       ],
       "is_common": false,
-      "display_order": 167,
-      "result_type": "quantitative"
+      "result_type": "quantitative",
+      "display_order": 167
     },
      {
       "test_name": "Urine Color",
@@ -2461,8 +2462,8 @@
         "Urine Color"
       ],
       "is_common": true,
-      "display_order": 168,
-      "result_type": "qualitative"
+      "result_type": "qualitative",
+      "display_order": 168
     },
     {
       "test_name": "Proteins in Urine",
@@ -2474,8 +2475,8 @@
         "Proteins in Urine"
       ],
       "is_common": false,
-      "display_order": 169,
-      "result_type": "quantitative"
+      "result_type": "quantitative",
+      "display_order": 169
     },
     {
       "test_name": "Glucose in Urine",
@@ -2487,8 +2488,8 @@
         "Glucose [Presence] in Urine"
       ],
       "is_common": false,
-      "display_order": 170,
-      "result_type": "qualitative"
+      "result_type": "qualitative",
+      "display_order": 170
     },
     {
       "test_name": "Ketones in Urine",
@@ -2500,8 +2501,8 @@
         "Ketones [Presence] in Urine"
       ],
       "is_common": false,
-      "display_order": 171,
-      "result_type": "qualitative"
+      "result_type": "qualitative",
+      "display_order": 171
     },
     {
       "test_name": "Bilirubin in Urine",
@@ -2513,8 +2514,8 @@
         "Bilirubin [Presence] in Urine"
       ],
       "is_common": false,
-      "display_order": 172,
-      "result_type": "qualitative"
+      "result_type": "qualitative",
+      "display_order": 172
     },
     {
       "test_name": "Erythrocytes [Presence] in Urine",
@@ -2526,8 +2527,8 @@
         "Erythrocytes [Presence] in Urine"
       ],
       "is_common": false,
-      "display_order": 173,
-      "result_type": "qualitative"
+      "result_type": "qualitative",
+      "display_order": 173
     },
     {
       "test_name": "Nitrite in Urine",
@@ -2539,8 +2540,8 @@
         "Nitrite [Presence] in Urine"
       ],
       "is_common": false,
-      "display_order": 174,
-      "result_type": "qualitative"
+      "result_type": "qualitative",
+      "display_order": 174
     },
     {
       "test_name": "Leukocytes in Urine",
@@ -2553,8 +2554,8 @@
         "Leukocytes [#/volume] in Urine"
       ],
       "is_common": false,
-      "display_order": 175,
-      "result_type": "quantitative"
+      "result_type": "quantitative",
+      "display_order": 175
     }
   ]
 }

--- a/shared/data/test_library.json
+++ b/shared/data/test_library.json
@@ -2404,7 +2404,7 @@
         "PCT",
         "Plateletcrit"
       ],
-      "is_common": true,
+      "is_common": false,
       "result_type": "quantitative",
       "display_order": 164
     },
@@ -2418,7 +2418,7 @@
         "PDW",
         "Platelet distribution width"
       ],
-      "is_common": true,
+      "is_common": false,
       "result_type": "quantitative",
       "display_order": 165
     },


### PR DESCRIPTION
## Summary

Adds 12 additional lab tests to library:

1. [Plateletcrit](https://loinc.org/51637-7)
2. [Platelet distribution width](https://loinc.org/32207-3)
3. [Band form Neutrophils (Absolute)](https://loinc.org/26507-4)
4. [Band form Neutrophils](https://loinc.org/26508-2)
5. [Urine Color](https://loinc.org/5778-6)
6. [Proteins in Urine](https://loinc.org/2888-6)
7. [Glucose in Urine](https://loinc.org/2349-9)
8. [Ketones in Urine](https://loinc.org/33903-6)
9. [Bilirubin in Urine](https://loinc.org/1977-8)
10. [Erythrocytes [Presence] in Urine](https://loinc.org/33051-4)
11. [Nitrite in Urine](https://loinc.org/32710-6)
12. [Leukocytes in Urine](https://loinc.org/30405-5)

Please double check `category` and `is_common` values, as I am not 100% sure about the criteria to follow.

## Related issue

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Translation / i18n
- [ ] Other

## Testing
It only includes new data for the lab results

## Checklist

- [ ] Tests added or updated (or N/A with reason)
- [ ] `npm run lint` and `npm run build` pass
- [ ] Backend tests pass (`pytest`) if backend code changed
- [ ] No PHI, secrets, or `console.log` left in the diff
- [ ] User-facing strings go through `t()` translations
- [ ] Documentation updated if API, schema, or service behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added laboratory test definitions for platelet metrics and band-form neutrophils.
  * Added urine analysis tests covering color, protein, glucose, ketones, bilirubin, erythrocytes, nitrites, and leukocytes.
  * Added qualitative and quantitative result support, including standardized units for quantitative urine measurements.

* **Updates**
  * Updated the test library to version **1.8.1**.
  * Recorded the latest dataset update date and refined test display ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->