### PR TITLE
feat: add language switcher to mobile navigation and adjust z-index for dropdown

### DIFF
--- a/frontend/src/components/navigation/MobileNavigation.jsx
+++ b/frontend/src/components/navigation/MobileNavigation.jsx
@@ -94,7 +94,7 @@ const MobileNavigation = ({
             </button>
             <div className="mobile-theme-toggle">
               <span>{t('sidebarNav.items.language', 'Language')}</span>
-              <LanguageSwitcher size="xs" />
+              <LanguageSwitcher size="xs" compact />
             </div>
             <div className="mobile-theme-toggle">
               <span>{t('sidebarNav.items.theme', 'Theme')}</span>

--- a/frontend/src/components/navigation/MobileNavigation.jsx
+++ b/frontend/src/components/navigation/MobileNavigation.jsx
@@ -4,6 +4,7 @@ import { IconX } from '@tabler/icons-react';
 import { getNavigationSections } from '../../config/navigation.config';
 import { useViewport } from '../../hooks/useViewport';
 import ThemeToggle from '../ui/ThemeToggle';
+import LanguageSwitcher from '../shared/LanguageSwitcher';
 
 const MobileNavigation = ({
   isOpen,
@@ -91,6 +92,10 @@ const MobileNavigation = ({
             >
               {'\u2699\uFE0F'} {t('shared:labels.settings', 'Settings')}
             </button>
+            <div className="mobile-theme-toggle">
+              <span>{t('sidebarNav.items.language', 'Language')}</span>
+              <LanguageSwitcher size="xs" />
+            </div>
             <div className="mobile-theme-toggle">
               <span>{t('sidebarNav.items.theme', 'Theme')}</span>
               <ThemeToggle />

--- a/frontend/src/components/shared/LanguageSwitcher.tsx
+++ b/frontend/src/components/shared/LanguageSwitcher.tsx
@@ -164,7 +164,7 @@ const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({
           cursor: 'pointer',
         },
       }}
-      comboboxProps={{ withinPortal: true }}
+      comboboxProps={{ withinPortal: true, zIndex: 1100 }}
       allowDeselect={false}
       aria-label="Select language"
     />


### PR DESCRIPTION
## Summary

This pull request adds a language selection option to the mobile navigation menu and improves the display of the language switcher component. The main changes are:

**Mobile navigation improvements:**
* Added the `LanguageSwitcher` component to the mobile navigation menu, allowing users to select their preferred language directly from the mobile sidebar. (`frontend/src/components/navigation/MobileNavigation.jsx`) [[1]](diffhunk://#diff-607e70c080e803092cde1d969e1f0b7918e38bb5d9f1e4b3f366cbd5c43e0effR7) [[2]](diffhunk://#diff-607e70c080e803092cde1d969e1f0b7918e38bb5d9f1e4b3f366cbd5c43e0effR95-R98)

**UI enhancements:**
* Set a higher `zIndex` for the language switcher dropdown to ensure it displays correctly above other UI elements. (`frontend/src/components/shared/LanguageSwitcher.tsx`)

## Related issue

<!-- e.g. "Closes #123" or "N/A" -->

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Translation / i18n
- [ ] Other

## Testing


## Checklist

- [x] Tests added or updated (or N/A with reason)
- [x] `npm run lint` and `npm run build` pass
- [x] Backend tests pass (`pytest`) if backend code changed
- [x] No PHI, secrets, or `console.log` left in the diff
- [x] User-facing strings go through `t()` translations
- [x] Documentation updated if API, schema, or service behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added language selection to the mobile navigation account section.

* **Bug Fixes**
  * Improved the language selector’s display layering so it appears correctly above other interface elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->