### PR TITLE
feat: Enhance Epic MyChart parsing with layout-aware extraction

### DIFF
--- a/app/services/lab_parsers/__init__.py
+++ b/app/services/lab_parsers/__init__.py
@@ -5,10 +5,11 @@ This module provides a registry of lab-specific parsers that can automatically
 detect and parse different lab formats (LabCorp, Quest, etc.).
 """
 
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 from .base_parser import BaseLabParser, LabTestResult
-from .epic_mychart_parser import EpicMyChartParser
+from .epic_mychart_card_parser import EpicMyChartCardParser
+from .epic_mychart_parser import EpicMyChartSingleColumnParser
 from .labcorp_parser_v2 import LabCorpParserV2
 from .quest_parser import QuestParser
 
@@ -17,11 +18,25 @@ class LabParserRegistry:
     """Registry for lab-specific parsers."""
 
     def __init__(self):
-        # Register all available parsers
+        # Register all available parsers. Order matters: the first parser whose
+        # can_parse() matches wins.
+        #
+        # The Epic MyChart card parser is tried FIRST because its signature (the
+        # MyChart "Test Details" header, the Epic Systems license, and the
+        # gauge/two-column card structure) is unambiguous and far more specific
+        # than a substring match. MyChart exports of labs performed by LabCorp
+        # or Quest name that lab in the footer, so without this precedence the
+        # LabCorp/Quest parsers would greedily claim them and fail on the Epic
+        # layout. A genuine LabCorp/Quest report never carries the Epic card
+        # signature, so this ordering does not affect their routing.
+        #
+        # The single-column Epic parser is the fallback for simpler Epic text
+        # that lacks the card signature.
         self.parsers: List[BaseLabParser] = [
+            EpicMyChartCardParser(),
             LabCorpParserV2(),  # Using improved V2 parser
             QuestParser(),
-            EpicMyChartParser(),
+            EpicMyChartSingleColumnParser(),
         ]
 
     def get_parser(self, text: str) -> Optional[BaseLabParser]:
@@ -39,24 +54,37 @@ class LabParserRegistry:
                 return parser
         return None
 
-    def parse(self, text: str) -> tuple[List[LabTestResult], str]:
+    def parse(
+        self,
+        text: str,
+        layout_text_provider: Optional[Callable[[], Optional[str]]] = None,
+    ) -> tuple[List[LabTestResult], str]:
         """
         Automatically detect lab and parse results.
 
         Args:
-            text: Extracted PDF text
+            text: Extracted PDF text (plain, used for detection)
+            layout_text_provider: Callable returning layout-preserved text
+                (pdfplumber ``layout=True``). Invoked lazily only when the
+                selected parser sets ``prefers_layout_text``, so the expensive
+                layout extraction is skipped for parsers that do not need it.
 
         Returns:
             (List of test results, lab name)
         """
         parser = self.get_parser(text)
+        if parser is None:
+            # No specific parser found, return empty
+            return [], "Unknown"
 
-        if parser:
-            results = parser.parse(text)
-            return results, parser.LAB_NAME
+        parse_text = text
+        if parser.prefers_layout_text and layout_text_provider is not None:
+            layout_text = layout_text_provider()
+            if layout_text:
+                parse_text = layout_text
 
-        # No specific parser found, return empty
-        return [], "Unknown"
+        results = parser.parse(parse_text)
+        return results, parser.LAB_NAME
 
 
 # Global registry instance
@@ -68,7 +96,8 @@ __all__ = [
     "LabTestResult",
     "LabCorpParserV2",
     "QuestParser",
-    "EpicMyChartParser",
+    "EpicMyChartCardParser",
+    "EpicMyChartSingleColumnParser",
     "LabParserRegistry",
     "lab_parser_registry",
 ]

--- a/app/services/lab_parsers/base_parser.py
+++ b/app/services/lab_parsers/base_parser.py
@@ -164,8 +164,10 @@ class BaseLabParser(ABC):
         # First apply OCR cleanup to handle artifacts
         name = self.clean_ocr_artifacts(name)
 
-        # Remove superscript patterns (01, 02, etc.)
-        name = re.sub(r"\d{2}$", "", name)
+        # Remove superscript footnote markers (01, 02, etc.). Only strip a
+        # trailing 2-digit run that is whitespace-delimited, so significant
+        # digits embedded in a name (e.g. "Vitamin B12") are preserved.
+        name = re.sub(r"\s+\d{2}$", "", name)
         name = re.sub(r"\s+\d{2}\s+", " ", name)
 
         # Remove extra whitespace

--- a/app/services/lab_parsers/base_parser.py
+++ b/app/services/lab_parsers/base_parser.py
@@ -5,7 +5,7 @@ Each lab (LabCorp, Quest, etc.) will have its own parser implementation.
 
 import re
 from abc import ABC, abstractmethod
-from typing import Dict, List
+from typing import Dict, List, Set
 
 
 class LabTestResult:
@@ -20,6 +20,7 @@ class LabTestResult:
         flag: str = "",
         confidence: float = 1.0,
         test_date: str = None,  # Date in YYYY-MM-DD format
+        qualitative_value: str = "",  # Non-numeric result (e.g. "Negative", "3+")
     ):
         self.test_name = test_name
         self.value = value
@@ -28,6 +29,7 @@ class LabTestResult:
         self.flag = flag
         self.confidence = confidence
         self.test_date = test_date
+        self.qualitative_value = qualitative_value
 
     def to_dict(self) -> Dict:
         """Convert to dictionary for serialization."""
@@ -39,6 +41,7 @@ class LabTestResult:
             "flag": self.flag,
             "confidence": self.confidence,
             "test_date": self.test_date,
+            "qualitative_value": self.qualitative_value,
         }
 
 
@@ -49,6 +52,11 @@ class BaseLabParser(ABC):
     """
 
     LAB_NAME = "Generic"
+
+    # When True, the extraction pipeline feeds this parser layout-preserved
+    # text (pdfplumber ``extract_text(layout=True)``) instead of plain text,
+    # so column positions are retained for spatial reconstruction.
+    prefers_layout_text: bool = False
 
     # OCR corruption patterns and their corrections
     # These handle common OCR errors found in scanned lab reports
@@ -189,6 +197,18 @@ class BaseLabParser(ABC):
             r"^(Ref\.?\s*Range:?|Reference:?)\s*", "", range_str, flags=re.IGNORECASE
         )
         return range_str
+
+    @staticmethod
+    def deduplicate(results: List["LabTestResult"]) -> List["LabTestResult"]:
+        """Deduplicate results by test name, keeping the first occurrence."""
+        seen: Set[str] = set()
+        unique = []
+        for result in results:
+            key = result.test_name.lower()
+            if key not in seen:
+                seen.add(key)
+                unique.append(result)
+        return unique
 
     def extract_date_from_text(self, text: str) -> str:
         """

--- a/app/services/lab_parsers/epic_mychart_base_parser.py
+++ b/app/services/lab_parsers/epic_mychart_base_parser.py
@@ -1,0 +1,45 @@
+"""
+Shared base for the Epic MyChart parsers.
+
+Both the single-column parser (``EpicMyChartSingleColumnParser``) and the
+two-column card parser (``EpicMyChartCardParser``) are Epic MyChart exports and
+share the same month-name collection-date format. Behavior common to both lives
+here so it does not drift between the two implementations.
+"""
+
+import re
+from datetime import datetime
+from typing import Optional
+
+from .base_parser import BaseLabParser
+
+
+class EpicMyChartBaseParser(BaseLabParser):
+    """Common Epic MyChart behavior shared by the layout-specific parsers."""
+
+    LAB_NAME = "Epic MyChart"
+
+    # Epic uses month-name dates ("Collected on Jul 07, 2026 3:10 PM").
+    _MONTH_NAME_DATE_PATTERNS = (
+        r"(?i)collected on\s+([A-Z][a-z]+)\s+(\d{1,2}),?\s+(\d{4})",
+        r"(?i)collection date:?\s+([A-Z][a-z]+)\s+(\d{1,2}),?\s+(\d{4})",
+        r"(?i)reported on\s+([A-Z][a-z]+)\s+(\d{1,2}),?\s+(\d{4})",
+    )
+
+    def extract_date_from_text(self, text: str) -> Optional[str]:
+        """
+        Extract the collection date from Epic month-name date fields.
+
+        e.g. "Collected on Jul 07, 2026 3:10 PM" or "Collection date: ...".
+        Falls back to the base numeric (MM/DD/YYYY) extraction.
+        """
+        for pattern in self._MONTH_NAME_DATE_PATTERNS:
+            match = re.search(pattern, text)
+            if match:
+                date_str = f"{match.group(1)} {match.group(2)}, {match.group(3)}"
+                for fmt in ("%B %d, %Y", "%b %d, %Y"):
+                    try:
+                        return datetime.strptime(date_str, fmt).strftime("%Y-%m-%d")
+                    except ValueError:
+                        continue
+        return super().extract_date_from_text(text)

--- a/app/services/lab_parsers/epic_mychart_card_parser.py
+++ b/app/services/lab_parsers/epic_mychart_card_parser.py
@@ -1,0 +1,474 @@
+"""
+Epic MyChart "Test Details" card/gauge PDF parser.
+
+Handles the rich Epic MyChart export whose native text retains a card-based,
+frequently two-column layout with visual gauge bars. Compared to the simple
+single-column stream handled by ``EpicMyChartSingleColumnParser``, this format
+adds several wrinkles that the single-column parser cannot handle:
+
+- Two cards rendered side by side, so test names, "Normal range/value:" lines,
+  and values are merged onto shared text lines.
+- "Normal value:" anchors (qualitative or "Not Estab.") in addition to the
+  numeric "Normal range:" anchors.
+- Value and flag on one line (e.g. "9.9 High").
+- Non-numeric values ("Negative", "None seen", "Trace", "3+", ">60").
+- Gauge endpoint numbers rendered with every character doubled, e.g.
+  "110000 220000" for the range 100 - 200, or "44..88 55..66" for 4.8 - 5.6.
+
+To recover columns reliably this parser consumes layout-preserved text
+(pdfplumber ``extract_text(layout=True)``) so horizontal positions survive as
+whitespace. The column gutter is derived from the character position of the
+second "Normal range/value:" anchor on two-column lines, which names and values
+share. Single-column exports (no such lines) are parsed as one column.
+"""
+
+import re
+from typing import List, Optional, Tuple
+
+from app.core.logging.config import get_logger
+
+from .base_parser import LabTestResult
+from .epic_mychart_base_parser import EpicMyChartBaseParser
+
+logger = get_logger(__name__, "app")
+
+
+class EpicMyChartCardParser(EpicMyChartBaseParser):
+    """Parser for the two-column Epic MyChart "Test Details" card layout."""
+
+    LAB_NAME = "Epic MyChart"
+
+    # This parser relies on retained column positions.
+    prefers_layout_text = True
+
+    # Matches the start of an anchor line ("Normal range:" / "Normal value:").
+    _ANCHOR_RE = re.compile(r"(?i)normal (?:range|value):")
+
+    # Anchor line with its trailing content captured (used per line in parsing).
+    _ANCHOR_CAPTURE_RE = re.compile(r"(?i)\s*normal (?:range|value):\s*(.*)")
+
+    # Whitespace / segmentation helpers used per line in the hot parse loop.
+    _MULTISPACE_RE = re.compile(r"\s{2,}")
+    _NAME_SPLIT_RE = re.compile(r"\s{3,}")
+
+    # Numeric-line helpers for gauge detection and name validation.
+    _NUMERIC_LINE_RE = re.compile(r"^[\d.]+$")
+    _NUMBER_RE = re.compile(r"\d+\.?\d*")
+    _DIGITS_ONLY_NAME_RE = re.compile(r"^[\d\s.]+$")
+    _ALPHA_RE = re.compile(r"[A-Za-z]")
+
+    # A value line: a number optionally followed by a flag word.
+    _VALUE_FLAG_RE = re.compile(
+        r"(?i)^(-?\d+\.?\d*)\s*(high|low|critical|abnormal|h|l)?$"
+    )
+
+    # An inequality value such as ">60" or "<5".
+    _VALUE_INEQ_RE = re.compile(r"^[<>]=?\s*\d+\.?\d*$")
+
+    # Recognised qualitative result tokens.
+    _QUAL_RE = re.compile(
+        r"(?i)^(negative|positive|detected|undetected|reactive|non-?reactive|"
+        r"not detected|none seen|none|trace|few|normal|abnormal|\d\+|"
+        r"<?\d+\s*-\s*\d+)$"
+    )
+
+    # Labels that sit between an anchor and its value; skipped, never a name.
+    _STOP_LABELS = {"value", "results", "result"}
+
+    # Substrings that mark a line as metadata/footer noise.
+    _NOISE_SUBSTRINGS = (
+        "mychart",
+        "licensed from epic",
+        "epic systems",
+        "authorizing provider",
+        "collection date",
+        "collected on",
+        "result date",
+        "result status",
+        "resulting lab",
+        "ordering provider",
+        "performed at",
+        "test performed",
+        "lab director",
+        "specimens:",
+        "specimen",
+        "https://",
+        "http://",
+        "www.",
+        "for specimens sent",
+        "additional information",
+        "enter test",
+        "reference ranges",
+        "risk category",
+        "risk factor",
+        "risk equivalent",
+        "guidelines",
+        "goals depend",
+        "more complete",
+        "definitions of",
+        "prediabetes",
+        "diabetes:",
+        "glycemic",
+        "moderately increased",
+        "severely increased",
+        "clia#",
+        "all rights reserved",
+        "copyright",
+        "page ",
+    )
+
+    def can_parse(self, text: str) -> bool:
+        """
+        Detect the Epic MyChart "Test Details" card layout.
+
+        Requires generic Epic indicators plus at least one signature specific to
+        the card/gauge export, so single-column Epic text routes to the
+        single-column parser instead.
+        """
+        if not text or not text.strip():
+            return False
+
+        if not self._looks_like_epic(text):
+            return False
+
+        return self._has_card_signature(text)
+
+    def _looks_like_epic(self, text: str) -> bool:
+        """Generic Epic MyChart indicators (mirrors the single-column parser)."""
+        score = 0
+        if re.search(r"(?i)licensed from epic systems corporation", text):
+            score += 1
+        if re.search(r"(?i)mychart", text):
+            score += 1
+        if re.search(r"(?i)collected on\s+[A-Z][a-z]{2}\s+\d{1,2},\s+\d{4}", text):
+            score += 1
+        if self._ANCHOR_RE.search(text):
+            score += 1
+        if re.search(r"(?i)authorizing provider:", text):
+            score += 1
+        if re.search(r"(?i)result status:", text):
+            score += 1
+        return score >= 2
+
+    def _has_card_signature(self, text: str) -> bool:
+        """At least one signal unique to the card/gauge "Test Details" export."""
+        # "Test Details" page header or the details URL.
+        if re.search(r"(?i)mychart\s*-\s*test details", text):
+            return True
+        if re.search(r"(?i)/test-results/details", text):
+            return True
+        # "Normal value:" anchors (single-column parser only handles "range").
+        if re.search(r"(?i)normal value:", text):
+            return True
+        for line in text.split("\n"):
+            # Two anchors on one line => two-column layout.
+            if len(self._ANCHOR_RE.findall(line)) >= 2:
+                return True
+            # A doubled-digit gauge line.
+            if self._is_doubled_gauge(line.replace(" ", "")):
+                return True
+        return False
+
+    def parse(self, text: str) -> List[LabTestResult]:
+        """
+        Parse Epic MyChart card results from layout-preserved text.
+
+        Splits the page into columns, parses each column independently by
+        anchoring on "Normal range/value:" lines, then deduplicates.
+        """
+        if not text or not text.strip():
+            return []
+
+        test_date = self.extract_date_from_text(text)
+        if test_date:
+            logger.info("Extracted test date from Epic MyChart card PDF")
+
+        results: List[LabTestResult] = []
+        for column in self._split_columns(text):
+            results.extend(self._parse_column(column, test_date))
+
+        results = self.deduplicate(results)
+        logger.info(
+            "Epic MyChart card parsing complete",
+            extra={"component": "EpicMyChartCardParser", "test_count": len(results)},
+        )
+        return results
+
+    # ------------------------------------------------------------------
+    # Column reconstruction
+    # ------------------------------------------------------------------
+
+    def _find_gutter(self, lines: List[str]) -> Optional[int]:
+        """
+        Locate the column gutter as the smallest character index of a second
+        anchor on any line. Returns None for single-column layouts.
+        """
+        candidates = []
+        for line in lines:
+            matches = list(self._ANCHOR_RE.finditer(line))
+            if len(matches) >= 2:
+                candidates.append(matches[1].start())
+        return min(candidates) if candidates else None
+
+    def _split_columns(self, layout_text: str) -> List[List[str]]:
+        """
+        Split layout text into columns of raw (un-collapsed) lines.
+
+        Returns a single column when no gutter is detected.
+        """
+        lines = layout_text.split("\n")
+        gutter = self._find_gutter(lines)
+        if gutter is None:
+            return [lines]
+        left = [line[:gutter] for line in lines]
+        right = [line[gutter:] for line in lines]
+        return [left, right]
+
+    # ------------------------------------------------------------------
+    # Per-column card parsing
+    # ------------------------------------------------------------------
+
+    def _parse_column(
+        self, lines: List[str], test_date: Optional[str]
+    ) -> List[LabTestResult]:
+        results = []
+        for i, line in enumerate(lines):
+            anchor = self._ANCHOR_CAPTURE_RE.match(line)
+            if not anchor:
+                continue
+
+            ref_range, unit, low, high = self._parse_anchor(
+                self._normspace(anchor.group(1))
+            )
+
+            test_name = self._find_name_before(lines, i)
+            if not test_name:
+                continue
+
+            value, flag, qualitative = self._find_value_after(lines, i, low, high)
+            if value is None and not qualitative:
+                continue
+
+            if value is not None and not flag:
+                flag = self._compute_flag(value, ref_range, low, high)
+
+            # Strip spurious trailing punctuation from names like "Monocytes:".
+            clean_name = self.clean_test_name(test_name).rstrip(" :;,")
+
+            results.append(
+                LabTestResult(
+                    test_name=clean_name,
+                    value=value,
+                    unit=unit,
+                    reference_range=ref_range,
+                    flag=flag,
+                    confidence=0.9,
+                    test_date=test_date,
+                    qualitative_value=qualitative or "",
+                )
+            )
+        return results
+
+    def _find_name_before(self, lines: List[str], anchor_idx: int) -> Optional[str]:
+        """Search upward from the anchor for the test name."""
+        for offset in range(1, 5):
+            idx = anchor_idx - offset
+            if idx < 0:
+                break
+            raw = lines[idx]
+            if not raw.strip():
+                continue
+            candidate = self._name_from_raw(raw)
+            if self._ANCHOR_RE.search(candidate):
+                break
+            if candidate.lower() in self._STOP_LABELS:
+                continue
+            if self._is_noise(candidate):
+                continue
+            if self._is_valid_name(candidate):
+                return candidate
+        return None
+
+    def _find_value_after(
+        self,
+        lines: List[str],
+        anchor_idx: int,
+        low: Optional[float],
+        high: Optional[float],
+    ) -> Tuple[Optional[float], str, Optional[str]]:
+        """
+        Search downward from the anchor for the value.
+
+        Returns (numeric_value, flag, qualitative_value). Stops only at the next
+        card's anchor so qualitative values (which resemble names) are not
+        mistaken for the following test.
+        """
+        for offset in range(1, 8):
+            idx = anchor_idx + offset
+            if idx >= len(lines):
+                break
+            candidate = self._normspace(lines[idx])
+            if not candidate:
+                continue
+            if self._ANCHOR_RE.search(candidate):
+                break
+            if candidate.lower() in self._STOP_LABELS:
+                continue
+            if self._is_gauge(candidate, low, high):
+                continue
+
+            value_flag = self._VALUE_FLAG_RE.match(candidate)
+            if value_flag:
+                try:
+                    value = float(value_flag.group(1))
+                except ValueError:
+                    continue
+                flag = value_flag.group(2).capitalize() if value_flag.group(2) else ""
+                return value, flag, None
+
+            if self._VALUE_INEQ_RE.match(candidate):
+                return None, "", candidate.replace(" ", "")
+
+            if self._QUAL_RE.match(candidate):
+                return None, "", candidate
+
+        return None, "", None
+
+    # ------------------------------------------------------------------
+    # Anchor / value helpers
+    # ------------------------------------------------------------------
+
+    def _parse_anchor(
+        self, content: str
+    ) -> Tuple[str, str, Optional[float], Optional[float]]:
+        """
+        Parse the text after "Normal range/value:" into
+        (reference_range, unit, low_bound, high_bound).
+        """
+        content = content.strip()
+        if not content:
+            return ("", "", None, None)
+
+        # "Not Estab." (no numeric range; value follows separately).
+        not_estab = re.match(r"(?i)not\s+estab\.?\s*(.*)", content)
+        if not_estab:
+            return ("Not Estab.", not_estab.group(1).strip(), None, None)
+
+        # "above >=N unit".
+        above = re.match(r"(?i)above\s*>=?\s*(\d+\.?\d*)\s*(.*)", content)
+        if above:
+            return (f">={above.group(1)}", above.group(2).strip(), None, None)
+
+        # "<N unit" or ">N unit".
+        ineq = re.match(r"([<>]=?\s*\d+\.?\d*)\s*(.*)", content)
+        if ineq:
+            return (ineq.group(1).replace(" ", ""), ineq.group(2).strip(), None, None)
+
+        # "X - Y unit" (the common numeric range).
+        rng = re.match(r"(\d+\.?\d*)\s*-\s*(\d+\.?\d*)\s*(.*)", content)
+        if rng:
+            low, high = float(rng.group(1)), float(rng.group(2))
+            return (f"{rng.group(1)} - {rng.group(2)}", rng.group(3).strip(), low, high)
+
+        # Qualitative expected value (e.g. "Negative", "None seen/Few").
+        return (content, "", None, None)
+
+    def _compute_flag(
+        self, value: float, ref_range: str, low: Optional[float], high: Optional[float]
+    ) -> str:
+        """Derive a High/Low flag from the value and reference range."""
+        gte = re.match(r">=?\s*(\d+\.?\d*)", ref_range)
+        if gte:
+            return "Low" if value < float(gte.group(1)) else ""
+        lte = re.match(r"<=?\s*(\d+\.?\d*)", ref_range)
+        if lte:
+            return "High" if value > float(lte.group(1)) else ""
+        if low is not None and high is not None:
+            if value < low:
+                return "Low"
+            if value > high:
+                return "High"
+        return ""
+
+    # ------------------------------------------------------------------
+    # Gauge-artifact detection
+    # ------------------------------------------------------------------
+
+    def _is_doubled_gauge(self, compact: str) -> bool:
+        """True if a space-free line is a doubled-digit gauge (all chars paired).
+
+        e.g. "110000220000" (range 100 - 200) or "44..8855..66" (4.8 - 5.6).
+        """
+        if len(compact) < 4 or len(compact) % 2 != 0:
+            return False
+        if not self._NUMERIC_LINE_RE.match(compact):
+            return False
+        return all(compact[i] == compact[i + 1] for i in range(0, len(compact), 2))
+
+    def _is_gauge(self, line: str, low: Optional[float], high: Optional[float]) -> bool:
+        """
+        True if the line is a gauge endpoint rendering rather than a value.
+
+        Recognises the doubled-digit form and the plain "low high" form
+        (single-column exports, whose two numbers match the range bounds).
+        """
+        compact = line.replace(" ", "")
+        if not compact or not self._NUMERIC_LINE_RE.match(compact):
+            return False
+
+        if self._is_doubled_gauge(compact):
+            return True
+
+        if low is not None and high is not None:
+            nums = [float(n) for n in self._NUMBER_RE.findall(line)]
+            if (
+                len(nums) >= 2
+                and self._approx(nums[0], low)
+                and self._approx(nums[-1], high)
+            ):
+                return True
+        return False
+
+    @staticmethod
+    def _approx(a: float, b: float, tolerance: float = 0.05) -> bool:
+        return abs(a - b) < tolerance
+
+    # ------------------------------------------------------------------
+    # Text helpers
+    # ------------------------------------------------------------------
+
+    def _normspace(self, text: str) -> str:
+        """Collapse runs of whitespace to single spaces and strip."""
+        return self._MULTISPACE_RE.sub(" ", text).strip()
+
+    def _name_from_raw(self, raw: str) -> str:
+        """
+        Return the left-most segment of a raw layout line as a name.
+
+        When two column names share a line but no anchor gutter is available,
+        the wide gap between them separates the segments; keeping the first
+        avoids fusing two names.
+        """
+        segment = self._NAME_SPLIT_RE.split(raw.strip())[0]
+        return self._normspace(segment)
+
+    def _is_valid_name(self, name: str) -> bool:
+        """Validate a candidate test name."""
+        if not name or len(name) < 2 or len(name) > 80:
+            return False
+        if not name[0].isalpha():
+            return False
+        if not self._ALPHA_RE.search(name):
+            return False
+        if self._DIGITS_ONLY_NAME_RE.match(name):
+            return False
+        if self._is_noise(name):
+            return False
+        return True
+
+    def _is_noise(self, line: str) -> bool:
+        """True if the line is metadata/footer noise."""
+        if not line or len(line.strip()) < 2:
+            return True
+        lowered = line.lower()
+        return any(sub in lowered for sub in self._NOISE_SUBSTRINGS)

--- a/app/services/lab_parsers/epic_mychart_parser.py
+++ b/app/services/lab_parsers/epic_mychart_parser.py
@@ -1,26 +1,30 @@
 """
-Epic MyChart-specific PDF parser.
-Handles lab results downloaded from Epic MyChart patient portals.
+Epic MyChart single-column PDF parser.
+Handles lab results downloaded from Epic MyChart patient portals whose text
+extracts as a simple single-column stream.
 
-Epic MyChart uses a card-based visual layout with gauge bars.
 Each test shows: test name, "Normal range: X - Y unit", a value with a
 visual gauge, and gauge endpoint numbers. This is very different from the
 tabular formats of LabCorp/Quest.
+
+For the richer two-column "Test Details" export layout (with doubled-digit
+gauge artifacts and "Normal value:" anchors) see
+``epic_mychart_card_parser.EpicMyChartCardParser``, which is tried first.
 """
 
 import re
-from datetime import datetime
 from typing import List, Optional, Set, Tuple
 
 from app.core.logging.config import get_logger
 
-from .base_parser import BaseLabParser, LabTestResult
+from .base_parser import LabTestResult
+from .epic_mychart_base_parser import EpicMyChartBaseParser
 
 logger = get_logger(__name__, "app")
 
 
-class EpicMyChartParser(BaseLabParser):
-    """Parser for Epic MyChart lab results."""
+class EpicMyChartSingleColumnParser(EpicMyChartBaseParser):
+    """Parser for single-column Epic MyChart lab results."""
 
     LAB_NAME = "Epic MyChart"
 
@@ -160,7 +164,7 @@ class EpicMyChartParser(BaseLabParser):
             )
 
         # Deduplicate by test name (card layout can cause double parsing)
-        results = self._deduplicate(results)
+        results = self.deduplicate(results)
 
         logger.info("=" * 80)
         logger.info(f"TOTAL PARSED: {len(results)} components")
@@ -425,50 +429,3 @@ class EpicMyChartParser(BaseLabParser):
                 return True
 
         return False
-
-    @staticmethod
-    def _deduplicate(results: List[LabTestResult]) -> List[LabTestResult]:
-        """Deduplicate results by test name, keeping the first occurrence."""
-        seen: Set[str] = set()
-        unique = []
-        for result in results:
-            key = result.test_name.lower()
-            if key not in seen:
-                seen.add(key)
-                unique.append(result)
-        return unique
-
-    def extract_date_from_text(self, text: str) -> Optional[str]:
-        """
-        Extract lab test date from Epic MyChart PDF text.
-
-        Epic uses month-name date format:
-        - "Collected on Apr 10, 2025"
-        - "Collection date: Apr 10, 2025"
-        - "Collected on April 10, 2025"
-        """
-        # Epic-specific date patterns with month names
-        date_patterns = [
-            r"(?i)collected on\s+([A-Z][a-z]+)\s+(\d{1,2}),?\s+(\d{4})",
-            r"(?i)collection date:?\s+([A-Z][a-z]+)\s+(\d{1,2}),?\s+(\d{4})",
-            r"(?i)reported on\s+([A-Z][a-z]+)\s+(\d{1,2}),?\s+(\d{4})",
-        ]
-
-        for pattern in date_patterns:
-            match = re.search(pattern, text)
-            if match:
-                month_str = match.group(1)
-                day = match.group(2)
-                year = match.group(3)
-                date_str = f"{month_str} {day}, {year}"
-
-                # Try full month name first, then abbreviated
-                for fmt in ("%B %d, %Y", "%b %d, %Y"):
-                    try:
-                        date_obj = datetime.strptime(date_str, fmt)
-                        return date_obj.strftime("%Y-%m-%d")
-                    except ValueError:
-                        continue
-
-        # Fallback to base class method for numeric dates
-        return super().extract_date_from_text(text)

--- a/app/services/pdf_text_extraction_service.py
+++ b/app/services/pdf_text_extraction_service.py
@@ -6,7 +6,7 @@ Includes lab-specific parsing for structured extraction.
 
 import io
 import re
-from typing import Dict, Optional
+from typing import Callable, Dict, Optional
 
 import pdfplumber
 import pytesseract
@@ -306,8 +306,13 @@ class PDFTextExtractionService:
             native_result = self._extract_native_text(pdf_bytes)
 
             if self._is_valid_text(native_result["text"]):
-                # Try lab-specific parsing first
-                parsed_result = self._try_lab_specific_parsing(native_result["text"])
+                # Try lab-specific parsing first. Layout-preserved text is
+                # extracted lazily (and only for parsers that need it) via the
+                # provider, so the expensive layout pass is skipped otherwise.
+                parsed_result = self._try_lab_specific_parsing(
+                    native_result["text"],
+                    layout_text_provider=lambda: self._extract_layout_text(pdf_bytes),
+                )
 
                 if parsed_result:
                     # Lab-specific parser succeeded, but check if quality is good enough
@@ -448,6 +453,24 @@ class PDFTextExtractionService:
 
         return {"text": text, "page_count": page_count, "char_count": len(text)}
 
+    def _extract_layout_text(self, pdf_bytes: bytes) -> str:
+        """Extract a layout-preserved rendering (pdfplumber ``layout=True``).
+
+        This retains horizontal positions as whitespace so column-aware parsers
+        (e.g. the Epic MyChart card parser) can reconstruct columns. It is
+        materially more expensive than plain extraction, so it is only invoked
+        lazily for the parser that needs it.
+        """
+        layout_parts = []
+        with pdfplumber.open(io.BytesIO(pdf_bytes)) as pdf:
+            for page in pdf.pages:
+                try:
+                    layout_parts.append(page.extract_text(layout=True) or "")
+                except Exception:
+                    # Layout extraction is best-effort; fall back to plain text.
+                    layout_parts.append("")
+        return "\n".join(layout_parts)
+
     def _extract_ocr_text(self, pdf_bytes: bytes) -> Dict:
         """
         Extract text using OCR (slower, for scanned PDFs).
@@ -585,7 +608,10 @@ class PDFTextExtractionService:
         return cleaned_text
 
     def _try_lab_specific_parsing(
-        self, text: str, extraction_method: str = "native"
+        self,
+        text: str,
+        extraction_method: str = "native",
+        layout_text_provider: Optional[Callable[[], Optional[str]]] = None,
     ) -> Optional[Dict]:
         """
         Try to parse using lab-specific parsers.
@@ -593,12 +619,16 @@ class PDFTextExtractionService:
         Args:
             text: Extracted PDF text
             extraction_method: Method used to extract text ('native' or 'ocr')
+            layout_text_provider: Callable returning layout-preserved text,
+                invoked lazily only for column-aware parsers
 
         Returns:
             Dict with formatted text if successful, None otherwise
         """
         try:
-            results, lab_name = lab_parser_registry.parse(text)
+            results, lab_name = lab_parser_registry.parse(
+                text, layout_text_provider=layout_text_provider
+            )
 
             if not results:
                 logger.info(
@@ -610,6 +640,14 @@ class PDFTextExtractionService:
             # Convert parsed results to formatted text
             formatted_lines = []
             for result in results:
+                # Qualitative result (no numeric value): "TestName: Negative".
+                # Emitted bare so the frontend qualitative matcher applies.
+                if result.value is None and result.qualitative_value:
+                    formatted_lines.append(
+                        f"{result.test_name}: {result.qualitative_value}"
+                    )
+                    continue
+
                 # Format: TestName: Value Unit (Range)
                 line_parts = [result.test_name + ":"]
 

--- a/app/services/pdf_text_extraction_service.py
+++ b/app/services/pdf_text_extraction_service.py
@@ -453,22 +453,37 @@ class PDFTextExtractionService:
 
         return {"text": text, "page_count": page_count, "char_count": len(text)}
 
-    def _extract_layout_text(self, pdf_bytes: bytes) -> str:
+    def _extract_layout_text(self, pdf_bytes: bytes) -> Optional[str]:
         """Extract a layout-preserved rendering (pdfplumber ``layout=True``).
 
         This retains horizontal positions as whitespace so column-aware parsers
         (e.g. the Epic MyChart card parser) can reconstruct columns. It is
         materially more expensive than plain extraction, so it is only invoked
         lazily for the parser that needs it.
+
+        Column reconstruction derives a single document-wide gutter, so a page
+        silently rendered as empty text would corrupt that alignment and drop
+        the page's data. If any page fails layout extraction we therefore abandon
+        the layout rendering entirely and return ``None``, which makes the caller
+        fall back to the complete plain-text extraction rather than a truncated
+        or misaligned layout.
         """
         layout_parts = []
         with pdfplumber.open(io.BytesIO(pdf_bytes)) as pdf:
-            for page in pdf.pages:
+            for page_number, page in enumerate(pdf.pages, start=1):
                 try:
                     layout_parts.append(page.extract_text(layout=True) or "")
-                except Exception:
-                    # Layout extraction is best-effort; fall back to plain text.
-                    layout_parts.append("")
+                except Exception as e:
+                    logger.warning(
+                        "Layout extraction failed for a page; falling back to "
+                        "plain-text extraction for the whole document",
+                        extra={
+                            "component": "PDFTextExtractionService",
+                            "page_number": page_number,
+                            "error": str(e),
+                        },
+                    )
+                    return None
         return "\n".join(layout_parts)
 
     def _extract_ocr_text(self, pdf_bytes: bytes) -> Dict:

--- a/docs/wiki/Lab-Result-Parsing.md
+++ b/docs/wiki/Lab-Result-Parsing.md
@@ -16,8 +16,16 @@ MediKeep automatically detects and parses reports from:
 
 - **LabCorp** (Laboratory Corporation of America)
 - **Quest Diagnostics**
+- **Epic MyChart** patient-portal exports, including the two-column "Test Details" layout with visual gauge bars
 
-The system identifies the lab provider by scanning for signature indicators in the PDF (e.g., company name, website, copyright notices) and applies the appropriate parser.
+The system identifies the lab provider by scanning for signature indicators in the PDF (e.g., company name, website, copyright notices) and applies the appropriate parser. Epic MyChart exports are detected even when the performing lab (LabCorp, Quest, etc.) is named in the footer.
+
+### Result types
+
+Beyond standard numeric results, MediKeep also extracts:
+
+- **Qualitative results** such as *Negative* / *Positive* / *Detected* (common in urinalysis and infectious-disease panels)
+- **Semi-quantitative results** such as *Trace*, *Few*, *None seen*, *3+*, or *&gt;60*, which are saved as free-text results
 
 ---
 

--- a/frontend/src/components/medical/labresults/TestComponentBulkEntry.tsx
+++ b/frontend/src/components/medical/labresults/TestComponentBulkEntry.tsx
@@ -143,6 +143,22 @@ export const REGEX_PATTERNS = {
 export const QUALITATIVE_PATTERN =
   /^(.+?)[:]\s*(positive|negative|detected|undetected|reactive|non-reactive|not detected)\s*$/i;
 
+// Pattern for textual / semi-quantitative results that are not standard
+// qualitative values. Common in urinalysis and estimated results, e.g.
+// "Ketones, UA: Trace", "Squamous Epi (lpf), UA: Few", "WBC, UA: None seen",
+// "GFR Calculation: >60", "Epithelial Cells: 0-10", "Glucose, UA: 3+".
+// The value must be exactly a recognized token at end-of-line, so numeric
+// results (which carry a unit and/or reference range) never match here.
+export const TEXTUAL_PATTERN = new RegExp(
+  String.raw`^(.+?):\s*(` +
+    String.raw`none seen|none|trace|few|rare|occasional|moderate|many|small|large|present|absent|` +
+    String.raw`[1-4]\+|` +
+    String.raw`[<>]=?\s*\d+(?:\.\d+)?|` +
+    String.raw`\d+(?:\.\d+)?\s*[-–]\s*\d+(?:\.\d+)?` +
+    String.raw`)\s*$`,
+  'i'
+);
+
 /** Normalize qualitative value strings to standard values. */
 function normalizeQualitativeValue(raw: string): string {
   const lower = raw.toLowerCase().trim();
@@ -577,6 +593,28 @@ const TestComponentBulkEntry: React.FC<TestComponentBulkEntryProps> = ({
               parsed.status = 'abnormal';
             } else {
               parsed.status = 'normal';
+            }
+          }
+        }
+
+        // Try textual / semi-quantitative results (Trace, Few, None seen, 3+,
+        // >60, 0-10) before numeric patterns. Stored as free-text results.
+        if (!parsed) {
+          const textualMatch = trimmedLine.match(TEXTUAL_PATTERN);
+          if (textualMatch) {
+            const testName = textualMatch[1].trim().replace(/[,;:]+$/, '');
+            const textualValue = textualMatch[2].trim();
+            if (testName) {
+              parsed = {
+                test_name: testName,
+                value: null,
+                unit: '',
+                original_line: trimmedLine,
+                confidence: 0.7,
+                issues: [],
+                result_type: 'textual',
+                textual_value: textualValue,
+              };
             }
           }
         }

--- a/frontend/src/components/medical/labresults/__tests__/TestComponentBulkEntry.test.tsx
+++ b/frontend/src/components/medical/labresults/__tests__/TestComponentBulkEntry.test.tsx
@@ -9,7 +9,11 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { REGEX_PATTERNS } from '../TestComponentBulkEntry';
+import {
+  REGEX_PATTERNS,
+  QUALITATIVE_PATTERN,
+  TEXTUAL_PATTERN,
+} from '../TestComponentBulkEntry';
 
 /**
  * Helper to parse a line using the same logic as TestComponentBulkEntry.
@@ -344,5 +348,50 @@ describe('TestComponentBulkEntry Parser', () => {
       expect(result).not.toBeNull();
       expect(result!.status).toBe('normal');
     });
+  });
+});
+
+/**
+ * Textual / semi-quantitative results (Epic MyChart urinalysis, GFR, etc.).
+ * These are emitted by the backend Epic MyChart card parser as bare
+ * "Name: token" lines and stored as free-text results.
+ */
+describe('TEXTUAL_PATTERN: semi-quantitative results', () => {
+  const cases: Array<[string, string, string]> = [
+    ['Ketones, UA: Trace', 'Ketones, UA', 'Trace'],
+    ['Squamous Epi (lpf), UA: Few', 'Squamous Epi (lpf), UA', 'Few'],
+    ['WBC, UA: None seen', 'WBC, UA', 'None seen'],
+    ['Bacteria, UA: None', 'Bacteria, UA', 'None'],
+    ['GFR Calculation: >60', 'GFR Calculation', '>60'],
+    ['Epithelial Cells (non renal): 0-10', 'Epithelial Cells (non renal)', '0-10'],
+    ['Glucose, UA: 3+', 'Glucose, UA', '3+'],
+  ];
+
+  it.each(cases)('parses "%s"', (line, expectedName, expectedValue) => {
+    const match = line.match(TEXTUAL_PATTERN);
+    expect(match).not.toBeNull();
+    expect(match![1].trim()).toBe(expectedName);
+    expect(match![2].trim()).toBe(expectedValue);
+  });
+
+  it('does not match numeric results with unit and range', () => {
+    expect('WBC: 14.2 x10E3/uL (3.4 - 10.8)'.match(TEXTUAL_PATTERN)).toBeNull();
+  });
+
+  it('does not match a bare decimal value', () => {
+    expect('Anion Gap: 10.0'.match(TEXTUAL_PATTERN)).toBeNull();
+  });
+
+  it('does not match standard qualitative values (handled elsewhere)', () => {
+    expect('Protein, UA: Negative'.match(TEXTUAL_PATTERN)).toBeNull();
+  });
+});
+
+describe('QUALITATIVE_PATTERN precedence', () => {
+  it('matches standard qualitative value', () => {
+    const match = 'Protein, UA: Negative'.match(QUALITATIVE_PATTERN);
+    expect(match).not.toBeNull();
+    expect(match![1].trim()).toBe('Protein, UA');
+    expect(match![2].toLowerCase()).toBe('negative');
   });
 });

--- a/tests/unit/test_epic_mychart_card_parser.py
+++ b/tests/unit/test_epic_mychart_card_parser.py
@@ -1,0 +1,297 @@
+"""
+Unit tests for the Epic MyChart card/gauge "Test Details" parser.
+
+Fixtures are synthetic layout-preserved pages (no real patient data) built to
+reproduce the structural quirks of the real export: two-column cards, doubled-
+digit gauge artifacts, "Normal value:" anchors, value+flag lines, and non-
+numeric values.
+"""
+
+import pytest
+
+from app.services.lab_parsers import LabParserRegistry
+from app.services.lab_parsers.epic_mychart_card_parser import EpicMyChartCardParser
+from tests.fixtures.lab_text_samples import (
+    EPIC_MYCHART_RENAL_PANEL,
+    LABCORP_CLEAN_TEXT,
+    QUEST_DIAGNOSTICS_SAMPLE,
+    EMPTY_PDF_TEXT,
+)
+
+GUTTER = 46
+LEFT_INDENT = "        "
+
+
+def build_page(cards, collected="Collected on Jul 07, 2025 3:10 PM", footer_lab=None):
+    """Assemble a layout-preserved page from ``cards``.
+
+    Each card is an ``(left_lines, right_lines)`` tuple. Right-column content is
+    placed at a fixed gutter column so the parser's anchor-based column
+    detection sees a consistent split point.
+    """
+    lines = [
+        "   8/6/25, 12:10 PM".ljust(40) + "MyChart - Test Details",
+        LEFT_INDENT + "SAMPLE PANEL",
+        LEFT_INDENT + collected,
+        "       Results",
+    ]
+    for left_lines, right_lines in cards:
+        rows = max(len(left_lines), len(right_lines))
+        for r in range(rows):
+            left = left_lines[r] if r < len(left_lines) else ""
+            right = right_lines[r] if r < len(right_lines) else ""
+            left_cell = LEFT_INDENT + left
+            if right:
+                lines.append(left_cell.ljust(GUTTER) + right)
+            else:
+                lines.append(left_cell)
+    if footer_lab:
+        lines.append(LEFT_INDENT + f"Performed at: 01 - {footer_lab}")
+    lines.append(LEFT_INDENT + "Authorizing provider: Ronald Oglesby, DO")
+    lines.append(LEFT_INDENT + "Result status: Final")
+    lines.append(
+        LEFT_INDENT + "MyChart licensed from Epic Systems Corporation 1999 - 2025"
+    )
+    lines.append(
+        LEFT_INDENT + "https://mychart.example.com/UPC/app/test-results/details?x=1"
+    )
+    return "\n".join(lines)
+
+
+# A two-column CBC-like page with numeric values, a High flag, and doubled gauges.
+TWO_COLUMN_CBC = build_page(
+    [
+        (
+            [
+                "WBC",
+                "Normal range: 3.4 - 10.8 x10E3/uL",
+                "14.2 High",
+                "33..44 1100..88",
+            ],
+            ["RBC", "Normal range: 4.14 - 5.80 x10E6/uL", "4.88", "44..1144 55..88"],
+        ),
+        (
+            ["Hemoglobin", "Normal range: 13.0 - 17.7 g/dL", "15.0", "1133 1177..77"],
+            ["Hematocrit", "Normal range: 37.5 - 51.0 %", "43.4", "3377..55 5511"],
+        ),
+    ]
+)
+
+# A two-column urinalysis page with qualitative "Normal value:" cards.
+TWO_COLUMN_QUALITATIVE = build_page(
+    [
+        (
+            ["Protein, UA", "Normal value: Negative", "Value", "Negative"],
+            ["Glucose, UA", "Normal value: Negative", "Value", "3+"],
+        ),
+    ]
+)
+
+# A single-column GFR card whose value is an inequality (">60").
+GFR_INEQUALITY = build_page(
+    [
+        (["GFR Calculation", "Normal value: >=60 mL/min", "Value", ">60"], []),
+    ]
+)
+
+# A single-column card using "Normal value: Not Estab." with a numeric value.
+NOT_ESTAB_NUMERIC = build_page(
+    [
+        (["Creatinine, Ur", "Normal value: Not Estab. mg/dL", "Value", "398.9"], []),
+    ]
+)
+
+
+class TestCardDetection:
+    @pytest.fixture
+    def parser(self):
+        return EpicMyChartCardParser()
+
+    def test_detects_two_column_card(self, parser):
+        assert parser.can_parse(TWO_COLUMN_CBC) is True
+
+    def test_detects_qualitative_card(self, parser):
+        assert parser.can_parse(TWO_COLUMN_QUALITATIVE) is True
+
+    def test_rejects_single_column_epic_text(self, parser):
+        # The simple single-column format belongs to the fallback parser.
+        assert parser.can_parse(EPIC_MYCHART_RENAL_PANEL) is False
+
+    def test_rejects_labcorp(self, parser):
+        assert parser.can_parse(LABCORP_CLEAN_TEXT) is False
+
+    def test_rejects_quest(self, parser):
+        assert parser.can_parse(QUEST_DIAGNOSTICS_SAMPLE) is False
+
+    def test_rejects_empty(self, parser):
+        assert parser.can_parse(EMPTY_PDF_TEXT) is False
+        assert parser.can_parse("") is False
+
+
+class TestTwoColumnParsing:
+    @pytest.fixture
+    def parser(self):
+        return EpicMyChartCardParser()
+
+    def test_extracts_all_four_components(self, parser):
+        results = parser.parse(TWO_COLUMN_CBC)
+        names = {r.test_name for r in results}
+        assert names == {"WBC", "RBC", "Hemoglobin", "Hematocrit"}
+
+    def test_left_and_right_values(self, parser):
+        results = {r.test_name: r for r in parser.parse(TWO_COLUMN_CBC)}
+        assert results["WBC"].value == 14.2
+        assert results["RBC"].value == 4.88
+        assert results["Hemoglobin"].value == 15.0
+        assert results["Hematocrit"].value == 43.4
+
+    def test_units_and_ranges(self, parser):
+        results = {r.test_name: r for r in parser.parse(TWO_COLUMN_CBC)}
+        assert results["WBC"].unit == "x10E3/uL"
+        assert results["WBC"].reference_range == "3.4 - 10.8"
+        assert results["RBC"].reference_range == "4.14 - 5.80"
+
+    def test_explicit_flag_preserved(self, parser):
+        results = {r.test_name: r for r in parser.parse(TWO_COLUMN_CBC)}
+        assert results["WBC"].flag == "High"
+
+    def test_gauge_lines_not_taken_as_values(self, parser):
+        # 14.2 must win over the doubled gauge "33..44 1100..88".
+        results = {r.test_name: r for r in parser.parse(TWO_COLUMN_CBC)}
+        for name, expected in {
+            "WBC": 14.2,
+            "RBC": 4.88,
+            "Hemoglobin": 15.0,
+            "Hematocrit": 43.4,
+        }.items():
+            assert results[name].value == expected
+
+
+class TestQualitativeParsing:
+    @pytest.fixture
+    def parser(self):
+        return EpicMyChartCardParser()
+
+    def test_negative_and_plus_values(self, parser):
+        results = {r.test_name: r for r in parser.parse(TWO_COLUMN_QUALITATIVE)}
+        assert results["Protein, UA"].qualitative_value == "Negative"
+        assert results["Protein, UA"].value is None
+        assert results["Glucose, UA"].qualitative_value == "3+"
+
+    def test_inequality_value(self, parser):
+        results = parser.parse(GFR_INEQUALITY)
+        assert len(results) == 1
+        assert results[0].test_name == "GFR Calculation"
+        assert results[0].qualitative_value == ">60"
+        assert results[0].value is None
+
+    def test_not_estab_numeric_value(self, parser):
+        results = parser.parse(NOT_ESTAB_NUMERIC)
+        assert len(results) == 1
+        assert results[0].test_name == "Creatinine, Ur"
+        assert results[0].value == 398.9
+        assert results[0].reference_range == "Not Estab."
+        assert results[0].unit == "mg/dL"
+
+
+class TestFlagComputation:
+    @pytest.fixture
+    def parser(self):
+        return EpicMyChartCardParser()
+
+    def test_high_from_range(self, parser):
+        assert parser._compute_flag(12.0, "3 - 10", 3.0, 10.0) == "High"
+
+    def test_low_from_range(self, parser):
+        assert parser._compute_flag(2.0, "3 - 10", 3.0, 10.0) == "Low"
+
+    def test_within_range_no_flag(self, parser):
+        assert parser._compute_flag(5.0, "3 - 10", 3.0, 10.0) == ""
+
+    def test_gte_range_low(self, parser):
+        assert parser._compute_flag(50.0, ">=60", None, None) == "Low"
+
+    def test_lte_range_high(self, parser):
+        assert parser._compute_flag(130.0, "<=126", None, None) == "High"
+
+    def test_computed_flag_applied_on_parse(self, parser):
+        results = {r.test_name: r for r in parser.parse(TWO_COLUMN_CBC)}
+        # Hematocrit 43.4 within 37.5-51.0 -> no flag.
+        assert results["Hematocrit"].flag == ""
+
+
+class TestGaugeDetection:
+    @pytest.fixture
+    def parser(self):
+        return EpicMyChartCardParser()
+
+    def test_doubled_gauge_recognised(self, parser):
+        # _is_doubled_gauge takes the space-free (compact) form.
+        assert parser._is_doubled_gauge("110000220000") is True
+        assert parser._is_doubled_gauge("44..8855..66") is True
+
+    def test_doubled_gauge_line_filtered(self, parser):
+        assert parser._is_gauge("110000 220000", 100.0, 200.0) is True
+
+    def test_real_value_not_flagged_as_gauge(self, parser):
+        assert parser._is_doubled_gauge("14.2") is False
+        assert parser._is_gauge("14.2", 3.4, 10.8) is False
+
+    def test_plain_gauge_matches_bounds(self, parser):
+        assert parser._is_gauge("3.4 10.8", 3.4, 10.8) is True
+
+
+class TestDateExtraction:
+    @pytest.fixture
+    def parser(self):
+        return EpicMyChartCardParser()
+
+    def test_collected_on_month_name(self, parser):
+        results = parser.parse(TWO_COLUMN_CBC)
+        assert all(r.test_date == "2025-07-07" for r in results)
+
+
+class TestDeduplication:
+    @pytest.fixture
+    def parser(self):
+        return EpicMyChartCardParser()
+
+    def test_no_duplicate_names(self, parser):
+        results = parser.parse(TWO_COLUMN_CBC)
+        names = [r.test_name for r in results]
+        assert len(names) == len(set(n.lower() for n in names))
+
+    def test_empty_text(self, parser):
+        assert parser.parse("") == []
+        assert parser.parse("   ") == []
+
+
+class TestRegistryRouting:
+    def test_card_layout_routes_to_card_parser_over_labcorp(self):
+        """Regression: MyChart exports naming LabCorp in the footer must still
+        route to the card parser, not LabCorp."""
+        page = build_page(
+            [
+                (
+                    ["WBC", "Normal range: 3.4 - 10.8 x10E3/uL", "14.2 High"],
+                    ["RBC", "Normal range: 4.14 - 5.80 x10E6/uL", "4.88"],
+                ),
+            ],
+            footer_lab="Labcorp Dallas",
+        )
+        registry = LabParserRegistry()
+        parser = registry.get_parser(page)
+        assert type(parser).__name__ == "EpicMyChartCardParser"
+
+    def test_registry_parse_uses_layout_text(self):
+        registry = LabParserRegistry()
+        results, lab_name = registry.parse(
+            TWO_COLUMN_CBC, layout_text_provider=lambda: TWO_COLUMN_CBC
+        )
+        assert lab_name == "Epic MyChart"
+        assert len(results) == 4
+
+    def test_card_parser_registered_before_labcorp(self):
+        registry = LabParserRegistry()
+        names = [type(p).__name__ for p in registry.parsers]
+        assert names.index("EpicMyChartCardParser") < names.index("LabCorpParserV2")

--- a/tests/unit/test_epic_mychart_card_parser.py
+++ b/tests/unit/test_epic_mychart_card_parser.py
@@ -241,6 +241,22 @@ class TestGaugeDetection:
         assert parser._is_gauge("3.4 10.8", 3.4, 10.8) is True
 
 
+class TestNameCleaning:
+    @pytest.fixture
+    def parser(self):
+        return EpicMyChartCardParser()
+
+    def test_embedded_digits_preserved(self, parser):
+        # Significant digits in a name must survive superscript stripping.
+        assert parser.clean_test_name("Vitamin B12") == "Vitamin B12"
+        assert parser.clean_test_name("Hemoglobin A1C") == "Hemoglobin A1C"
+
+    def test_whitespace_delimited_superscript_stripped(self, parser):
+        # Footnote markers (space-delimited two-digit runs) are still removed.
+        assert parser.clean_test_name("Folate 01") == "Folate"
+        assert parser.clean_test_name("WBC 02") == "WBC"
+
+
 class TestDateExtraction:
     @pytest.fixture
     def parser(self):

--- a/tests/unit/test_epic_mychart_parser.py
+++ b/tests/unit/test_epic_mychart_parser.py
@@ -6,7 +6,9 @@ flag determination, gauge artifact filtering, and edge cases.
 """
 
 import pytest
-from app.services.lab_parsers.epic_mychart_parser import EpicMyChartParser
+from app.services.lab_parsers.epic_mychart_parser import (
+    EpicMyChartSingleColumnParser as EpicMyChartParser,
+)
 from tests.fixtures.lab_text_samples import (
     EPIC_MYCHART_RENAL_PANEL,
     EPIC_MYCHART_FULL_PANEL,
@@ -424,7 +426,7 @@ class TestEpicMyChartRegistryIntegration:
 
         registry = LabParserRegistry()
         parser_types = [type(p).__name__ for p in registry.parsers]
-        assert "EpicMyChartParser" in parser_types
+        assert "EpicMyChartSingleColumnParser" in parser_types
 
     def test_registry_detects_epic_format(self):
         """Test registry auto-detects Epic MyChart format."""


### PR DESCRIPTION
## Summary

This pull request introduces major improvements to the lab result parsing system, especially for Epic MyChart PDF reports, and enhances support for qualitative and semi-quantitative results. The changes add a new two-column Epic MyChart parser, improve parser selection logic to avoid misclassification, enable lazy extraction of layout-preserved text for performance, and extend result handling to cover qualitative and semi-quantitative values. The frontend is also updated to better recognize these result types.

**Lab Parser Architecture and Epic MyChart Support:**

- Added a new `EpicMyChartCardParser` for the two-column "Test Details" Epic MyChart layout and refactored the single-column parser as `EpicMyChartSingleColumnParser`. Parser selection now tries the card parser first, avoiding misclassification of Epic reports as LabCorp/Quest. Shared Epic-specific date extraction logic is moved to a new `EpicMyChartBaseParser`. (`app/services/lab_parsers/__init__.py` [[1]](diffhunk://#diff-5e8acc60bb01e81f31d027f6ddec688d6f6103e2532717045837f69da8f168f6L8-R12) [[2]](diffhunk://#diff-5e8acc60bb01e81f31d027f6ddec688d6f6103e2532717045837f69da8f168f6L20-R39) [[3]](diffhunk://#diff-5e8acc60bb01e81f31d027f6ddec688d6f6103e2532717045837f69da8f168f6L71-R100); `app/services/lab_parsers/epic_mychart_base_parser.py` [[4]](diffhunk://#diff-2e0458a470e5568a01c4ea8d34217939ec0d625005a0f0a477b126e067047c66R1-R45); `app/services/lab_parsers/epic_mychart_parser.py` [[5]](diffhunk://#diff-eb5110796c74e74252b381623bddab20e8cbe922dcaa0d44ed959d90048ead63L2-R27) [[6]](diffhunk://#diff-eb5110796c74e74252b381623bddab20e8cbe922dcaa0d44ed959d90048ead63L163-R167) [[7]](diffhunk://#diff-eb5110796c74e74252b381623bddab20e8cbe922dcaa0d44ed959d90048ead63L428-L474)

- Parser selection order and documentation are updated to clarify why Epic card parsing must take precedence, ensuring correct routing and robust handling of Epic exports. (`app/services/lab_parsers/__init__.py` [app/services/lab_parsers/__init__.pyL20-R39](diffhunk://#diff-5e8acc60bb01e81f31d027f6ddec688d6f6103e2532717045837f69da8f168f6L20-R39))

**Qualitative and Semi-Quantitative Result Handling:**

- The `LabTestResult` model now supports a `qualitative_value` field for non-numeric results (e.g., "Negative", "3+"), and this is included in serialization. The parsing pipeline and frontend display logic are updated to handle and present these values. (`app/services/lab_parsers/base_parser.py` [[1]](diffhunk://#diff-6afd070d9184e815a148a69d5504579ad96ee0b5ebf8d8281f8d2bd4e6d0b656R23) [[2]](diffhunk://#diff-6afd070d9184e815a148a69d5504579ad96ee0b5ebf8d8281f8d2bd4e6d0b656R32) [[3]](diffhunk://#diff-6afd070d9184e815a148a69d5504579ad96ee0b5ebf8d8281f8d2bd4e6d0b656R44); `app/services/pdf_text_extraction_service.py` [[4]](diffhunk://#diff-984fa5cf7f62cb591e05a3d1eab803557916a1bbd840c380fbaa9f2433d6f636R643-R650)

- The frontend bulk entry component now includes a new `TEXTUAL_PATTERN` to recognize semi-quantitative results (e.g., "Trace", "Few", "3+", ">60", "0-10") in addition to standard qualitative values. (`frontend/src/components/medical/labresults/TestComponentBulkEntry.tsx` [frontend/src/components/medical/labresults/TestComponentBulkEntry.tsxR146-R161](diffhunk://#diff-cec0081561483500a26a697d74a34b3a1fbe19c3fc0909e5138d2a62ce197e47R146-R161))

**Performance and API Improvements:**

- Layout-preserved text extraction (needed for column-aware parsing) is now performed lazily only if a parser requests it, significantly improving performance for plain-text parsers. (`app/services/pdf_text_extraction_service.py` [[1]](diffhunk://#diff-984fa5cf7f62cb591e05a3d1eab803557916a1bbd840c380fbaa9f2433d6f636L309-R315) [[2]](diffhunk://#diff-984fa5cf7f62cb591e05a3d1eab803557916a1bbd840c380fbaa9f2433d6f636R456-R473) [[3]](diffhunk://#diff-984fa5cf7f62cb591e05a3d1eab803557916a1bbd840c380fbaa9f2433d6f636L588-R631)

- The parser registry and service APIs are updated to support the optional provision of a layout text provider, and the documentation is clarified. (`app/services/lab_parsers/__init__.py` [[1]](diffhunk://#diff-5e8acc60bb01e81f31d027f6ddec688d6f6103e2532717045837f69da8f168f6L42-R88); `app/services/pdf_text_extraction_service.py` [[2]](diffhunk://#diff-984fa5cf7f62cb591e05a3d1eab803557916a1bbd840c380fbaa9f2433d6f636L588-R631)

**Documentation:**

- The lab parsing documentation is updated to explain Epic MyChart support and the new qualitative/semi-quantitative result handling. (`docs/wiki/Lab-Result-Parsing.md` [docs/wiki/Lab-Result-Parsing.mdR19-R28](diffhunk://#diff-c41998e4e33e01adefa21f2054f0443c0d445624d1f94a1bffb9ea6ab8b5a470R19-R28))

**Codebase Simplification:**

- Deduplication logic for test results is centralized in the base parser, and Epic-specific date extraction is unified in a shared base class. (`app/services/lab_parsers/base_parser.py` [[1]](diffhunk://#diff-6afd070d9184e815a148a69d5504579ad96ee0b5ebf8d8281f8d2bd4e6d0b656R201-R212); `app/services/lab_parsers/epic_mychart_parser.py` [[2]](diffhunk://#diff-eb5110796c74e74252b381623bddab20e8cbe922dcaa0d44ed959d90048ead63L163-R167) [[3]](diffhunk://#diff-eb5110796c74e74252b381623bddab20e8cbe922dcaa0d44ed959d90048ead63L428-L474)

These changes make the lab parsing system more robust, extensible, and accurate for a wider variety of lab report formats and result types.

## Related issue

<!-- e.g. "Closes #123" or "N/A" -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Translation / i18n
- [ ] Other

## Testing

<!-- How did you verify this works? Manual steps, screenshots, or test names. -->

## Checklist

- [ ] Tests added or updated (or N/A with reason)
- [ ] `npm run lint` and `npm run build` pass
- [ ] Backend tests pass (`pytest`) if backend code changed
- [ ] No PHI, secrets, or `console.log` left in the diff
- [ ] User-facing strings go through `t()` translations
- [ ] Documentation updated if API, schema, or service behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Epic MyChart PDF lab-result support for card-based, two-column, and single-column layouts.
  * Added extraction of qualitative and semi-quantitative values, including “Trace,” “Few,” ranges, and graded results.
  * Improved detection of dates, laboratories, reference ranges, flags, units, and duplicate results.
  * Added support for textual lab values during bulk entry.
  * Improved handling of layout-preserved PDF text and extraction fallbacks.

* **Documentation**
  * Updated lab-result parsing documentation with supported layouts and qualitative results.

* **Tests**
  * Expanded coverage for layout detection, parsing, dates, flags, deduplication, and textual entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->