### PR TITLE
fix: Correct display_order collision in test library

### DIFF
--- a/shared/data/test_library.json
+++ b/shared/data/test_library.json
@@ -2337,7 +2337,7 @@
       ],
       "is_common": false,
       "result_type": "quantitative",
-      "display_order": 160
+      "display_order": 159
     },
     {
       "test_name": "Alpha-2 Globulin",
@@ -2434,7 +2434,6 @@
         "Neuts Band #"
       ],
       "is_common": false,
-
       "result_type": "quantitative",
       "display_order": 166
     },


### PR DESCRIPTION
## Summary

Alpha-1 Globulin shared display_order 160 with Alpha-2 Globulin after PR #942's field reorder. Restore it to 159 and remove a stray blank line in the Band form Neutrophils (Absolute) entry.

## Related issue

<!-- e.g. "Closes #123" or "N/A" -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Translation / i18n
- [ ] Other

## Testing

<!-- How did you verify this works? Manual steps, screenshots, or test names. -->

## Checklist

- [ ] Tests added or updated (or N/A with reason)
- [ ] `npm run lint` and `npm run build` pass
- [ ] Backend tests pass (`pytest`) if backend code changed
- [ ] No PHI, secrets, or `console.log` left in the diff
- [ ] User-facing strings go through `t()` translations
- [ ] Documentation updated if API, schema, or service behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the display order of the `Alpha-1 Globulin` test.
  * Removed the outdated `"Neuts Band #"` common name from the absolute band-form neutrophils test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->