### PR TITLE
fix: use local date instead of UTC when auto-filling symptom dates

### DIFF
--- a/frontend/src/pages/medical/Symptoms.jsx
+++ b/frontend/src/pages/medical/Symptoms.jsx
@@ -1,4 +1,5 @@
 import logger from '../../services/logger';
+import { getTodayString } from '../../utils/dateUtils';
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useFormSubmissionWithUploads } from '../../hooks/useFormSubmissionWithUploads';
@@ -89,9 +90,7 @@ const Symptoms = () => {
   // Default occurrence form state - used for both initial state and reset
   const getDefaultOccurrenceFormData = useCallback(
     (withTodayDate = false) => ({
-      occurrence_date: withTodayDate
-        ? new Date().toISOString().split('T')[0]
-        : '',
+      occurrence_date: withTodayDate ? getTodayString() : '',
       occurrence_time: '',
       severity: 'moderate',
       pain_scale: '',
@@ -219,7 +218,7 @@ const Symptoms = () => {
     setSymptomFormData({
       symptom_name: '',
       category: '',
-      first_occurrence_date: new Date().toISOString().split('T')[0],
+      first_occurrence_date: getTodayString(),
       status: 'active',
       is_chronic: false,
       resolved_date: '',
@@ -259,7 +258,7 @@ const Symptoms = () => {
       if (name === 'status') {
         if (value === 'resolved' && !prev.resolved_date) {
           // Auto-fill resolved_date with today when status changes to resolved
-          updated.resolved_date = new Date().toISOString().split('T')[0];
+          updated.resolved_date = getTodayString();
         } else if (value !== 'resolved') {
           // Clear resolved_date when status changes away from resolved
           updated.resolved_date = '';

--- a/frontend/src/pages/medical/__tests__/Symptoms.dates.test.jsx
+++ b/frontend/src/pages/medical/__tests__/Symptoms.dates.test.jsx
@@ -236,6 +236,7 @@ const DIVERGENT_INSTANT = IS_EAST_OF_UTC
 
 const EXPECTED_LOCAL_DATE = '2026-07-30';
 
+/** Render the Symptoms page and flush the async loading effect. */
 async function renderAndWait() {
   render(
     <BrowserRouter>

--- a/frontend/src/pages/medical/__tests__/Symptoms.dates.test.jsx
+++ b/frontend/src/pages/medical/__tests__/Symptoms.dates.test.jsx
@@ -260,14 +260,16 @@ describe('Symptoms page - date auto-fill uses the local date, not UTC', () => {
     vi.useRealTimers();
   });
 
-  it('confirms the pinned clock actually straddles the date line', () => {
-    // Precondition for the assertions below. Skipped only when CI runs in UTC,
-    // where no local/UTC divergence is possible.
-    if (!DIVERGES_FROM_UTC) return;
-    expect(new Date().toISOString().split('T')[0]).not.toBe(
-      EXPECTED_LOCAL_DATE
-    );
-  });
+  it.runIf(DIVERGES_FROM_UTC)(
+    'confirms the pinned clock actually straddles the date line',
+    () => {
+      // Precondition for the assertions below. Reported as skipped when CI
+      // runs in UTC, where no local/UTC divergence is possible.
+      expect(new Date().toISOString().split('T')[0]).not.toBe(
+        EXPECTED_LOCAL_DATE
+      );
+    }
+  );
 
   it('defaults a new symptom first occurrence date to the local date', async () => {
     await renderAndWait();

--- a/frontend/src/pages/medical/__tests__/Symptoms.dates.test.jsx
+++ b/frontend/src/pages/medical/__tests__/Symptoms.dates.test.jsx
@@ -1,0 +1,322 @@
+/**
+ * Timezone regression tests for the Symptoms page date auto-fills.
+ *
+ * Three fields default to "today": the new-symptom first occurrence date, the
+ * new-occurrence date, and the resolved date that appears when status becomes
+ * "resolved". All three previously used
+ * `new Date().toISOString().split('T')[0]`, which yields the *UTC* calendar
+ * date. For users west of UTC that auto-filled tomorrow's date during evening
+ * hours, which then failed "cannot be in the future" validation and made it
+ * impossible to save.
+ *
+ * Vitest workers resolve the timezone once at startup, so it cannot be switched
+ * mid-run. Instead the clock is pinned with the *local-time* Date constructor,
+ * making the expected calendar date identical in every timezone while the hour
+ * is chosen so local and UTC genuinely disagree.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: key => key,
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
+  Trans: ({ i18nKey, children }) => i18nKey || children,
+  initReactI18next: { type: '3rdParty', init: vi.fn() },
+}));
+import { BrowserRouter } from 'react-router-dom';
+
+const { mockGetAll, stablePatientData, viewingSymptom } = vi.hoisted(() => ({
+  mockGetAll: vi.fn(() => Promise.resolve([])),
+  stablePatientData: {
+    patient: { patient: { id: 1, first_name: 'John', last_name: 'Doe' } },
+    practitioners: { practitioners: [] },
+    pharmacies: { pharmacies: [] },
+  },
+  viewingSymptom: { id: 7, symptom_name: 'dysesthesia neuropathy' },
+}));
+
+vi.mock('../../../services/api/symptomApi', () => ({
+  symptomApi: {
+    getAll: mockGetAll,
+    create: vi.fn(() => Promise.resolve({})),
+    update: vi.fn(() => Promise.resolve({})),
+    delete: vi.fn(() => Promise.resolve({})),
+    createOccurrence: vi.fn(() => Promise.resolve({})),
+    updateOccurrence: vi.fn(() => Promise.resolve({})),
+  },
+}));
+
+vi.mock('../../../hooks/useGlobalData', () => ({
+  usePatientWithStaticData: () => stablePatientData,
+  useCurrentPatient: () => ({
+    patient: { id: 1, owner_user_id: 1, permission_level: 'full' },
+    loading: false,
+  }),
+}));
+
+vi.mock('../../../hooks/usePatientPermissions', () => ({
+  usePatientPermissions: () => ({
+    isOwner: true,
+    permissionLevel: 'full',
+    canCreate: true,
+    canEdit: true,
+    canDelete: true,
+    isViewOnly: false,
+    viewOnlyTooltip: undefined,
+  }),
+}));
+
+// Report the view modal as open so its onLogEpisode wiring is reachable.
+vi.mock('../../../hooks/useViewModalNavigation', () => ({
+  useViewModalNavigation: () => ({
+    isOpen: true,
+    viewingItem: viewingSymptom,
+    openModal: vi.fn(),
+    closeModal: vi.fn(),
+  }),
+}));
+
+vi.mock('../../../hooks/useDateFormat', () => ({
+  useDateFormat: () => ({ formatDate: d => d || '' }),
+}));
+
+vi.mock('../../../services/logger', () => ({
+  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@mantine/core', () => ({
+  MantineProvider: ({ children }) => <div>{children}</div>,
+  Container: ({ children }) => <div>{children}</div>,
+  Paper: ({ children }) => <div>{children}</div>,
+  Text: ({ children }) => <span>{children}</span>,
+  Stack: ({ children }) => <div>{children}</div>,
+  Alert: ({ children }) => <div>{children}</div>,
+  Tabs: Object.assign(({ children }) => <div>{children}</div>, {
+    List: ({ children }) => <div>{children}</div>,
+    Tab: ({ children, value }) => (
+      <button data-value={value}>{children}</button>
+    ),
+    Panel: ({ children }) => <div>{children}</div>,
+  }),
+  Badge: ({ children }) => <span>{children}</span>,
+  Button: ({ children, onClick, disabled }) => (
+    <button onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+  Group: ({ children }) => <div>{children}</div>,
+  createTheme: () => ({}),
+  useMantineColorScheme: () => ({
+    colorScheme: 'light',
+    setColorScheme: vi.fn(),
+  }),
+}));
+
+vi.mock('@tabler/icons-react', () => ({
+  IconStethoscope: props => <span {...props} />,
+  IconPlus: props => <span {...props} />,
+  IconTrash: props => <span {...props} />,
+  IconTimeline: props => <span {...props} />,
+  IconCalendar: props => <span {...props} />,
+  IconList: props => <span {...props} />,
+  IconEye: props => <span {...props} />,
+  IconNote: props => <span {...props} />,
+  IconEdit: props => <span {...props} />,
+}));
+
+/**
+ * Surfaces the symptom form state and lets tests drive onInputChange the same
+ * way the real Mantine Select/DateInput controls do.
+ */
+vi.mock('../../../components/medical/MantineSymptomForm', () => ({
+  default: ({ isOpen, formData, onInputChange }) => {
+    if (!isOpen) return null;
+    const change = (name, value) =>
+      onInputChange({ target: { name, value, type: 'text' } });
+    return (
+      <div data-testid="symptom-form">
+        <span data-testid="first-occurrence-date">
+          {formData.first_occurrence_date}
+        </span>
+        <span data-testid="resolved-date">{formData.resolved_date}</span>
+        <button
+          data-testid="status-resolved"
+          onClick={() => change('status', 'resolved')}
+        />
+        <button
+          data-testid="status-active"
+          onClick={() => change('status', 'active')}
+        />
+        <button
+          data-testid="type-resolved-date"
+          onClick={() => change('resolved_date', '2026-07-01')}
+        />
+      </div>
+    );
+  },
+}));
+
+vi.mock('../../../components/medical/MantineSymptomOccurrenceForm', () => ({
+  default: ({ isOpen, formData }) => {
+    if (!isOpen) return null;
+    return (
+      <div data-testid="occurrence-form">
+        <span data-testid="occurrence-date">{formData.occurrence_date}</span>
+      </div>
+    );
+  },
+}));
+
+vi.mock('../../../components/medical/SymptomTimeline', () => ({
+  default: () => <div />,
+}));
+
+vi.mock('../../../components/medical/SymptomCalendar', () => ({
+  default: () => <div />,
+}));
+
+vi.mock('../../../components/medical/symptoms', () => ({
+  SymptomViewModal: ({ isOpen, symptom, onLogEpisode }) =>
+    isOpen ? (
+      <button
+        data-testid="log-episode-btn"
+        onClick={() => onLogEpisode(symptom)}
+      />
+    ) : null,
+}));
+
+vi.mock('../../../components/shared/MedicalPageLoading', () => ({
+  default: () => <div />,
+}));
+
+vi.mock('../../../components/shared/MedicalPageAlerts', () => ({
+  default: () => <div />,
+}));
+
+vi.mock('../../../components/shared/MedicalPageActions', () => ({
+  default: ({ primaryAction }) => (
+    <div>
+      {primaryAction && (
+        <button onClick={primaryAction.onClick} data-testid="add-symptom-btn" />
+      )}
+    </div>
+  ),
+}));
+
+vi.mock('../../../components', () => ({
+  PageHeader: () => <div />,
+}));
+
+vi.mock('../../../constants/symptomEnums', () => ({
+  SYMPTOM_STATUS_COLORS: {
+    active: 'green',
+    resolved: 'gray',
+    recurring: 'orange',
+    monitoring: 'blue',
+  },
+}));
+
+import Symptoms from '../Symptoms';
+
+/** Minutes UTC is ahead of local time; positive west of UTC (e.g. 420 for PDT). */
+const UTC_OFFSET_MINUTES = new Date(2026, 6, 30).getTimezoneOffset();
+const IS_EAST_OF_UTC = UTC_OFFSET_MINUTES < 0;
+const DIVERGES_FROM_UTC = UTC_OFFSET_MINUTES !== 0;
+
+/**
+ * Local Thu 2026-07-30 at whichever edge of the day puts the UTC clock on a
+ * different calendar date than the user's own.
+ */
+const DIVERGENT_INSTANT = IS_EAST_OF_UTC
+  ? new Date(2026, 6, 30, 0, 30, 0)
+  : new Date(2026, 6, 30, 23, 30, 0);
+
+const EXPECTED_LOCAL_DATE = '2026-07-30';
+
+async function renderAndWait() {
+  render(
+    <BrowserRouter>
+      <Symptoms />
+    </BrowserRouter>
+  );
+  await act(async () => {
+    await new Promise(resolve => setTimeout(resolve, 0));
+  });
+}
+
+describe('Symptoms page - date auto-fill uses the local date, not UTC', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAll.mockImplementation(() => Promise.resolve([]));
+    // Fake only Date so real timers keep driving React's async effects.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(DIVERGENT_INSTANT);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('confirms the pinned clock actually straddles the date line', () => {
+    // Precondition for the assertions below. Skipped only when CI runs in UTC,
+    // where no local/UTC divergence is possible.
+    if (!DIVERGES_FROM_UTC) return;
+    expect(new Date().toISOString().split('T')[0]).not.toBe(
+      EXPECTED_LOCAL_DATE
+    );
+  });
+
+  it('defaults a new symptom first occurrence date to the local date', async () => {
+    await renderAndWait();
+
+    fireEvent.click(screen.getByTestId('add-symptom-btn'));
+
+    expect(screen.getByTestId('first-occurrence-date')).toHaveTextContent(
+      EXPECTED_LOCAL_DATE
+    );
+  });
+
+  it('auto-fills the resolved date with the local date when status becomes resolved', async () => {
+    await renderAndWait();
+    fireEvent.click(screen.getByTestId('add-symptom-btn'));
+
+    fireEvent.click(screen.getByTestId('status-resolved'));
+
+    expect(screen.getByTestId('resolved-date')).toHaveTextContent(
+      EXPECTED_LOCAL_DATE
+    );
+  });
+
+  it('does not auto-fill a resolved date the user already entered', async () => {
+    await renderAndWait();
+    fireEvent.click(screen.getByTestId('add-symptom-btn'));
+
+    fireEvent.click(screen.getByTestId('type-resolved-date'));
+    fireEvent.click(screen.getByTestId('status-resolved'));
+
+    expect(screen.getByTestId('resolved-date')).toHaveTextContent('2026-07-01');
+  });
+
+  it('clears the resolved date when status moves away from resolved', async () => {
+    await renderAndWait();
+    fireEvent.click(screen.getByTestId('add-symptom-btn'));
+    fireEvent.click(screen.getByTestId('status-resolved'));
+
+    fireEvent.click(screen.getByTestId('status-active'));
+
+    expect(screen.getByTestId('resolved-date')).toBeEmptyDOMElement();
+  });
+
+  it('defaults a newly logged episode to the local date', async () => {
+    await renderAndWait();
+
+    fireEvent.click(screen.getByTestId('log-episode-btn'));
+
+    expect(screen.getByTestId('occurrence-date')).toHaveTextContent(
+      EXPECTED_LOCAL_DATE
+    );
+  });
+});

--- a/frontend/src/utils/dateUtils.timezone.test.js
+++ b/frontend/src/utils/dateUtils.timezone.test.js
@@ -1,0 +1,149 @@
+/**
+ * Timezone regression tests for the "today as YYYY-MM-DD" helpers.
+ *
+ * Guards against reintroducing `new Date().toISOString().split('T')[0]`, which
+ * returns the *UTC* calendar date rather than the user's *local* one. Symptom
+ * date fields auto-populated with that pattern handed users west of UTC a date
+ * one day in the future, which then failed "cannot be in the future" validation
+ * and blocked saving entirely during evening hours.
+ *
+ * Why these tests look the way they do
+ * ------------------------------------
+ * Vitest workers resolve the timezone once at startup, so `process.env.TZ` and
+ * `vi.stubEnv('TZ', ...)` cannot switch it mid-run - a per-timezone matrix is
+ * not achievable in-process. Instead every instant here is built with the
+ * *local-time* Date constructor (`new Date(y, m, d, H, M)`), so the expected
+ * calendar date is the same no matter which timezone CI happens to run in,
+ * while the hour is chosen so local and UTC genuinely disagree.
+ *
+ * These tests assert observable behaviour rather than mocking Date's getters,
+ * so they stay valid if the implementation is refactored (e.g. to
+ * `toLocaleDateString('en-CA')`) and still fail if it regresses back to UTC.
+ */
+import { describe, test, expect, afterEach, vi } from 'vitest';
+import { getTodayString, formatDateForAPI, isDateInFuture } from './dateUtils';
+
+/** Minutes UTC is ahead of local time; positive west of UTC (e.g. 420 for PDT). */
+const UTC_OFFSET_MINUTES = new Date(2026, 6, 30).getTimezoneOffset();
+const IS_WEST_OF_UTC = UTC_OFFSET_MINUTES > 0;
+const IS_EAST_OF_UTC = UTC_OFFSET_MINUTES < 0;
+const DIVERGES_FROM_UTC = IS_WEST_OF_UTC || IS_EAST_OF_UTC;
+
+/**
+ * Local Thu 2026-07-30 at the edge of the day, in whatever timezone the test
+ * runner is in. West of UTC, 23:30 local has already rolled over to Jul 31 in
+ * UTC; east of UTC, 00:30 local is still Jul 29 in UTC. Either way the correct
+ * local answer is 2026-07-30.
+ */
+const LOCAL_LATE_EVENING = new Date(2026, 6, 30, 23, 30, 0);
+const LOCAL_EARLY_MORNING = new Date(2026, 6, 30, 0, 30, 0);
+
+/** The instant most likely to expose a UTC-based implementation here. */
+const DIVERGENT_INSTANT = IS_EAST_OF_UTC
+  ? LOCAL_EARLY_MORNING
+  : LOCAL_LATE_EVENING;
+
+/** What the old, buggy implementation would have produced. */
+const utcDateString = () => new Date().toISOString().split('T')[0];
+
+function at(instant, fn) {
+  vi.useFakeTimers();
+  vi.setSystemTime(instant);
+  return fn();
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('getTodayString - returns the local calendar date, never the UTC one', () => {
+  test('at 23:30 local, still reports today rather than tomorrow', () => {
+    at(LOCAL_LATE_EVENING, () => {
+      expect(getTodayString()).toBe('2026-07-30');
+    });
+  });
+
+  test('at 00:30 local, still reports today rather than yesterday', () => {
+    at(LOCAL_EARLY_MORNING, () => {
+      expect(getTodayString()).toBe('2026-07-30');
+    });
+  });
+
+  test.runIf(DIVERGES_FROM_UTC)(
+    'disagrees with the UTC date exactly when the two calendars differ',
+    () => {
+      at(DIVERGENT_INSTANT, () => {
+        // Precondition: this instant really does straddle the date line.
+        expect(utcDateString()).not.toBe('2026-07-30');
+
+        expect(getTodayString()).toBe('2026-07-30');
+        expect(getTodayString()).not.toBe(utcDateString());
+      });
+    }
+  );
+
+  test.runIf(!DIVERGES_FROM_UTC)(
+    'agrees with the UTC date when the runner is in UTC',
+    () => {
+      at(LOCAL_LATE_EVENING, () => {
+        expect(getTodayString()).toBe(utcDateString());
+      });
+    }
+  );
+
+  test('zero-pads single-digit months and days', () => {
+    at(new Date(2026, 0, 5, 23, 30, 0), () => {
+      expect(getTodayString()).toBe('2026-01-05');
+    });
+  });
+
+  test('stays correct on a DST transition date', () => {
+    // 2026-03-08 is the US spring-forward date. Midday avoids the skipped hour
+    // so this is a valid wall-clock time in every timezone.
+    at(new Date(2026, 2, 8, 12, 0, 0), () => {
+      expect(getTodayString()).toBe('2026-03-08');
+    });
+  });
+});
+
+describe('getTodayString feeds validation without tripping it', () => {
+  /**
+   * The actual user-visible contract behind the bug: whatever the form
+   * auto-fills must survive the "cannot be in the future" check. Under the old
+   * UTC implementation this assertion failed for the whole evening.
+   */
+  test('the auto-filled value is never considered a future date', () => {
+    at(DIVERGENT_INSTANT, () => {
+      expect(isDateInFuture(getTodayString())).toBe(false);
+    });
+  });
+
+  test('a genuinely future date is still rejected', () => {
+    at(DIVERGENT_INSTANT, () => {
+      expect(isDateInFuture('2026-08-15')).toBe(true);
+    });
+  });
+});
+
+describe('formatDateForAPI - formats a Date by its local parts', () => {
+  test.runIf(DIVERGES_FROM_UTC)(
+    'uses local date parts rather than the UTC ones',
+    () => {
+      at(DIVERGENT_INSTANT, () => {
+        const now = new Date();
+
+        expect(now.toISOString().split('T')[0]).not.toBe('2026-07-30');
+        expect(formatDateForAPI(now)).toBe('2026-07-30');
+      });
+    }
+  );
+
+  test('passes through an existing YYYY-MM-DD string untouched', () => {
+    expect(formatDateForAPI('2026-07-30')).toBe('2026-07-30');
+  });
+
+  test('returns null for empty input', () => {
+    expect(formatDateForAPI(null)).toBeNull();
+    expect(formatDateForAPI('')).toBeNull();
+  });
+});

--- a/frontend/src/utils/dateUtils.timezone.test.js
+++ b/frontend/src/utils/dateUtils.timezone.test.js
@@ -46,6 +46,7 @@ const DIVERGENT_INSTANT = IS_EAST_OF_UTC
 /** What the old, buggy implementation would have produced. */
 const utcDateString = () => new Date().toISOString().split('T')[0];
 
+/** Run `fn` with the system clock pinned to `instant`, restoring real timers after. */
 function at(instant, fn) {
   vi.useFakeTimers();
   vi.setSystemTime(instant);


### PR DESCRIPTION
## Summary

Symptom date fields derived "today" with `new Date().toISOString().split('T')[0]`, which returns the UTC calendar date rather than the user's local one. For users west of UTC this filled in tomorrow's date during evening hours, and the date picker's `maxDate` then blocked saving, making it impossible to mark a symptom resolved. Full details in #945.

This replaces the three affected call sites in `Symptoms.jsx` with the existing `getTodayString()` helper from `dateUtils.js`, which already reads the local calendar date via `Date`'s local getters.

```diff
-      first_occurrence_date: new Date().toISOString().split('T')[0],
+      first_occurrence_date: getTodayString(),
```

I used the existing helper rather than adding a new one so the codebase keeps a single way to get today's date as a string. The same local-getter approach already backs `getTodayEndOfDay()` and `isDateInFuture()` in that file.

The fix is direction-neutral. `getFullYear()`, `getMonth()` and `getDate()` read the local date straight from the browser, so it is correct both west and east of UTC, with no locale or offset assumptions.

## Related issue

Closes #945

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Translation / i18n
- [ ] Other

## Testing

Two new test files, 17 tests. Both were checked by putting the bug back and confirming they fail, since a regression test that passes on the original defect is not worth much. Reintroducing it breaks 4 tests in the helper file and 3 in the page file, one per call site.

- `frontend/src/utils/dateUtils.timezone.test.js` covers `getTodayString()`, `formatDateForAPI()` and `isDateInFuture()`. The key assertion states the actual contract, that whatever the form fills in has to survive the future-date check.
- `frontend/src/pages/medical/__tests__/Symptoms.dates.test.jsx` mounts the page, reusing the mock setup from the existing `Symptoms.translations.test.jsx`, and covers all three call sites plus the guard that stops the auto-fill overwriting a date the user typed.

One note on how the tests are written. Vitest workers resolve the timezone once at startup, so `process.env.TZ` and `vi.stubEnv('TZ', ...)` cannot switch it mid-run and a per-timezone matrix is not possible. The tests instead pin the clock with the local-time `Date` constructor, so the expected date is the same under any CI timezone, while the hour is picked from the runner's real UTC offset so local and UTC land on different dates. Assertions that need that divergence are guarded with `test.runIf`, so the suite is still correct if CI runs in UTC.

Also verified manually against a local dev instance: the resolved date fill, the occurrence date default, the first occurrence default, the don't-overwrite guard, and clear-on-status-change all produce the correct local date.

Full frontend suite: 2779 passed, 12 skipped, with 2 pre-existing failures in `HistoryByDiseaseView.test.tsx` and `LabResultFormWrapper.test.tsx` that are unrelated to this change and fail the same way on a clean checkout.

## A related backend issue, not changed here

While tracing this I found something adjacent that this PR does not touch, but which interacts with it.

`app/schemas/validators.py` checks future dates against `date.today()`, which resolves in the server's timezone and knows nothing about the user's. Local dates worldwide span 26 hours, from UTC-12 to UTC+14, so no single server-side date is correct for everyone.

That means this fix can surface a problem for users **ahead** of the server. A user in Tokyo at 8am on Jul 31, with the backend on UTC, now sends `2026-07-31` where before it sent `2026-07-30`. The server's `date.today()` is still `2026-07-30`, so the value is rejected. Before this change it saved, but stored a date one day behind what the user saw.

A bounded tolerance would fix it without an API change. Since a user's local date can be at most one day ahead of UTC, comparing against the current date at UTC+14 expresses exactly that limit:

```python
# Latest calendar date in effect anywhere on Earth (UTC+14).
max_valid_date = (datetime.now(timezone.utc) + timedelta(hours=14)).date()
if value > max_valid_date:
    raise ValueError(f"{field_name} cannot be in the future")
```

Applied in `validate_date_not_future` itself this would cover all 20 call sites across the `condition`, `injury`, `encounter`, `patient` and `symptom` schemas at once.

I kept it out of this PR because it touches a validator shared by five schemas and deserves its own review. **Happy to open that as a separate PR if you want it**, using this bound or whatever you would prefer.

## Also left alone

The same `toISOString()` pattern appears in eight other files. Some look harmless, such as the trends panels that only use the date as a CSV filename suffix. Others may be real bugs of a different shape, particularly `SymptomCalendar.jsx` and `SymptomTimeline.jsx`, which build calendar cell keys and query ranges from it. Those need their own investigation and I did not want to fold an unverified broader change into this one.

## Checklist

- [x] Tests added or updated. 17 new regression tests.
- [x] `npm run lint` and `npm run build` pass.
- [x] Backend tests pass (pytest) if backend code changed. N/A, no backend code changed.
- [x] No PHI, secrets, or console.log left in the diff.
- [x] User-facing strings go through `t()` translations. N/A, no strings added.
- [x] Documentation updated if API, schema, or service behavior changed. N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected symptom dates to consistently use the user’s local calendar date, including occurrence, resolution, and logged episode dates.
  * Preserved manually entered resolution dates and cleared them when a symptom is no longer marked resolved.
  * Improved date handling across timezone boundaries, daylight saving changes, formatting, validation, and empty values.

* **Tests**
  * Added regression coverage for local-date and timezone-related behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->