### PR TITLE
fix: correct reference range parsing and enhance status calculation logic

### DIFF
--- a/frontend/src/components/medical/labresults/InlineTestComponentEntry.tsx
+++ b/frontend/src/components/medical/labresults/InlineTestComponentEntry.tsx
@@ -115,16 +115,16 @@ function InlineTestComponentEntry({
           if (
             field === 'value' ||
             field === 'ref_range_min' ||
-            field === 'ref_range_max'
+            field === 'ref_range_max' ||
+            field === 'ref_range_text'
           ) {
+            // updatedComp already has the changed field merged in above, so read
+            // every argument from it rather than re-selecting `value` per field.
             updatedComp.status = calculateStatus(
-              field === 'value' ? (value as number | '') : updatedComp.value,
-              field === 'ref_range_min'
-                ? (value as number | '')
-                : updatedComp.ref_range_min,
-              field === 'ref_range_max'
-                ? (value as number | '')
-                : updatedComp.ref_range_max
+              updatedComp.value,
+              updatedComp.ref_range_min,
+              updatedComp.ref_range_max,
+              updatedComp.ref_range_text
             );
           }
 

--- a/frontend/src/components/medical/labresults/TestComponentEditModal.tsx
+++ b/frontend/src/components/medical/labresults/TestComponentEditModal.tsx
@@ -24,7 +24,10 @@ import FormLoadingOverlay from '../../shared/FormLoadingOverlay';
 import { LabTestComponent } from '../../../services/api/labTestComponentApi';
 import { TEST_LIBRARY } from '../../../constants/testLibrary';
 import { QUALITATIVE_SELECT_OPTIONS } from '../../../constants/labCategories';
-import { MAX_REF_RANGE_TEXT_LENGTH } from '../../../utils/labTestComponentUtils';
+import {
+  MAX_REF_RANGE_TEXT_LENGTH,
+  calculateStatus,
+} from '../../../utils/labTestComponentUtils';
 
 interface TestComponentEditModalProps {
   component: LabTestComponent | null;
@@ -42,30 +45,6 @@ const TestComponentEditModal: React.FC<TestComponentEditModalProps> = ({
   const { t } = useTranslation(['common', 'shared']);
   const [formData, setFormData] = useState<Partial<LabTestComponent>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
-
-  // Auto-calculate status based on value and reference range
-  const calculateStatus = (
-    value: number | undefined,
-    refMin: number | undefined,
-    refMax: number | undefined
-  ): LabTestComponent['status'] => {
-    if (value === undefined || value === null) return undefined;
-    if (refMin === undefined && refMax === undefined) return undefined;
-
-    if (refMin !== undefined && refMax !== undefined) {
-      if (value < refMin) return 'low';
-      if (value > refMax) return 'high';
-      return 'normal';
-    }
-    if (refMin !== undefined) {
-      return value < refMin ? 'low' : 'normal';
-    }
-    if (refMax !== undefined) {
-      return value > refMax ? 'high' : 'normal';
-    }
-
-    return undefined;
-  };
 
   // Auto-suggest category based on test name
   const suggestCategory = (testName: string): LabTestComponent['category'] => {
@@ -201,7 +180,8 @@ const TestComponentEditModal: React.FC<TestComponentEditModalProps> = ({
       const calculatedStatus = calculateStatus(
         component.value,
         component.ref_range_min ?? undefined,
-        component.ref_range_max ?? undefined
+        component.ref_range_max ?? undefined,
+        component.ref_range_text
       );
 
       // Use existing category if present, otherwise suggest one
@@ -234,7 +214,8 @@ const TestComponentEditModal: React.FC<TestComponentEditModalProps> = ({
     const newStatus = calculateStatus(
       formData.value as number,
       formData.ref_range_min as number | undefined,
-      formData.ref_range_max as number | undefined
+      formData.ref_range_max as number | undefined,
+      formData.ref_range_text
     );
 
     // Only update if status actually changed to avoid infinite loops
@@ -244,7 +225,12 @@ const TestComponentEditModal: React.FC<TestComponentEditModalProps> = ({
       }
       return { ...prev, status: newStatus };
     });
-  }, [formData.value, formData.ref_range_min, formData.ref_range_max]);
+  }, [
+    formData.value,
+    formData.ref_range_min,
+    formData.ref_range_max,
+    formData.ref_range_text,
+  ]);
 
   // Separate effect for auto-suggesting category when test name changes
   useEffect(() => {

--- a/frontend/src/components/medical/labresults/TestComponentTemplates.tsx
+++ b/frontend/src/components/medical/labresults/TestComponentTemplates.tsx
@@ -136,16 +136,16 @@ function TestComponentTemplates({
         if (
           field === 'value' ||
           field === 'ref_range_min' ||
-          field === 'ref_range_max'
+          field === 'ref_range_max' ||
+          field === 'ref_range_text'
         ) {
+          // updatedComp already has the changed field merged in above, so read
+          // every argument from it rather than re-selecting `value` per field.
           updatedComp.status = calculateStatus(
-            field === 'value' ? (value as number | '') : updatedComp.value,
-            field === 'ref_range_min'
-              ? (value as number | '')
-              : updatedComp.ref_range_min,
-            field === 'ref_range_max'
-              ? (value as number | '')
-              : updatedComp.ref_range_max
+            updatedComp.value,
+            updatedComp.ref_range_min,
+            updatedComp.ref_range_max,
+            updatedComp.ref_range_text
           );
         }
 

--- a/frontend/src/components/medical/labresults/TestComponentTemplates.tsx
+++ b/frontend/src/components/medical/labresults/TestComponentTemplates.tsx
@@ -853,6 +853,22 @@ function TestComponentTemplates({
                                   hideControls
                                 />
                               </Box>
+                              <Box
+                                style={{ width: '120px', minWidth: '120px' }}
+                              >
+                                <TextInput
+                                  placeholder="Ref Text (e.g. <200)"
+                                  size="xs"
+                                  value={component.ref_range_text || ''}
+                                  onChange={event =>
+                                    updateComponent(
+                                      index,
+                                      'ref_range_text',
+                                      event.target.value
+                                    )
+                                  }
+                                />
+                              </Box>
                             </>
                           )}
                           <Box style={{ width: '120px', minWidth: '120px' }}>

--- a/frontend/src/utils/labTestComponentUtils.test.ts
+++ b/frontend/src/utils/labTestComponentUtils.test.ts
@@ -1,50 +1,102 @@
 import { describe, it, expect } from 'vitest';
 import { parseRefRangeText, calculateStatus } from './labTestComponentUtils';
 
+const NONE = { min: null, max: null, minExclusive: false, maxExclusive: false };
+
 describe('parseRefRangeText', () => {
-  it('parses a standard "X - Y" range', () => {
-    expect(parseRefRangeText('70-100')).toEqual({ min: 70, max: 100 });
+  it('parses a standard "X - Y" range (inclusive bounds)', () => {
+    expect(parseRefRangeText('70-100')).toEqual({
+      min: 70,
+      max: 100,
+      minExclusive: false,
+      maxExclusive: false,
+    });
   });
 
   it('parses a range with spaces and decimals', () => {
-    expect(parseRefRangeText('4.0 - 5.6')).toEqual({ min: 4.0, max: 5.6 });
+    expect(parseRefRangeText('4.0 - 5.6')).toEqual({
+      min: 4.0,
+      max: 5.6,
+      minExclusive: false,
+      maxExclusive: false,
+    });
   });
 
   it('tolerates a trailing unit after the range', () => {
-    expect(parseRefRangeText('4.0-5.6 mg/dL')).toEqual({ min: 4.0, max: 5.6 });
+    expect(parseRefRangeText('4.0-5.6 mg/dL')).toEqual({
+      min: 4.0,
+      max: 5.6,
+      minExclusive: false,
+      maxExclusive: false,
+    });
   });
 
-  it('parses an upper-bound-only "<N" range', () => {
-    expect(parseRefRangeText('<200')).toEqual({ min: null, max: 200 });
+  it('parses "<N" as an exclusive upper bound', () => {
+    expect(parseRefRangeText('<200')).toEqual({
+      min: null,
+      max: 200,
+      minExclusive: false,
+      maxExclusive: true,
+    });
   });
 
-  it('parses "<=N" and the unicode "≤N"', () => {
-    expect(parseRefRangeText('<=200')).toEqual({ min: null, max: 200 });
-    expect(parseRefRangeText('≤200')).toEqual({ min: null, max: 200 });
+  it('parses "<=N" and the unicode "≤N" as inclusive upper bounds', () => {
+    expect(parseRefRangeText('<=200')).toEqual({
+      min: null,
+      max: 200,
+      minExclusive: false,
+      maxExclusive: false,
+    });
+    expect(parseRefRangeText('≤200')).toEqual({
+      min: null,
+      max: 200,
+      minExclusive: false,
+      maxExclusive: false,
+    });
   });
 
-  it('parses a lower-bound-only ">N" range', () => {
-    expect(parseRefRangeText('>40')).toEqual({ min: 40, max: null });
+  it('parses ">N" as an exclusive lower bound', () => {
+    expect(parseRefRangeText('>40')).toEqual({
+      min: 40,
+      max: null,
+      minExclusive: true,
+      maxExclusive: false,
+    });
   });
 
-  it('parses ">=N" and the unicode "≥N"', () => {
-    expect(parseRefRangeText('>=90')).toEqual({ min: 90, max: null });
-    expect(parseRefRangeText('≥90')).toEqual({ min: 90, max: null });
+  it('parses ">=N" and the unicode "≥N" as inclusive lower bounds', () => {
+    expect(parseRefRangeText('>=90')).toEqual({
+      min: 90,
+      max: null,
+      minExclusive: false,
+      maxExclusive: false,
+    });
+    expect(parseRefRangeText('≥90')).toEqual({
+      min: 90,
+      max: null,
+      minExclusive: false,
+      maxExclusive: false,
+    });
   });
 
   it('parses a negative lower bound', () => {
-    expect(parseRefRangeText('-5-5')).toEqual({ min: -5, max: 5 });
+    expect(parseRefRangeText('-5-5')).toEqual({
+      min: -5,
+      max: 5,
+      minExclusive: false,
+      maxExclusive: false,
+    });
   });
 
   it('returns nulls for non-numeric / non-standard text', () => {
-    expect(parseRefRangeText('Not Estab.')).toEqual({ min: null, max: null });
-    expect(parseRefRangeText('Negative')).toEqual({ min: null, max: null });
+    expect(parseRefRangeText('Not Estab.')).toEqual(NONE);
+    expect(parseRefRangeText('Negative')).toEqual(NONE);
   });
 
   it('returns nulls for empty / missing input', () => {
-    expect(parseRefRangeText('')).toEqual({ min: null, max: null });
-    expect(parseRefRangeText(undefined)).toEqual({ min: null, max: null });
-    expect(parseRefRangeText(null)).toEqual({ min: null, max: null });
+    expect(parseRefRangeText('')).toEqual(NONE);
+    expect(parseRefRangeText(undefined)).toEqual(NONE);
+    expect(parseRefRangeText(null)).toEqual(NONE);
   });
 });
 
@@ -75,9 +127,20 @@ describe('calculateStatus', () => {
     expect(calculateStatus(150, '', '', '<200')).toBe('normal');
   });
 
+  it('treats the boundary as high for exclusive "<N" but normal for "<=N"', () => {
+    // Value exactly at the bound: "<200" excludes 200 (high); "<=200" includes it (normal).
+    expect(calculateStatus(200, '', '', '<200')).toBe('high');
+    expect(calculateStatus(200, '', '', '<=200')).toBe('normal');
+  });
+
   it('handles ">=N" ref text as a lower bound', () => {
     expect(calculateStatus(80, '', '', '>=90')).toBe('low');
     expect(calculateStatus(100, '', '', '>=90')).toBe('normal');
+  });
+
+  it('treats the boundary as low for exclusive ">N" but normal for ">=N"', () => {
+    expect(calculateStatus(90, '', '', '>90')).toBe('low');
+    expect(calculateStatus(90, '', '', '>=90')).toBe('normal');
   });
 
   it('prefers numeric bounds over ref text when both are present', () => {

--- a/frontend/src/utils/labTestComponentUtils.test.ts
+++ b/frontend/src/utils/labTestComponentUtils.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { parseRefRangeText, calculateStatus } from './labTestComponentUtils';
+
+describe('parseRefRangeText', () => {
+  it('parses a standard "X - Y" range', () => {
+    expect(parseRefRangeText('70-100')).toEqual({ min: 70, max: 100 });
+  });
+
+  it('parses a range with spaces and decimals', () => {
+    expect(parseRefRangeText('4.0 - 5.6')).toEqual({ min: 4.0, max: 5.6 });
+  });
+
+  it('tolerates a trailing unit after the range', () => {
+    expect(parseRefRangeText('4.0-5.6 mg/dL')).toEqual({ min: 4.0, max: 5.6 });
+  });
+
+  it('parses an upper-bound-only "<N" range', () => {
+    expect(parseRefRangeText('<200')).toEqual({ min: null, max: 200 });
+  });
+
+  it('parses "<=N" and the unicode "≤N"', () => {
+    expect(parseRefRangeText('<=200')).toEqual({ min: null, max: 200 });
+    expect(parseRefRangeText('≤200')).toEqual({ min: null, max: 200 });
+  });
+
+  it('parses a lower-bound-only ">N" range', () => {
+    expect(parseRefRangeText('>40')).toEqual({ min: 40, max: null });
+  });
+
+  it('parses ">=N" and the unicode "≥N"', () => {
+    expect(parseRefRangeText('>=90')).toEqual({ min: 90, max: null });
+    expect(parseRefRangeText('≥90')).toEqual({ min: 90, max: null });
+  });
+
+  it('parses a negative lower bound', () => {
+    expect(parseRefRangeText('-5-5')).toEqual({ min: -5, max: 5 });
+  });
+
+  it('returns nulls for non-numeric / non-standard text', () => {
+    expect(parseRefRangeText('Not Estab.')).toEqual({ min: null, max: null });
+    expect(parseRefRangeText('Negative')).toEqual({ min: null, max: null });
+  });
+
+  it('returns nulls for empty / missing input', () => {
+    expect(parseRefRangeText('')).toEqual({ min: null, max: null });
+    expect(parseRefRangeText(undefined)).toEqual({ min: null, max: null });
+    expect(parseRefRangeText(null)).toEqual({ min: null, max: null });
+  });
+});
+
+describe('calculateStatus', () => {
+  it('returns undefined when there is no value', () => {
+    expect(calculateStatus('', 70, 100)).toBeUndefined();
+  });
+
+  it('returns undefined when there are no bounds at all', () => {
+    expect(calculateStatus(85, '', '')).toBeUndefined();
+    expect(calculateStatus(85, '', '', '')).toBeUndefined();
+  });
+
+  it('uses numeric bounds when provided', () => {
+    expect(calculateStatus(60, 70, 100)).toBe('low');
+    expect(calculateStatus(85, 70, 100)).toBe('normal');
+    expect(calculateStatus(120, 70, 100)).toBe('high');
+  });
+
+  it('falls back to ref text when numeric bounds are empty', () => {
+    expect(calculateStatus(60, '', '', '70-100')).toBe('low');
+    expect(calculateStatus(85, '', '', '70-100')).toBe('normal');
+    expect(calculateStatus(120, '', '', '70-100')).toBe('high');
+  });
+
+  it('handles "<N" ref text as an upper bound', () => {
+    expect(calculateStatus(250, '', '', '<200')).toBe('high');
+    expect(calculateStatus(150, '', '', '<200')).toBe('normal');
+  });
+
+  it('handles ">=N" ref text as a lower bound', () => {
+    expect(calculateStatus(80, '', '', '>=90')).toBe('low');
+    expect(calculateStatus(100, '', '', '>=90')).toBe('normal');
+  });
+
+  it('prefers numeric bounds over ref text when both are present', () => {
+    // Numeric range 70-100 says normal; text range would say high — numeric wins.
+    expect(calculateStatus(90, 70, 100, '<50')).toBe('normal');
+  });
+
+  it('regression (issue #883): fasting glucose above a text-only range is high', () => {
+    // Reporter typed the range only into the Ref Text field, leaving min/max blank.
+    expect(calculateStatus(126, '', '', '70-99')).toBe('high');
+  });
+});

--- a/frontend/src/utils/labTestComponentUtils.ts
+++ b/frontend/src/utils/labTestComponentUtils.ts
@@ -83,25 +83,44 @@ export function isSubmittableComponent(component: ComponentRowData): boolean {
   return component.test_name.trim() !== '';
 }
 
+/** Numeric bounds parsed from a free-text reference range. */
+export interface ParsedRefRange {
+  min: number | null;
+  max: number | null;
+  /** True when the lower bound is strict ("> N"), i.e. value === min is out of range. */
+  minExclusive: boolean;
+  /** True when the upper bound is strict ("< N"), i.e. value === max is out of range. */
+  maxExclusive: boolean;
+}
+
 /**
  * Parse a free-text reference range into numeric bounds.
  *
  * Uses `match` (not full-string) so trailing units are tolerated
  * (e.g. "4.0-5.6 mg/dL"). Modeled on the backend Epic parser in
- * app/services/lab_parsers/epic_mychart_parser.py, but not identical to it:
- * this parser also accepts "<=", ">=" and negative numbers, and treats "<N"
- * bounds as exclusive, so the two can differ at the boundary.
+ * app/services/lab_parsers/epic_mychart_parser.py, though this parser accepts a
+ * few more forms the backend does not ("<=", ">=", "≥", bare ">" and negatives).
+ *
+ * The operator's strictness is preserved so "<N" (exclusive) and "<=N"
+ * (inclusive) classify a value equal to N differently.
  *
  * Supported forms:
- *   "X - Y" / "X-Y"      -> { min: X, max: Y }
- *   "< N" / "<= N" / "≤ N" -> { min: null, max: N }
- *   "> N" / ">= N" / "≥ N" -> { min: N, max: null }
- *   anything else         -> { min: null, max: null }
+ *   "X - Y" / "X-Y"      -> { min: X, max: Y }        (both inclusive)
+ *   "< N"                -> { max: N, maxExclusive }
+ *   "<= N" / "≤ N"       -> { max: N }                (inclusive)
+ *   "> N"                -> { min: N, minExclusive }
+ *   ">= N" / "≥ N"       -> { min: N }                (inclusive)
+ *   anything else        -> { min: null, max: null }
  */
 export function parseRefRangeText(
   text: string | undefined | null
-): { min: number | null; max: number | null } {
-  const empty = { min: null, max: null };
+): ParsedRefRange {
+  const empty: ParsedRefRange = {
+    min: null,
+    max: null,
+    minExclusive: false,
+    maxExclusive: false,
+  };
   if (!text) return empty;
 
   const trimmed = text.trim();
@@ -111,19 +130,31 @@ export function parseRefRangeText(
     /^(-?\d+(?:\.\d+)?)\s*-\s*(-?\d+(?:\.\d+)?)/
   );
   if (rangeMatch) {
-    return { min: parseFloat(rangeMatch[1]), max: parseFloat(rangeMatch[2]) };
+    return {
+      ...empty,
+      min: parseFloat(rangeMatch[1]),
+      max: parseFloat(rangeMatch[2]),
+    };
   }
 
-  // Upper bound only: "< N", "<= N", "≤ N"
-  const ltMatch = trimmed.match(/^(?:<=?|≤)\s*(-?\d+(?:\.\d+)?)/);
+  // Upper bound only: "< N", "<= N", "≤ N" ("<" is exclusive of N).
+  const ltMatch = trimmed.match(/^(<=?|≤)\s*(-?\d+(?:\.\d+)?)/);
   if (ltMatch) {
-    return { min: null, max: parseFloat(ltMatch[1]) };
+    return {
+      ...empty,
+      max: parseFloat(ltMatch[2]),
+      maxExclusive: ltMatch[1] === '<',
+    };
   }
 
-  // Lower bound only: "> N", ">= N", "≥ N"
-  const gtMatch = trimmed.match(/^(?:>=?|≥)\s*(-?\d+(?:\.\d+)?)/);
+  // Lower bound only: "> N", ">= N", "≥ N" (">" is exclusive of N).
+  const gtMatch = trimmed.match(/^(>=?|≥)\s*(-?\d+(?:\.\d+)?)/);
   if (gtMatch) {
-    return { min: parseFloat(gtMatch[1]), max: null };
+    return {
+      ...empty,
+      min: parseFloat(gtMatch[2]),
+      minExclusive: gtMatch[1] === '>',
+    };
   }
 
   return empty;
@@ -147,17 +178,22 @@ export function calculateStatus(
 
   let min: number | null = isValidNumber(refMin) ? refMin : null;
   let max: number | null = isValidNumber(refMax) ? refMax : null;
+  // Numeric bounds from the Min/Max inputs are treated as inclusive.
+  let minExclusive = false;
+  let maxExclusive = false;
 
   if (min === null && max === null) {
     const parsed = parseRefRangeText(refText);
     min = parsed.min;
     max = parsed.max;
+    minExclusive = parsed.minExclusive;
+    maxExclusive = parsed.maxExclusive;
   }
 
   if (min === null && max === null) return undefined;
 
-  if (min !== null && value < min) return 'low';
-  if (max !== null && value > max) return 'high';
+  if (min !== null && (minExclusive ? value <= min : value < min)) return 'low';
+  if (max !== null && (maxExclusive ? value >= max : value > max)) return 'high';
   return 'normal';
 }
 

--- a/frontend/src/utils/labTestComponentUtils.ts
+++ b/frontend/src/utils/labTestComponentUtils.ts
@@ -84,23 +84,80 @@ export function isSubmittableComponent(component: ComponentRowData): boolean {
 }
 
 /**
+ * Parse a free-text reference range into numeric bounds.
+ *
+ * Uses `match` (not full-string) so trailing units are tolerated
+ * (e.g. "4.0-5.6 mg/dL"). Modeled on the backend Epic parser in
+ * app/services/lab_parsers/epic_mychart_parser.py, but not identical to it:
+ * this parser also accepts "<=", ">=" and negative numbers, and treats "<N"
+ * bounds as exclusive, so the two can differ at the boundary.
+ *
+ * Supported forms:
+ *   "X - Y" / "X-Y"      -> { min: X, max: Y }
+ *   "< N" / "<= N" / "≤ N" -> { min: null, max: N }
+ *   "> N" / ">= N" / "≥ N" -> { min: N, max: null }
+ *   anything else         -> { min: null, max: null }
+ */
+export function parseRefRangeText(
+  text: string | undefined | null
+): { min: number | null; max: number | null } {
+  const empty = { min: null, max: null };
+  if (!text) return empty;
+
+  const trimmed = text.trim();
+
+  // Range "X - Y": require a separating hyphen that is not the leading sign.
+  const rangeMatch = trimmed.match(
+    /^(-?\d+(?:\.\d+)?)\s*-\s*(-?\d+(?:\.\d+)?)/
+  );
+  if (rangeMatch) {
+    return { min: parseFloat(rangeMatch[1]), max: parseFloat(rangeMatch[2]) };
+  }
+
+  // Upper bound only: "< N", "<= N", "≤ N"
+  const ltMatch = trimmed.match(/^(?:<=?|≤)\s*(-?\d+(?:\.\d+)?)/);
+  if (ltMatch) {
+    return { min: null, max: parseFloat(ltMatch[1]) };
+  }
+
+  // Lower bound only: "> N", ">= N", "≥ N"
+  const gtMatch = trimmed.match(/^(?:>=?|≥)\s*(-?\d+(?:\.\d+)?)/);
+  if (gtMatch) {
+    return { min: parseFloat(gtMatch[1]), max: null };
+  }
+
+  return empty;
+}
+
+/**
  * Auto-calculate status based on value and reference range.
  * Returns 'normal', 'high', 'low', or undefined.
+ *
+ * Numeric refMin/refMax take priority. When neither is a valid number, the
+ * optional free-text reference range (e.g. "70-100", "<200") is parsed and used
+ * as a fallback, so a range typed only in the Ref Text field still drives status.
  */
 export function calculateStatus(
-  value: number | '',
-  refMin: number | '',
-  refMax: number | ''
-): string | undefined {
+  value: number | '' | null | undefined,
+  refMin: number | '' | null | undefined,
+  refMax: number | '' | null | undefined,
+  refText?: string | null
+): ComponentStatus | undefined {
   if (!isValidNumber(value)) return undefined;
 
-  const hasMin = isValidNumber(refMin);
-  const hasMax = isValidNumber(refMax);
+  let min: number | null = isValidNumber(refMin) ? refMin : null;
+  let max: number | null = isValidNumber(refMax) ? refMax : null;
 
-  if (!hasMin && !hasMax) return undefined;
+  if (min === null && max === null) {
+    const parsed = parseRefRangeText(refText);
+    min = parsed.min;
+    max = parsed.max;
+  }
 
-  if (hasMin && value < refMin) return 'low';
-  if (hasMax && value > refMax) return 'high';
+  if (min === null && max === null) return undefined;
+
+  if (min !== null && value < min) return 'low';
+  if (max !== null && value > max) return 'high';
   return 'normal';
 }
 


### PR DESCRIPTION
## Summary

This pull request enhances the lab test component logic to improve how status is calculated from reference ranges. The main improvement is that the `calculateStatus` function now supports parsing and using free-text reference ranges (e.g., "70-100", "<200") as a fallback when numeric min/max values are missing. This ensures that status is still auto-calculated even if the reference range is only provided in text form. The update also introduces comprehensive tests for the new parsing logic and refactors usage throughout the UI components.

**Reference Range Parsing and Status Calculation Improvements**
- Added a new `parseRefRangeText` function to extract numeric bounds from free-text reference ranges, supporting formats like "X-Y", "<N", "<=N", "≥N", and handling edge cases such as negative numbers and trailing units.
- Updated `calculateStatus` to use numeric min/max if available, and to fall back to parsed values from the reference range text if not, ensuring accurate status calculation even when only text is provided.
- Refactored all usages of `calculateStatus` in UI components (`TestComponentEditModal`, `InlineTestComponentEntry`, and `TestComponentTemplates`) to pass `ref_range_text` as an argument, and to trigger recalculation when the text changes. [[1]](diffhunk://#diff-27fbd229699daf4189329670f8f26af6fdd728f2a0943ecb26a3aee7da4f2698L27-R30) [[2]](diffhunk://#diff-27fbd229699daf4189329670f8f26af6fdd728f2a0943ecb26a3aee7da4f2698L204-R184) [[3]](diffhunk://#diff-27fbd229699daf4189329670f8f26af6fdd728f2a0943ecb26a3aee7da4f2698L237-R218) [[4]](diffhunk://#diff-27fbd229699daf4189329670f8f26af6fdd728f2a0943ecb26a3aee7da4f2698L247-R233) [[5]](diffhunk://#diff-c65750d62994845c7eb0162fccb0fc3c1cb6bcf223dc516caad7a10737f2b781L118-R127) [[6]](diffhunk://#diff-5f89694266f380adc8aa15a7cfe075774e31aba7f368cf182e225d335f760aa8L139-R148)

**Testing**
- Added a new test suite (`labTestComponentUtils.test.ts`) to verify correct parsing of reference range text and status calculation, including edge cases and regression scenarios.

**Code Cleanup**
- Removed the local `calculateStatus` implementation from `TestComponentEditModal` in favor of the shared utility function.

## Related issue

#883 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Translation / i18n
- [ ] Other

## Checklist

- [x] Tests added or updated (or N/A with reason)
- [x] `npm run lint` and `npm run build` pass
- [x] Backend tests pass (`pytest`) if backend code changed
- [x] No PHI, secrets, or `console.log` left in the diff
- [ ] User-facing strings go through `t()` translations
- [ ] Documentation updated if API, schema, or service behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for evaluating lab results using text-based reference ranges, including one-sided, decimal, negative, and unit-suffixed ranges.
  * Numeric reference bounds continue to take precedence when available.
* **Bug Fixes**
  * Lab result status now updates when the textual reference range changes.
  * Improved handling of missing, empty, and invalid reference ranges.
* **Tests**
  * Added comprehensive coverage for reference-range parsing and status evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->