### PR TITLE
Add hemoglobin fraction test definitions

### DIFF
--- a/shared/data/test_library.json
+++ b/shared/data/test_library.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.8.0",
-  "lastUpdated": "2026-05-23",
+  "version": "1.9.0",
+  "lastUpdated": "2026-08-01",
   "tests": [
     {
       "test_name": "Alanine Aminotransferase",
@@ -2392,6 +2392,49 @@
       "is_common": false,
       "result_type": "qualitative",
       "display_order": 163
+    },
+    {
+      "test_name": "Hemoglobin A",
+      "abbreviation": "HbA",
+      "test_code": "4546-8",
+      "default_unit": "%",
+      "category": "hematology",
+      "common_names": [
+        "HbA",
+        "Hgb A"
+      ],
+      "is_common": false,
+      "display_order": 164,
+      "result_type": "quantitative"
+    },
+    {
+      "test_name": "Hemoglobin A2",
+      "abbreviation": "HbA2",
+      "test_code": "4551-8",
+      "default_unit": "%",
+      "category": "hematology",
+      "common_names": [
+        "HbA2",
+        "Hgb A2"
+      ],
+      "is_common": false,
+      "display_order": 165,
+      "result_type": "quantitative"
+    },
+    {
+      "test_name": "Hemoglobin F",
+      "abbreviation": "HbF",
+      "test_code": "4576-5",
+      "default_unit": "%",
+      "category": "hematology",
+      "common_names": [
+        "HbF",
+        "Fetal Hemoglobin",
+        "Hgb F"
+      ],
+      "is_common": false,
+      "display_order": 166,
+      "result_type": "quantitative"
     }
   ]
 }

--- a/tests/services/test_canonical_test_matching.py
+++ b/tests/services/test_canonical_test_matching.py
@@ -322,6 +322,23 @@ class TestCanonicalTestMatchingService:
             result = matching_service.find_canonical_match(variation)
             assert result == "Hemoglobin A1c", f"Failed to match: {variation}"
 
+    def test_hemoglobin_fraction_matching(self, matching_service):
+        """Test exact matching for hemoglobin fraction names."""
+        expected_matches = {
+            "Hemoglobin A": "Hemoglobin A",
+            "HbA": "Hemoglobin A",
+            "Hgb A": "Hemoglobin A",
+            "Hemoglobin A2": "Hemoglobin A2",
+            "HbA2": "Hemoglobin A2",
+            "Hgb A2": "Hemoglobin A2",
+            "Hemoglobin F": "Hemoglobin F",
+            "HbF": "Hemoglobin F",
+            "Fetal Hemoglobin": "Hemoglobin F",
+        }
+
+        for variation, expected in expected_matches.items():
+            assert matching_service.find_canonical_match(variation) == expected
+
     def test_thyroid_matching(self, matching_service):
         """Test thyroid test matching."""
         result = matching_service.find_canonical_match("TSH")


### PR DESCRIPTION
## Summary

- Add standardized definitions for Hemoglobin A, Hemoglobin A2, and Hemoglobin F.
- Use method-unspecified LOINC codes with percentage units.
- Add canonical matching coverage for their common English names and abbreviations.

## Why

MediKeep already includes Hemoglobin and Hemoglobin A1c, but the common hemoglobin fractions reported by hemoglobin differentiation panels were missing. Adding separate canonical entries allows HbA, HbA2, and HbF results to be stored and matched without conflating Hemoglobin A with Hemoglobin A1c.

## Validation

- Library validation: 165 tests checked, 0 errors, 0 warnings
- Backend matcher and library tests: 60 passed
- Frontend test-library tests: 13 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added quantitative hematology entries for Hemoglobin A, Hemoglobin A2, and Hemoglobin F, including units, aliases, and LOINC codes.
  * Updated library metadata to version 1.9.0.

* **Bug Fixes**
  * Improved matching for canonical names and abbreviations of hemoglobin fractions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->