### PR TITLE
fix: enhance future date validation with timezone tolerance 

### DIFF
--- a/app/schemas/validators.py
+++ b/app/schemas/validators.py
@@ -18,7 +18,7 @@ Usage:
 """
 
 import re
-from datetime import date
+from datetime import date, datetime, timedelta, timezone
 from typing import List, Optional
 
 
@@ -141,6 +141,16 @@ def validate_date_not_future(
     """
     Validate that a date is not in the future.
 
+    The "future" bound is timezone-tolerant. The server cannot know the
+    submitting user's timezone, and local calendar dates worldwide span 26
+    hours (UTC-12 to UTC+14). A user's local date can therefore be at most one
+    day ahead of UTC, so we compare against the current date at UTC+14 (the
+    earliest timezone on Earth). This avoids rejecting a user's genuine "today"
+    when they are ahead of the server, at the cost of accepting a date up to
+    roughly one day early. That is the correct direction for a backstop guard
+    whose purpose is to catch obvious data-entry mistakes, not to be a precise
+    clock. See PR fixing symptom date auto-fill (#945/#946) for context.
+
     Args:
         value: The date to validate
         field_name: Name of the field for error messages
@@ -155,12 +165,14 @@ def validate_date_not_future(
     if value is None:
         return None
 
-    today = date.today()
+    # Latest calendar date in effect anywhere on Earth (UTC+14).
+    max_valid_date = (datetime.now(timezone.utc) + timedelta(hours=14)).date()
 
-    if value > today:
+    if value > max_valid_date:
         raise ValueError(f"{field_name} cannot be in the future")
 
     if max_years_past is not None:
+        today = date.today()
         if today.year - value.year > max_years_past:
             raise ValueError(
                 f"{field_name} cannot be more than {max_years_past} years ago"

--- a/tests/schemas/test_validators.py
+++ b/tests/schemas/test_validators.py
@@ -1,0 +1,115 @@
+"""
+Tests for shared schema validators.
+
+Focus is on ``validate_date_not_future`` and its timezone-tolerant "future"
+bound. The server cannot know the submitting user's timezone, so the check
+compares against the current date at UTC+14 (the earliest timezone on Earth).
+This is the backend half of the symptom date-auto-fill fix (#945/#946): once
+the frontend sends the user's genuine local date, a user *ahead* of the server
+(e.g. Tokyo with a UTC backend) must not be rejected for submitting "today".
+
+The clock is pinned by patching ``datetime`` inside the validators module (the
+project does not depend on freezegun), so assertions are deterministic
+regardless of the CI runner's timezone.
+"""
+
+from datetime import date, datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+from app.schemas.validators import validate_date_not_future
+
+
+class _FixedDatetime(datetime):
+    """datetime subclass whose ``now(tz)`` returns a pinned instant."""
+
+    _pinned = None
+
+    @classmethod
+    def now(cls, tz=None):
+        assert cls._pinned is not None, "pin the clock with pinned_utc()"
+        if tz is None:
+            return cls._pinned.replace(tzinfo=None)
+        return cls._pinned.astimezone(tz)
+
+
+def pinned_utc(year, month, day, hour=12, minute=0):
+    """Patch the validators module clock to a fixed UTC instant."""
+    _FixedDatetime._pinned = datetime(
+        year, month, day, hour, minute, tzinfo=timezone.utc
+    )
+    return patch("app.schemas.validators.datetime", _FixedDatetime)
+
+
+def test_none_passes_through():
+    assert validate_date_not_future(None) is None
+
+
+def test_today_is_accepted():
+    # The core regression: the server's own "today" must always validate.
+    with pinned_utc(2026, 7, 30, hour=12):
+        assert validate_date_not_future(date(2026, 7, 30)) == date(2026, 7, 30)
+
+
+def test_past_date_is_accepted():
+    with pinned_utc(2026, 7, 30, hour=12):
+        assert validate_date_not_future(date(2020, 1, 1)) == date(2020, 1, 1)
+
+
+def test_east_of_utc_local_date_is_accepted():
+    """
+    A user ahead of the server sends tomorrow's UTC-date as their local
+    "today". With UTC late in the day, UTC+14 has already rolled over, so the
+    date is accepted rather than rejected as future.
+    """
+    # UTC 2026-07-30 23:00 -> +14h = 2026-07-31 13:00 -> bound is 2026-07-31.
+    with pinned_utc(2026, 7, 30, hour=23):
+        assert validate_date_not_future(date(2026, 7, 31)) == date(2026, 7, 31)
+
+
+def test_genuine_future_date_is_rejected():
+    """Two days ahead of UTC is beyond any real timezone and must fail."""
+    with pinned_utc(2026, 7, 30, hour=23):
+        with pytest.raises(ValueError, match="cannot be in the future"):
+            validate_date_not_future(date(2026, 8, 1))
+
+
+def test_tomorrow_rejected_when_utc_is_early_in_the_day():
+    """
+    Early in the UTC day, even UTC+14 has not reached tomorrow, so a next-day
+    date cannot correspond to anyone's local "today" and is rejected.
+    """
+    # UTC 2026-07-30 03:00 -> +14h = 2026-07-30 17:00 -> bound stays 2026-07-30.
+    with pinned_utc(2026, 7, 30, hour=3):
+        with pytest.raises(ValueError, match="cannot be in the future"):
+            validate_date_not_future(date(2026, 7, 31))
+
+
+def test_field_name_appears_in_error_message():
+    with pinned_utc(2026, 7, 30, hour=3):
+        with pytest.raises(ValueError, match="Onset date cannot be in the future"):
+            validate_date_not_future(date(2026, 12, 1), field_name="Onset date")
+
+
+def test_max_years_past_rejects_too_old():
+    with pinned_utc(2026, 7, 30, hour=12):
+        with pytest.raises(ValueError, match="cannot be more than 150 years ago"):
+            validate_date_not_future(
+                date(1850, 1, 1), field_name="Birth date", max_years_past=150
+            )
+
+
+def test_max_years_past_accepts_within_bound():
+    with pinned_utc(2026, 7, 30, hour=12):
+        assert validate_date_not_future(
+            date(1990, 5, 20), field_name="Birth date", max_years_past=150
+        ) == date(1990, 5, 20)
+
+
+def test_bound_tracks_the_real_utc14_date():
+    """Without pinning, the accepted upper bound is the live UTC+14 date."""
+    expected = (datetime.now(timezone.utc) + timedelta(hours=14)).date()
+    assert validate_date_not_future(expected) == expected
+    with pytest.raises(ValueError, match="cannot be in the future"):
+        validate_date_not_future(expected + timedelta(days=1))

--- a/tests/schemas/test_validators.py
+++ b/tests/schemas/test_validators.py
@@ -111,5 +111,10 @@ def test_bound_tracks_the_real_utc14_date():
     """Without pinning, the accepted upper bound is the live UTC+14 date."""
     expected = (datetime.now(timezone.utc) + timedelta(hours=14)).date()
     assert validate_date_not_future(expected) == expected
+    # Reject with +2 days rather than +1: the validator recomputes its bound on
+    # each call, so if the UTC+14 clock crosses midnight between capturing
+    # `expected` and this call, the live bound would be expected+1 and a +1
+    # assertion would flake. The exact expected+1 boundary is covered by the
+    # pinned-clock tests above.
     with pytest.raises(ValueError, match="cannot be in the future"):
-        validate_date_not_future(expected + timedelta(days=1))
+        validate_date_not_future(expected + timedelta(days=2))


### PR DESCRIPTION
## Summary

This pull request improves the date validation logic to be tolerant of user timezones and adds comprehensive tests for this behavior. The main change ensures that a date is not considered "in the future" as long as it is valid in any timezone worldwide (up to UTC+14), preventing accidental rejections for users ahead of the server's timezone. This is especially important for accurately handling user-submitted dates such as symptom onset dates.

The most important changes are:

**Timezone-tolerant date validation:**
* Updated `validate_date_not_future` in `validators.py` to compare against the current date at UTC+14, the earliest timezone on Earth, instead of the server's local date. This prevents rejecting valid dates for users ahead of the server in timezones like Asia/Tokyo. [[1]](diffhunk://#diff-6928bdf23b73c7411252afc76d1e28f4b2cd96fdf3bd283ff2bfc8f85df74623R144-R153) [[2]](diffhunk://#diff-6928bdf23b73c7411252afc76d1e28f4b2cd96fdf3bd283ff2bfc8f85df74623L158-R175)
* Improved documentation in the function docstring to explain the rationale for this timezone-tolerant approach and its implications.

**Testing improvements:**
* Added a new test module `test_validators.py` with extensive tests for the updated date validation logic, including timezone edge cases and error messages. The tests use a patched `datetime` to ensure deterministic behavior regardless of the CI runner's timezone.

**Dependency updates:**
* Updated imports in `validators.py` to include `datetime`, `timedelta`, and `timezone` for the new validation logic.


## Related issue


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Translation / i18n
- [ ] Other


## Checklist

- [x] Tests added or updated (or N/A with reason)
- [x] `npm run lint` and `npm run build` pass
- [x] Backend tests pass (`pytest`) if backend code changed
- [ ] No PHI, secrets, or `console.log` left in the diff
- [ ] User-facing strings go through `t()` translations
- [ ] Documentation updated if API, schema, or service behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date validation to consistently handle timezone differences, including regions up to UTC+14.
  * Prevented valid dates from being incorrectly rejected based on the server’s local timezone.
  * Preserved clear validation errors for future dates and dates exceeding the allowed age.
  * Date checks now behave consistently across supported timezones and calendar boundaries.

* **Tests**
  * Added comprehensive coverage for date boundaries, optional values, future dates, and maximum-age rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->