### PR TITLE
fix: handle must_change_password flag for SSO users and update routing logic

### DIFF
--- a/app/api/v1/endpoints/sso.py
+++ b/app/api/v1/endpoints/sso.py
@@ -72,8 +72,9 @@ def _complete_sso_login(
 ) -> dict:
     """Shared post-authentication logic for all SSO login paths.
 
-    Logs the login activity, updates last_login_at, creates a JWT token,
-    and returns the standard SSO login response dict.
+    Logs the login activity, updates last_login_at, clears an unsatisfiable forced
+    password change for SSO-only accounts, creates a JWT token, and returns the
+    standard SSO login response dict.
     """
     sso_user = result["user"]
 
@@ -103,9 +104,31 @@ def _complete_sso_login(
             )
             # Continue login without active patient - user can set it later
 
+    # A forced password change is unsatisfiable for a pure-SSO user: the account was
+    # created with a random password that was discarded immediately (crud/user.py
+    # create_from_sso), and /auth/change-password requires the current password. The
+    # flag would lock the account out permanently, so clear it on successful SSO login.
+    # Hybrid users are deliberately excluded - they have a real local password they
+    # know, so the normal forced-change flow works for them.
+    clear_forced_password_change = (
+        bool(sso_user.must_change_password) and sso_user.auth_method == "sso"
+    )
+
     try:
         sso_user.last_login_at = get_utc_now()
+        if clear_forced_password_change:
+            sso_user.must_change_password = False
         db.commit()
+        if clear_forced_password_change:
+            log_security_event(
+                logger,
+                "sso_forced_password_change_cleared",
+                req,
+                "Cleared unsatisfiable forced password change for SSO-only user",
+                user_id=sso_user.id,
+                username=sso_user.username,
+                auth_method=sso_user.auth_method,
+            )
     except Exception:
         db.rollback()
 
@@ -152,6 +175,7 @@ def _complete_sso_login(
         },
         "is_new_user": result["is_new_user"],
         "session_timeout_minutes": session_timeout_minutes,
+        "must_change_password": bool(sso_user.must_change_password),
     }
     response = JSONResponse(content=response_data)
     set_auth_cookie(response, access_token, max_age_minutes=jwt_lifetime)

--- a/app/api/v1/endpoints/sso.py
+++ b/app/api/v1/endpoints/sso.py
@@ -119,18 +119,34 @@ def _complete_sso_login(
         if clear_forced_password_change:
             sso_user.must_change_password = False
         db.commit()
-        if clear_forced_password_change:
-            log_security_event(
-                logger,
-                "sso_forced_password_change_cleared",
-                req,
-                "Cleared unsatisfiable forced password change for SSO-only user",
-                user_id=sso_user.id,
-                username=sso_user.username,
-                auth_method=sso_user.auth_method,
-            )
-    except Exception:
+    except Exception as e:
         db.rollback()
+        if clear_forced_password_change:
+            # The flag is still set in the database. Issuing a session now would
+            # send the user to the forced-change form they cannot satisfy - the
+            # exact lockout this clear exists to prevent - so fail the login
+            # instead and let the next attempt retry the clear.
+            log_endpoint_error(
+                logger,
+                req,
+                "Failed to clear forced password change during SSO login",
+                e,
+                user_id=sso_user.id,
+            )
+            raise
+        # A failed last_login_at update on its own is not worth failing a login
+        # over; this tolerance predates the clear and is deliberate.
+
+    if clear_forced_password_change:
+        log_security_event(
+            logger,
+            "sso_forced_password_change_cleared",
+            req,
+            "Cleared unsatisfiable forced password change for SSO-only user",
+            user_id=sso_user.id,
+            username=sso_user.username,
+            auth_method=sso_user.auth_method,
+        )
 
     preferences = user_preferences.get_or_create_by_user_id(db, user_id=sso_user.id)
     session_timeout_minutes = (

--- a/docs/developer-guide/02-api-reference.md
+++ b/docs/developer-guide/02-api-reference.md
@@ -270,9 +270,19 @@ Base path: `/api/v1/auth/sso`
     "role": "user",
     "auth_method": "google_sso"
   },
-  "is_new_user": false
+  "is_new_user": false,
+  "must_change_password": false
 }
 ```
+
+- **`must_change_password`**: when `true`, the client must route the user to the
+  forced password change flow — every other endpoint returns 403 until it completes.
+  Accounts with `auth_method: "sso"` never see `true` here: their password is a
+  discarded random token, so a forced change is unsatisfiable and the flag is cleared
+  on login (audited as `sso_forced_password_change_cleared`). `hybrid` accounts, which
+  have a real local password, do see `true`.
+  The same field is returned by `/auth/sso/resolve-conflict` and
+  `/auth/sso/resolve-github-link`.
 
 - **Conflict Response** (200):
 

--- a/frontend/src/components/auth/SSOCallback.jsx
+++ b/frontend/src/components/auth/SSOCallback.jsx
@@ -7,6 +7,36 @@ import SSOConflictModal from './SSOConflictModal';
 import GitHubLinkModal from './GitHubLinkModal';
 import logger from '../../services/logger';
 
+/**
+ * Where to send a user after any successful SSO login.
+ *
+ * Shared by all three SSO entry points (callback, conflict resolution, GitHub
+ * manual linking) so they cannot drift apart - the backend already routes them
+ * through one function (_complete_sso_login).
+ *
+ * Consumes the stored return URL when it is used.
+ */
+const getPostSSORedirectPath = ({ mustChangePassword, isNewUser }) => {
+  // Every other route is blocked until the password is changed
+  if (mustChangePassword) {
+    return '/change-password';
+  }
+
+  // New SSO users go to profile completion
+  if (isNewUser) {
+    return '/patients/me?edit=true';
+  }
+
+  // Existing users go to their intended destination or dashboard
+  const returnUrl = sessionStorage.getItem('sso_return_url');
+  if (returnUrl) {
+    sessionStorage.removeItem('sso_return_url');
+    return returnUrl;
+  }
+
+  return '/dashboard';
+};
+
 const SSOCallback = () => {
   const { t } = useTranslation('auth');
   const [searchParams] = useSearchParams();
@@ -133,26 +163,16 @@ const SSOCallback = () => {
 
       // Update auth context with SSO login
       if (login) {
-        login(result.user, { sso: true });
-      }
-
-      // Determine where to redirect
-      let redirectPath = '/dashboard';
-
-      if (result.isNewUser) {
-        // New SSO users go to profile completion
-        logger.info('Redirecting new SSO user to profile', {
-          category: 'sso_callback_component',
+        login(result.user, {
+          sso: true,
+          mustChangePassword: result.mustChangePassword,
         });
-        redirectPath = '/patients/me?edit=true';
-      } else {
-        // Existing users go to their intended destination or dashboard
-        const returnUrl = sessionStorage.getItem('sso_return_url');
-        if (returnUrl) {
-          redirectPath = returnUrl;
-          sessionStorage.removeItem('sso_return_url');
-        }
       }
+
+      const redirectPath = getPostSSORedirectPath({
+        mustChangePassword: result.mustChangePassword,
+        isNewUser: result.isNewUser,
+      });
 
       logger.info('Redirecting after successful SSO', {
         redirectPath,
@@ -202,26 +222,22 @@ const SSOCallback = () => {
 
         // Update auth context with resolved login
         if (login) {
-          login(result.user, { sso: true });
+          login(result.user, {
+            sso: true,
+            mustChangePassword: result.mustChangePassword,
+          });
         }
 
         // Hide the modal and redirect
         setShowConflictModal(false);
 
-        // Determine where to redirect
-        let redirectPath = '/dashboard';
-
-        if (result.isNewUser) {
-          redirectPath = '/patients/me?edit=true';
-        } else {
-          const returnUrl = sessionStorage.getItem('sso_return_url');
-          if (returnUrl) {
-            redirectPath = returnUrl;
-            sessionStorage.removeItem('sso_return_url');
-          }
-        }
-
-        navigate(redirectPath, { replace: true });
+        navigate(
+          getPostSSORedirectPath({
+            mustChangePassword: result.mustChangePassword,
+            isNewUser: result.isNewUser,
+          }),
+          { replace: true }
+        );
       } else {
         setError(result.error || 'Failed to resolve account conflict');
         setShowConflictModal(false);
@@ -244,26 +260,24 @@ const SSOCallback = () => {
       category: 'sso_callback_component',
     });
 
+    // This path posts to the backend directly rather than going through
+    // simpleAuthService, so it receives the raw snake_case response. Normalize
+    // once here so everything below matches the other two SSO paths.
+    const mustChangePassword = result.must_change_password || false;
+    const isNewUser = result.is_new_user || false;
+
     // Update auth context with linked login
     if (login) {
-      login(result.user, result.access_token);
+      login(result.user, { sso: true, mustChangePassword });
     }
 
     // Hide the modal and redirect
     setShowGithubLinkModal(false);
 
-    // Determine where to redirect
-    let redirectPath = '/dashboard';
-
-    if (result.is_new_user) {
-      redirectPath = '/patients/me?edit=true';
-    } else {
-      const returnUrl = sessionStorage.getItem('sso_return_url');
-      if (returnUrl) {
-        redirectPath = returnUrl;
-        sessionStorage.removeItem('sso_return_url');
-      }
-    }
+    const redirectPath = getPostSSORedirectPath({
+      mustChangePassword,
+      isNewUser,
+    });
 
     navigate(redirectPath, { replace: true });
   };

--- a/frontend/src/components/auth/SSOCallback.test.jsx
+++ b/frontend/src/components/auth/SSOCallback.test.jsx
@@ -1,0 +1,211 @@
+import { vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import render from '../../test-utils/render';
+
+const mockNavigate = vi.fn();
+let mockSearchParams = new URLSearchParams('code=test-code&state=test-state');
+
+vi.mock('react-router-dom', async () => ({
+  ...(await vi.importActual('react-router-dom')),
+  useNavigate: () => mockNavigate,
+  useSearchParams: () => [mockSearchParams, vi.fn()],
+}));
+
+// The modals are driven by their own UI; stub them so this file tests
+// SSOCallback's post-login routing rather than the modals' internals.
+vi.mock('./SSOConflictModal', () => ({
+  default: ({ isOpen, onResolve }) =>
+    isOpen ? (
+      <button
+        onClick={() =>
+          onResolve({
+            action: 'link',
+            preference: 'auto_link',
+            tempToken: 'temp-token',
+          })
+        }
+      >
+        resolve-conflict
+      </button>
+    ) : null,
+}));
+
+vi.mock('./GitHubLinkModal', () => ({
+  default: ({ isOpen, onLinkComplete }) =>
+    isOpen ? (
+      <button
+        onClick={() =>
+          onLinkComplete({
+            // Raw backend response shape - snake_case
+            user: { id: 3, username: 'ghuser', role: 'user' },
+            access_token: 'token',
+            is_new_user: false,
+            must_change_password: true,
+          })
+        }
+      >
+        complete-github-link
+      </button>
+    ) : null,
+}));
+
+import SSOCallback from './SSOCallback';
+import { authService } from '../../services/auth/simpleAuthService';
+
+vi.spyOn(authService, 'completeSSOAuth');
+vi.spyOn(authService, 'resolveSSOConflict');
+
+const SSO_USER = { id: 7, username: 'ssouser', role: 'user' };
+
+/**
+ * Guards the lockout regression: an SSO user flagged must_change_password used to
+ * land on the dashboard, where every API call returned 403 with no way out.
+ */
+describe('SSOCallback - must change password routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchParams = new URLSearchParams('code=test-code&state=test-state');
+    sessionStorage.clear();
+  });
+
+  const renderCallback = () => {
+    const login = vi.fn();
+    render(<SSOCallback />, { authContextValue: { login } });
+    return login;
+  };
+
+  test('passes the flag to login and routes to /change-password', async () => {
+    authService.completeSSOAuth.mockResolvedValue({
+      success: true,
+      user: SSO_USER,
+      isNewUser: false,
+      mustChangePassword: true,
+    });
+
+    const login = renderCallback();
+
+    await waitFor(() =>
+      expect(login).toHaveBeenCalledWith(SSO_USER, {
+        sso: true,
+        mustChangePassword: true,
+      })
+    );
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith('/change-password', {
+        replace: true,
+      })
+    );
+  });
+
+  test('routes to the dashboard when the flag is not set', async () => {
+    authService.completeSSOAuth.mockResolvedValue({
+      success: true,
+      user: SSO_USER,
+      isNewUser: false,
+      mustChangePassword: false,
+    });
+
+    const login = renderCallback();
+
+    await waitFor(() =>
+      expect(login).toHaveBeenCalledWith(SSO_USER, {
+        sso: true,
+        mustChangePassword: false,
+      })
+    );
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith('/dashboard', { replace: true })
+    );
+  });
+
+  test('the flag wins over the new-user profile redirect', async () => {
+    authService.completeSSOAuth.mockResolvedValue({
+      success: true,
+      user: SSO_USER,
+      isNewUser: true,
+      mustChangePassword: true,
+    });
+
+    renderCallback();
+
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith('/change-password', {
+        replace: true,
+      })
+    );
+  });
+
+  test('the flag wins over a stored return URL', async () => {
+    sessionStorage.setItem('sso_return_url', '/medications');
+    authService.completeSSOAuth.mockResolvedValue({
+      success: true,
+      user: SSO_USER,
+      isNewUser: false,
+      mustChangePassword: true,
+    });
+
+    renderCallback();
+
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith('/change-password', {
+        replace: true,
+      })
+    );
+  });
+
+  test('conflict resolution carries the flag through', async () => {
+    authService.completeSSOAuth.mockResolvedValue({
+      success: true,
+      conflict: true,
+      existing_user_info: { email: 'ssouser@example.com' },
+      sso_user_info: { email: 'ssouser@example.com' },
+      temp_token: 'temp-token',
+    });
+    authService.resolveSSOConflict.mockResolvedValue({
+      success: true,
+      user: SSO_USER,
+      isNewUser: false,
+      mustChangePassword: true,
+    });
+
+    const login = renderCallback();
+    const user = userEvent.setup();
+
+    await user.click(await screen.findByText('resolve-conflict'));
+
+    await waitFor(() =>
+      expect(login).toHaveBeenCalledWith(SSO_USER, {
+        sso: true,
+        mustChangePassword: true,
+      })
+    );
+    expect(mockNavigate).toHaveBeenCalledWith('/change-password', {
+      replace: true,
+    });
+  });
+
+  test('GitHub manual linking carries the flag through', async () => {
+    authService.completeSSOAuth.mockResolvedValue({
+      success: true,
+      github_manual_link: true,
+      github_user_info: { github_username: 'ghuser' },
+      temp_token: 'temp-token',
+    });
+
+    const login = renderCallback();
+    const user = userEvent.setup();
+
+    await user.click(await screen.findByText('complete-github-link'));
+
+    await waitFor(() =>
+      expect(login).toHaveBeenCalledWith(
+        { id: 3, username: 'ghuser', role: 'user' },
+        { sso: true, mustChangePassword: true }
+      )
+    );
+    expect(mockNavigate).toHaveBeenCalledWith('/change-password', {
+      replace: true,
+    });
+  });
+});

--- a/frontend/src/contexts/AuthContext.d.ts
+++ b/frontend/src/contexts/AuthContext.d.ts
@@ -24,7 +24,7 @@ export interface AuthContextType {
   // Actions
   login: (
     credentialsOrUser: { username: string; password: string } | AuthUser,
-    tokenFromSSO?: string | null
+    ssoOptions?: { sso: boolean; mustChangePassword?: boolean } | null
   ) => Promise<{
     success: boolean;
     isFirstLogin?: boolean;

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -292,9 +292,11 @@ export function AuthProvider({ children }) {
       dispatch({ type: AUTH_ACTIONS.CLEAR_ERROR });
 
       // Check if this is SSO login (user object) or regular login (credentials).
-      // SSO callers pass the options object; regular logins pass nothing.
+      // Requires sso === true, not merely a present options object: { sso: false }
+      // must fall through to a credential login rather than trusting the first
+      // argument as an already-authenticated user.
       const isSSO =
-        ssoFlag !== null &&
+        ssoFlag?.sso === true &&
         typeof credentialsOrUser === 'object' &&
         credentialsOrUser.username;
 

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -284,14 +284,15 @@ export function AuthProvider({ children }) {
   // Auth Actions - handles both username/password credentials and SSO user object.
   // The token is stored as an HttpOnly cookie by the server -- the frontend
   // only manages user state and session timeout preferences.
-  // For SSO: pass { sso: true } as second arg to distinguish from regular login.
+  // For SSO: pass { sso: true, mustChangePassword } as second arg to distinguish
+  // from regular login and carry through flags from the SSO login response.
   const login = async (credentialsOrUser, ssoFlag = null) => {
     try {
       dispatch({ type: AUTH_ACTIONS.SET_LOADING, payload: true });
       dispatch({ type: AUTH_ACTIONS.CLEAR_ERROR });
 
       // Check if this is SSO login (user object) or regular login (credentials).
-      // SSO callers pass a truthy second arg (legacy: token string; new: { sso: true }).
+      // SSO callers pass the options object; regular logins pass nothing.
       const isSSO =
         ssoFlag !== null &&
         typeof credentialsOrUser === 'object' &&
@@ -347,9 +348,11 @@ export function AuthProvider({ children }) {
       // Get session timeout from result or use default
       const sessionTimeoutMinutes =
         (isSSO ? 120 : result?.sessionTimeoutMinutes) || 120;
-      const mustChangePassword = isSSO
-        ? false
-        : result?.mustChangePassword || false;
+      // SSO callers read the flag from the login response and pass it in the options
+      // object; regular logins get it from the login result.
+      const mustChangePassword =
+        (isSSO ? ssoFlag?.mustChangePassword : result?.mustChangePassword) ||
+        false;
 
       // Store session timeout preference in localStorage (not sensitive)
       localStorage.setItem(

--- a/frontend/src/contexts/AuthContext.sso.test.jsx
+++ b/frontend/src/contexts/AuthContext.sso.test.jsx
@@ -136,6 +136,46 @@ describe('AuthContext login - SSO mustChangePassword', () => {
     expect(screen.getByTestId('must-change')).toHaveTextContent('true');
   });
 
+  test('{ sso: false } is a credential login, not a trusted user object', async () => {
+    // The options object alone must not mark a login as SSO - otherwise the first
+    // argument would be accepted as an already-authenticated user without ever
+    // calling authService.login.
+    authService.login.mockResolvedValue({
+      success: true,
+      user: { id: 1, username: 'localuser', role: 'user' },
+      sessionTimeoutMinutes: 60,
+      mustChangePassword: false,
+    });
+
+    const credentials = { username: 'localuser', password: 'password123' };
+
+    function NotSSOHarness() {
+      const { login } = useAuth();
+      return (
+        <button onClick={() => login(credentials, { sso: false })}>
+          not-sso-login
+        </button>
+      );
+    }
+
+    render(
+      <AuthProvider>
+        <NotSSOHarness />
+      </AuthProvider>
+    );
+
+    await waitFor(() =>
+      expect(authService.getCurrentUser).toHaveBeenCalledTimes(1)
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByText('not-sso-login'));
+
+    await waitFor(() =>
+      expect(authService.login).toHaveBeenCalledWith(credentials)
+    );
+  });
+
   test('password login still reads the flag from the login result', async () => {
     authService.login.mockResolvedValue({
       success: true,

--- a/frontend/src/contexts/AuthContext.sso.test.jsx
+++ b/frontend/src/contexts/AuthContext.sso.test.jsx
@@ -1,0 +1,180 @@
+import { vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AuthProvider, useAuth } from './AuthContext';
+
+vi.mock('../services/auth/simpleAuthService', () => ({
+  authService: {
+    getCurrentUser: vi.fn(),
+    login: vi.fn(),
+    logout: vi.fn(),
+  },
+}));
+
+vi.mock('../utils/notifyTranslated', () => ({
+  notifySuccess: vi.fn(),
+  notifyInfo: vi.fn(),
+}));
+
+vi.mock('../services/api/userPreferencesApi', () => ({
+  getUserPreferences: vi.fn(),
+}));
+
+import { authService } from '../services/auth/simpleAuthService';
+import { getUserPreferences } from '../services/api/userPreferencesApi';
+
+const SSO_USER = {
+  id: 7,
+  username: 'ssouser',
+  email: 'ssouser@example.com',
+  role: 'user',
+  authMethod: 'hybrid',
+};
+
+/**
+ * Drives login() the way SSOCallback does and exposes the resulting state.
+ */
+function LoginHarness({ ssoOptions }) {
+  const { login, mustChangePassword, isAuthenticated } = useAuth();
+
+  return (
+    <div>
+      <button onClick={() => login(SSO_USER, ssoOptions)}>sso-login</button>
+      <span data-testid="must-change">{String(mustChangePassword)}</span>
+      <span data-testid="authenticated">{String(isAuthenticated)}</span>
+    </div>
+  );
+}
+
+/**
+ * These tests guard the regression where the SSO branch of login() hardcoded
+ * mustChangePassword to false, letting flagged SSO users reach a dashboard where
+ * every API call returned 403 with no path forward.
+ */
+describe('AuthContext login - SSO mustChangePassword', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    // No existing session - the provider's init effect resolves to logged out
+    authService.getCurrentUser.mockResolvedValue(null);
+    getUserPreferences.mockResolvedValue({ session_timeout_minutes: 120 });
+  });
+
+  const renderHarness = async ssoOptions => {
+    render(
+      <AuthProvider>
+        <LoginHarness ssoOptions={ssoOptions} />
+      </AuthProvider>
+    );
+
+    await waitFor(() =>
+      expect(authService.getCurrentUser).toHaveBeenCalledTimes(1)
+    );
+  };
+
+  test('carries mustChangePassword through from the SSO login response', async () => {
+    const user = userEvent.setup();
+    await renderHarness({ sso: true, mustChangePassword: true });
+
+    await user.click(screen.getByText('sso-login'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('must-change')).toHaveTextContent('true')
+    );
+    expect(screen.getByTestId('authenticated')).toHaveTextContent('true');
+  });
+
+  test('leaves mustChangePassword false when the SSO response does not set it', async () => {
+    const user = userEvent.setup();
+    await renderHarness({ sso: true, mustChangePassword: false });
+
+    await user.click(screen.getByText('sso-login'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('authenticated')).toHaveTextContent('true')
+    );
+    expect(screen.getByTestId('must-change')).toHaveTextContent('false');
+  });
+
+  test('defaults to false when the SSO caller omits the flag', async () => {
+    const user = userEvent.setup();
+    await renderHarness({ sso: true });
+
+    await user.click(screen.getByText('sso-login'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('authenticated')).toHaveTextContent('true')
+    );
+    expect(screen.getByTestId('must-change')).toHaveTextContent('false');
+  });
+
+  test('SSO login and session restore agree on the flag', async () => {
+    // Session restore reads must_change_password off /users/me. Before the fix
+    // the login path hardcoded false, so the two disagreed and a page refresh
+    // changed the app's behavior.
+    authService.getCurrentUser.mockResolvedValue({
+      ...SSO_USER,
+      must_change_password: true,
+    });
+
+    render(
+      <AuthProvider>
+        <LoginHarness ssoOptions={{ sso: true, mustChangePassword: true }} />
+      </AuthProvider>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('must-change')).toHaveTextContent('true')
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByText('sso-login'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('authenticated')).toHaveTextContent('true')
+    );
+    expect(screen.getByTestId('must-change')).toHaveTextContent('true');
+  });
+
+  test('password login still reads the flag from the login result', async () => {
+    authService.login.mockResolvedValue({
+      success: true,
+      user: { id: 1, username: 'localuser', role: 'user' },
+      sessionTimeoutMinutes: 60,
+      mustChangePassword: true,
+    });
+
+    function PasswordLoginHarness() {
+      const { login, mustChangePassword } = useAuth();
+      return (
+        <div>
+          <button
+            onClick={() =>
+              login({ username: 'localuser', password: 'password123' })
+            }
+          >
+            password-login
+          </button>
+          <span data-testid="must-change">{String(mustChangePassword)}</span>
+        </div>
+      );
+    }
+
+    render(
+      <AuthProvider>
+        <PasswordLoginHarness />
+      </AuthProvider>
+    );
+
+    await waitFor(() =>
+      expect(authService.getCurrentUser).toHaveBeenCalledTimes(1)
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByText('password-login'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('must-change')).toHaveTextContent('true')
+    );
+  });
+});

--- a/frontend/src/services/auth/simpleAuthService.js
+++ b/frontend/src/services/auth/simpleAuthService.js
@@ -624,6 +624,7 @@ class SimpleAuthService {
         user: enrichedUser,
         token: null,
         isNewUser: data.is_new_user,
+        mustChangePassword: data.must_change_password || false,
       };
     } catch (error) {
       logger.error('SSO callback error', {
@@ -728,6 +729,7 @@ class SimpleAuthService {
         },
         token: data.access_token,
         isNewUser: data.is_new_user,
+        mustChangePassword: data.must_change_password || false,
       };
     } catch (error) {
       logger.error('SSO conflict resolution error', {

--- a/tests/api/test_sso_must_change_password.py
+++ b/tests/api/test_sso_must_change_password.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from app.crud.user import user as user_crud
@@ -222,6 +223,47 @@ class TestForcedChangePreservedForOtherAuthMethods:
 
         db_session.expire_all()
         assert db_session.get(User, user_id).must_change_password is True
+
+
+class TestClearFailure:
+    """If the clear cannot be persisted, the login must not succeed."""
+
+    def test_commit_failure_fails_the_login_and_leaves_flag_set(
+        self, client: TestClient, db_session: Session
+    ):
+        user = make_sso_user(db_session, auth_method="sso", must_change_password=True)
+        user_id = user.id
+
+        # Break the commit that persists the clear. Issuing a session here would
+        # route the user to a forced-change form they cannot satisfy.
+        with patch.object(
+            Session, "commit", side_effect=SQLAlchemyError("commit failed")
+        ):
+            with patch_callback(user):
+                response = client.post(CALLBACK_URL, json=CALLBACK_BODY)
+
+        assert response.status_code != 200
+        assert "access_token" not in response.json()
+
+        db_session.rollback()
+        db_session.expire_all()
+        assert db_session.get(User, user_id).must_change_password is True
+
+    def test_last_login_failure_alone_does_not_fail_the_login(
+        self, client: TestClient, db_session: Session
+    ):
+        """No clear intended - the pre-existing tolerance for this must survive."""
+        user = make_sso_user(db_session, auth_method="sso", must_change_password=False)
+
+        with patch(
+            "app.api.v1.endpoints.sso.get_utc_now",
+            side_effect=SQLAlchemyError("clock failed"),
+        ):
+            with patch_callback(user):
+                response = client.post(CALLBACK_URL, json=CALLBACK_BODY)
+
+        assert response.status_code == 200
+        assert "access_token" in response.json()
 
 
 class TestEdgeCases:

--- a/tests/api/test_sso_must_change_password.py
+++ b/tests/api/test_sso_must_change_password.py
@@ -1,0 +1,265 @@
+"""
+Tests for must_change_password handling across the SSO login paths.
+
+A pure-SSO account is created with a random password that is discarded immediately,
+so a forced local password change can never be satisfied and locks the account out.
+These tests cover the three behaviors that fix and guard that:
+
+1. Every SSO login response carries must_change_password (all three entry points).
+2. auth_method == "sso" gets the unsatisfiable flag cleared on login.
+3. auth_method == "hybrid" keeps the flag - those users have a real local password.
+"""
+
+import logging
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.crud.user import user as user_crud
+from app.models.models import User
+from app.schemas.user import UserCreate
+
+CALLBACK_URL = "/api/v1/auth/sso/callback"
+CONFLICT_URL = "/api/v1/auth/sso/resolve-conflict"
+GITHUB_LINK_URL = "/api/v1/auth/sso/resolve-github-link"
+
+CALLBACK_BODY = {"code": "test-code", "state": "test-state"}
+CONFLICT_BODY = {
+    "temp_token": "test-temp-token",
+    "action": "link",
+    "preference": "auto_link",
+}
+GITHUB_LINK_BODY = {
+    "temp_token": "test-temp-token",
+    "username": "ssouser",
+    "password": "irrelevant-for-this-test",
+}
+
+
+def make_sso_user(
+    db_session: Session,
+    *,
+    username: str = "ssouser",
+    auth_method: str = "sso",
+    must_change_password: bool = False,
+    is_active: bool = True,
+) -> User:
+    """Create a user with the SSO fields and flags a test needs."""
+    user = user_crud.create(
+        db_session,
+        obj_in=UserCreate(
+            username=username,
+            email=f"{username}@example.com",
+            password="localpassword123",
+            full_name="SSO Test User",
+            role="user",
+        ),
+        must_change_password=must_change_password,
+    )
+
+    user.auth_method = auth_method
+    user.external_id = f"external-{username}"
+    user.sso_provider = "google"
+    user.is_active = is_active
+    db_session.commit()
+    db_session.refresh(user)
+
+    return user
+
+
+def patch_callback(user: User, is_new_user: bool = False):
+    """Patch the SSO service so /callback returns the given user."""
+    return patch(
+        "app.api.v1.endpoints.sso.sso_service.complete_authentication",
+        new=AsyncMock(return_value={"user": user, "is_new_user": is_new_user}),
+    )
+
+
+def patch_conflict(user: User, is_new_user: bool = False):
+    """Patch the SSO service so /resolve-conflict returns the given user."""
+    return patch(
+        "app.api.v1.endpoints.sso.sso_service.resolve_account_conflict",
+        return_value={"user": user, "is_new_user": is_new_user},
+    )
+
+
+def patch_github_link(user: User, is_new_user: bool = False):
+    """Patch the SSO service so /resolve-github-link returns the given user."""
+    return patch(
+        "app.api.v1.endpoints.sso.sso_service.resolve_github_manual_link",
+        return_value={"user": user, "is_new_user": is_new_user},
+    )
+
+
+# All three endpoints funnel through _complete_sso_login, so behavior that lives
+# there must hold for every one of them.
+ENTRY_POINTS = [
+    pytest.param(CALLBACK_URL, CALLBACK_BODY, patch_callback, id="callback"),
+    pytest.param(CONFLICT_URL, CONFLICT_BODY, patch_conflict, id="resolve-conflict"),
+    pytest.param(
+        GITHUB_LINK_URL, GITHUB_LINK_BODY, patch_github_link, id="resolve-github-link"
+    ),
+]
+
+
+class TestSSOResponseIncludesFlag:
+    """The SSO login response must expose must_change_password to the frontend."""
+
+    @pytest.mark.parametrize("url, body, patcher", ENTRY_POINTS)
+    def test_every_entry_point_returns_the_flag(
+        self, client: TestClient, db_session: Session, url, body, patcher
+    ):
+        user = make_sso_user(
+            db_session, auth_method="hybrid", must_change_password=True
+        )
+
+        with patcher(user):
+            response = client.post(url, json=body)
+
+        assert response.status_code == 200
+        assert response.json()["must_change_password"] is True
+
+    def test_flag_is_returned_as_false_when_not_set(
+        self, client: TestClient, db_session: Session
+    ):
+        user = make_sso_user(db_session, must_change_password=False)
+
+        with patch_callback(user):
+            response = client.post(CALLBACK_URL, json=CALLBACK_BODY)
+
+        assert response.status_code == 200
+        assert response.json()["must_change_password"] is False
+
+
+class TestForcedChangeClearedForSSOOnlyUsers:
+    """auth_method == 'sso' users cannot satisfy a forced change, so it is cleared."""
+
+    @pytest.mark.parametrize("url, body, patcher", ENTRY_POINTS)
+    def test_every_entry_point_clears_flag_for_sso_user(
+        self, client: TestClient, db_session: Session, url, body, patcher
+    ):
+        user = make_sso_user(db_session, auth_method="sso", must_change_password=True)
+        user_id = user.id
+
+        with patcher(user):
+            response = client.post(url, json=body)
+
+        assert response.status_code == 200
+        assert response.json()["must_change_password"] is False
+
+        db_session.expire_all()
+        assert db_session.get(User, user_id).must_change_password is False
+
+    def test_clear_emits_security_event(
+        self, client: TestClient, db_session: Session, caplog
+    ):
+        user = make_sso_user(db_session, auth_method="sso", must_change_password=True)
+
+        with caplog.at_level(logging.WARNING, logger="app.api.v1.endpoints.sso"):
+            with patch_callback(user):
+                response = client.post(CALLBACK_URL, json=CALLBACK_BODY)
+
+        assert response.status_code == 200
+        events = [getattr(record, "event", None) for record in caplog.records]
+        assert "sso_forced_password_change_cleared" in events
+
+    def test_no_event_when_flag_was_not_set(
+        self, client: TestClient, db_session: Session, caplog
+    ):
+        user = make_sso_user(db_session, auth_method="sso", must_change_password=False)
+
+        with caplog.at_level(logging.WARNING, logger="app.api.v1.endpoints.sso"):
+            with patch_callback(user):
+                response = client.post(CALLBACK_URL, json=CALLBACK_BODY)
+
+        assert response.status_code == 200
+        events = [getattr(record, "event", None) for record in caplog.records]
+        assert "sso_forced_password_change_cleared" not in events
+
+
+class TestForcedChangePreservedForOtherAuthMethods:
+    """Only pure-SSO accounts are exempt - everyone else keeps the flag."""
+
+    @pytest.mark.parametrize("auth_method", ["hybrid", "local"])
+    def test_flag_preserved_on_sso_login(
+        self, client: TestClient, db_session: Session, auth_method: str
+    ):
+        user = make_sso_user(
+            db_session, auth_method=auth_method, must_change_password=True
+        )
+        user_id = user.id
+
+        with patch_callback(user):
+            response = client.post(CALLBACK_URL, json=CALLBACK_BODY)
+
+        assert response.status_code == 200
+        assert response.json()["must_change_password"] is True
+
+        db_session.expire_all()
+        assert db_session.get(User, user_id).must_change_password is True
+
+    def test_password_login_leaves_flag_untouched(
+        self, client: TestClient, db_session: Session
+    ):
+        """Regression guard: the password login path must not clear the flag."""
+        user = make_sso_user(
+            db_session,
+            username="localuser",
+            auth_method="local",
+            must_change_password=True,
+        )
+        user_id = user.id
+
+        response = client.post(
+            "/api/v1/auth/login",
+            data={"username": "localuser", "password": "localpassword123"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["must_change_password"] is True
+
+        db_session.expire_all()
+        assert db_session.get(User, user_id).must_change_password is True
+
+
+class TestEdgeCases:
+    def test_inactive_sso_user_is_rejected_and_flag_untouched(
+        self, client: TestClient, db_session: Session
+    ):
+        """An inactive account is rejected before the clear runs."""
+        user = make_sso_user(
+            db_session,
+            auth_method="sso",
+            must_change_password=True,
+            is_active=False,
+        )
+        user_id = user.id
+
+        with patch_callback(user):
+            response = client.post(CALLBACK_URL, json=CALLBACK_BODY)
+
+        # Login does not succeed, so the clear never runs. The status is currently
+        # 500 rather than 401 because the endpoint's broad `except Exception`
+        # swallows UnauthorizedException - a pre-existing defect tracked separately
+        # in TECHNICAL_DEBT.md, deliberately not changed here.
+        assert response.status_code != 200
+
+        db_session.expire_all()
+        assert db_session.get(User, user_id).must_change_password is True
+
+    def test_new_sso_user_without_preferences_row(
+        self, client: TestClient, db_session: Session
+    ):
+        """A first-time SSO user has no preferences row yet; login still works."""
+        user = make_sso_user(db_session, auth_method="sso", must_change_password=True)
+
+        with patch_callback(user, is_new_user=True):
+            response = client.post(CALLBACK_URL, json=CALLBACK_BODY)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["is_new_user"] is True
+        assert data["must_change_password"] is False
+        assert "session_timeout_minutes" in data


### PR DESCRIPTION

## Summary

This pull request addresses a critical SSO edge case where users flagged for a forced password change could be locked out after SSO login, and standardizes how the `mustChangePassword` flag is handled and propagated through the backend, frontend, and documentation. It ensures that SSO-only users are never forced into an unsatisfiable password change, consistently routes such users to the change password flow, and adds robust tests to prevent regressions.

**Backend changes:**

* SSO-only users (`auth_method: "sso"`) with a forced password change flag now have this flag cleared on successful SSO login, preventing account lockout. This action is logged for auditing. Hybrid users (with a real password) are unaffected and still follow the forced password change flow. [[1]](diffhunk://#diff-a725c777f5f5020730d97e1e27a293d5f5ae297f4e413691b4e02b674011bb96L75-R77) [[2]](diffhunk://#diff-a725c777f5f5020730d97e1e27a293d5f5ae297f4e413691b4e02b674011bb96R107-R131)
* The SSO login response now always includes a `must_change_password` field, informing clients whether the user must complete a password change.

**Documentation updates:**

* The API reference documents the new `must_change_password` field in SSO responses, clarifying its meaning for SSO-only and hybrid accounts, and listing affected endpoints.

**Frontend logic improvements:**

* Centralizes SSO post-login routing in `getPostSSORedirectPath`, which always checks `mustChangePassword` and ensures flagged users are redirected to `/change-password` before any other destination. This logic is used in all SSO entry points, preventing drift. [[1]](diffhunk://#diff-fd9c279155ccd18f74b6da7c5146d76b27da8605b45ae863cc073b970c11b8caR10-R39) [[2]](diffhunk://#diff-fd9c279155ccd18f74b6da7c5146d76b27da8605b45ae863cc073b970c11b8caL136-L155) [[3]](diffhunk://#diff-fd9c279155ccd18f74b6da7c5146d76b27da8605b45ae863cc073b970c11b8caL205-R240) [[4]](diffhunk://#diff-fd9c279155ccd18f74b6da7c5146d76b27da8605b45ae863cc073b970c11b8caR263-R280)
* The `login` function in `AuthContext` now properly accepts and propagates the `mustChangePassword` flag for SSO logins, aligning SSO and password login flows. [[1]](diffhunk://#diff-3a8c5a8347827277ca8eb529ec90ffc5e52fc5ff5de9b5b0f840b6c29a22bb13L287-R295) [[2]](diffhunk://#diff-3a8c5a8347827277ca8eb529ec90ffc5e52fc5ff5de9b5b0f840b6c29a22bb13L350-R355)
* SSO service methods now extract and forward the `must_change_password` field from backend responses. [[1]](diffhunk://#diff-07bd4dcfe65c084db7c37c8e2f140a1c9bae55b96e2f2650738ad08881b9cfcdR627) [[2]](diffhunk://#diff-07bd4dcfe65c084db7c37c8e2f140a1c9bae55b96e2f2650738ad08881b9cfcdR732)

**Testing and regression coverage:**

* Adds comprehensive tests for SSO login and routing, ensuring that the `mustChangePassword` flag is correctly handled in all SSO scenarios, including conflict resolution and GitHub linking.
* Adds context-level tests to verify that SSO logins and session restores consistently set the `mustChangePassword` state, and that password logins are unaffected.

## Related issue

<!-- e.g. "Closes #123" or "N/A" -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Translation / i18n
- [ ] Other



## Checklist

- [x] Tests added or updated (or N/A with reason)
- [x] `npm run lint` and `npm run build` pass
- [x] Backend tests pass (`pytest`) if backend code changed
- [x] No PHI, secrets, or `console.log` left in the diff
- [x] User-facing strings go through `t()` translations
- [x] Documentation updated if API, schema, or service behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - SSO login responses now indicate when a password change is required.
  - Users requiring a password change are routed directly to that flow after SSO login.
  - Conflict resolution and GitHub-linking flows preserve password-change requirements.
  - Active SSO-only accounts automatically clear outdated password-change requirements, while hybrid accounts retain them.

- **Documentation**
  - Updated API documentation with response details and client handling requirements.

- **Tests**
  - Added coverage for SSO login, conflicts, GitHub linking, redirects, and password-change state handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->