### PR TITLE
fix(sso): GC state store, wire rate limiting, guard forced password change

### DIFF
--- a/app/api/v1/admin/models.py
+++ b/app/api/v1/admin/models.py
@@ -1835,13 +1835,38 @@ def _enforce_user_update_guards(
     current_user: User,
     request: Request,
 ) -> None:
-    """Block admin updates that would lock out admin access or self-disable.
+    """Block admin updates that would leave the account or the system unusable.
 
     Mirrors the protections on user DELETE (last admin / self) so role and
-    is_active changes cannot bypass them via the generic PUT endpoint.
+    is_active changes cannot bypass them via the generic PUT endpoint, and refuses
+    a forced password change that the target account could never satisfy.
     """
     is_self = record.id == current_user.id
     current_role = record.role
+
+    # A forced password change is meaningless for an account whose password is a
+    # discarded random token: it has no local password to change, and
+    # /auth/change-password requires the current one. Setting it would lock the
+    # account out until its next SSO login clears the flag.
+    #
+    # Ordering note: the admin UI resets the password first, which promotes the
+    # account to 'hybrid' (see admin_reset_password below), so the follow-up write
+    # that sets this flag passes this guard. It fires only on the incoherent case -
+    # forcing a change on an account that has never had a password set. Reversing
+    # those two frontend calls would break the flow.
+    if update_data.get("must_change_password") and not record.has_usable_password:
+        _block_user_update(
+            request=request,
+            current_user=current_user,
+            record=record,
+            event="forced_password_change_blocked_sso_account",
+            log_message="Attempt to force a password change on an SSO-only account",
+            detail=(
+                "Cannot require a password change for an SSO-only account - "
+                "it has no local password to change. Reset the user's password "
+                "first, which converts the account to hybrid authentication."
+            ),
+        )
 
     demoting_admin = (
         "role" in update_data
@@ -1874,9 +1899,7 @@ def _enforce_user_update_guards(
             detail="Cannot deactivate your own user account",
         )
 
-    if demoting_admin and not _has_other_admin(
-        db, record.id, active_only=False
-    ):
+    if demoting_admin and not _has_other_admin(db, record.id, active_only=False):
         _block_user_update(
             request=request,
             current_user=current_user,
@@ -2077,7 +2100,20 @@ def admin_reset_password(
         )
 
     try:
-        # Update password using the CRUD method
+        # An 'sso' account that is being given a real password is no longer SSO-only:
+        # /auth/login authenticates on password_hash alone and never reads
+        # auth_method, so local login works from the moment the password lands.
+        # Promoting the label grants no new capability - it makes the stored value
+        # match reality, which is what User.has_usable_password and the SSO login
+        # clear both key off. Mirrors _link_existing_user, which likewise only ever
+        # promotes 'local' -> 'hybrid'.
+        #
+        # Set before the password write so update_password's commit persists both
+        # columns in one transaction; if that commit fails, neither is applied.
+        promoting_to_hybrid = target_user.auth_method == "sso"
+        if promoting_to_hybrid:
+            target_user.auth_method = "hybrid"
+
         updated_user = user.update_password(
             db, user_id=user_id, new_password=password_data.new_password
         )
@@ -2085,6 +2121,16 @@ def admin_reset_password(
         if not updated_user:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
+            )
+
+        if promoting_to_hybrid:
+            log_security_event(
+                logger,
+                "sso_account_promoted_to_hybrid",
+                request,
+                "SSO-only account promoted to hybrid by admin password reset",
+                user_id=current_user.id,
+                target_user_id=user_id,
             )
 
         # Log admin password reset in activity log

--- a/app/api/v1/endpoints/medical_specialty.py
+++ b/app/api/v1/endpoints/medical_specialty.py
@@ -9,9 +9,8 @@ deactivate) stays behind the admin registry at ``/api/v1/admin/models/medical_sp
 Create is rate-limited per user to prevent form-abuse spam since this is the
 only write path non-admins have.
 """
-import time
-from collections import deque
-from typing import Any, Dict, List
+
+from typing import Any, List
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from sqlalchemy.orm import Session
@@ -20,6 +19,7 @@ from app.api import deps
 from app.api.activity_logging import safe_log_activity
 from app.core.http.error_handling import handle_database_errors
 from app.core.logging.config import get_logger
+from app.core.utils.rate_limit import SlidingWindowRateLimiter
 from app.crud.medical_specialty import medical_specialty
 from app.models.activity_log import ActionType, EntityType
 from app.schemas.medical_specialty import (
@@ -33,50 +33,11 @@ router = APIRouter()
 logger = get_logger(__name__, "app")
 
 
-class _UserRateLimiter:
-    """Tiny in-memory per-user rate limiter.
-
-    Mirrors the pattern from ``app.api.v1.endpoints.system.SimpleRateLimiter``
-    but keyed on user_id instead of IP so SSO users behind a shared NAT
-    aren't limited collectively. Not durable across restarts — adequate for
-    abuse prevention, not for hard quotas.
-    """
-
-    def __init__(self, max_requests: int, window_seconds: int):
-        self.max_requests = max_requests
-        self.window_seconds = window_seconds
-        # Plain dict — entries are only created when we actually record a
-        # request, and pruned-to-empty entries are deleted so idle users
-        # don't accumulate forever.
-        self.requests: Dict[int, deque] = {}
-
-    def allow(self, user_id: int) -> bool:
-        now = time.time()
-        window = self.requests.get(user_id)
-        if window is not None:
-            while window and window[0] <= now - self.window_seconds:
-                window.popleft()
-            if not window:
-                del self.requests[user_id]
-                window = None
-        if window is None:
-            window = deque()
-        if len(window) < self.max_requests:
-            window.append(now)
-            self.requests[user_id] = window
-            return True
-        return False
-
-    def retry_after(self, user_id: int) -> int:
-        window = self.requests.get(user_id)
-        if not window:
-            return 0
-        return max(1, int(window[0] + self.window_seconds - time.time()))
-
-
 # 20 specialty creates per user per hour — tight enough to prevent abuse,
 # generous enough for a real user onboarding multiple practitioners in one session.
-_create_limiter = _UserRateLimiter(max_requests=20, window_seconds=3600)
+# Keyed on user_id rather than IP so users behind a shared NAT aren't limited
+# collectively.
+_create_limiter = SlidingWindowRateLimiter(max_requests=20, window_seconds=3600)
 
 
 @router.get("/", response_model=List[MedicalSpecialtySummary])
@@ -113,18 +74,15 @@ def create_or_get_specialty(
     row is inserted so the frontend can treat both uniformly (select the
     returned row by id).
     """
-    if not _create_limiter.allow(current_user_id):
-        retry_after = _create_limiter.retry_after(current_user_id)
+    if not _create_limiter.is_allowed(current_user_id):
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             detail="Too many specialty create requests. Try again later.",
-            headers={"Retry-After": str(retry_after)},
+            headers=_create_limiter.rate_limit_headers(current_user_id),
         )
 
     with handle_database_errors(request=request):
-        specialty, created = medical_specialty.get_or_create(
-            db, obj_in=specialty_in
-        )
+        specialty, created = medical_specialty.get_or_create(db, obj_in=specialty_in)
 
         if not created:
             response.status_code = status.HTTP_200_OK

--- a/app/api/v1/endpoints/sso.py
+++ b/app/api/v1/endpoints/sso.py
@@ -18,16 +18,29 @@ from app.core.logging.helpers import (
     log_security_event,
 )
 from app.core.utils.cookie_auth import set_auth_cookie
+from app.core.utils.rate_limit import SlidingWindowRateLimiter, get_client_ip
 from app.core.utils.security import create_access_token
 from app.crud.user_preferences import user_preferences
 from app.models.activity_log import ActionType, EntityType
 from app.models.base import get_utc_now
+from app.models.models import User
 from app.services.patient_management import PatientManagementService
 from app.services.sso_service import SSOService
 
 logger = get_logger(__name__, "sso")
 router = APIRouter(prefix="/auth/sso", tags=["sso"])
 sso_service = SSOService()
+
+# Throttles the unauthenticated /initiate endpoint, which is what stops an
+# anonymous caller from minting SSO state entries without bound. Keyed per IP.
+#
+# The limits are read from settings at import time, so a test that patches
+# settings.SSO_RATE_LIMIT_* must call _initiate_limiter.reconfigure() to apply the
+# override to this instance.
+_initiate_limiter = SlidingWindowRateLimiter(
+    max_requests=settings.SSO_RATE_LIMIT_ATTEMPTS,
+    window_seconds=settings.SSO_RATE_LIMIT_WINDOW_MINUTES * 60,
+)
 
 
 class SSOConflictRequest(BaseModel):
@@ -111,7 +124,7 @@ def _complete_sso_login(
     # Hybrid users are deliberately excluded - they have a real local password they
     # know, so the normal forced-change flow works for them.
     clear_forced_password_change = (
-        bool(sso_user.must_change_password) and sso_user.auth_method == "sso"
+        bool(sso_user.must_change_password) and not sso_user.has_usable_password
     )
 
     try:
@@ -192,6 +205,11 @@ def _complete_sso_login(
         "is_new_user": result["is_new_user"],
         "session_timeout_minutes": session_timeout_minutes,
         "must_change_password": bool(sso_user.must_change_password),
+        # The deep link /auth/sso/initiate was given, carried through the state entry.
+        # Ships inert: no frontend reads it yet (deep links currently survive via
+        # sessionStorage, which fails in private browsing). See SSO_ONLY_MODE_SPEC.md
+        # 8.8 - the consumer is a later PR.
+        "return_url": result.get("return_url"),
     }
     response = JSONResponse(content=response_data)
     set_auth_cookie(response, access_token, max_age_minutes=jwt_lifetime)
@@ -225,6 +243,36 @@ async def initiate_sso_login(
     db: Session = Depends(deps.get_db),
 ):
     """Start SSO authentication flow"""
+    # Checked before get_authorization_url so a limited request mints no state
+    # entry - throttling this endpoint is what bounds the in-memory state store.
+    client_ip = get_client_ip(request)
+    if not _initiate_limiter.is_allowed(client_ip):
+        headers = _initiate_limiter.rate_limit_headers(client_ip)
+
+        log_security_event(
+            logger,
+            "sso_initiate_rate_limited",
+            request,
+            "Rate limit exceeded for SSO initiate endpoint",
+            endpoint="/api/v1/auth/sso/initiate",
+            retry_after_seconds=headers["Retry-After"],
+        )
+
+        raise HTTPException(
+            status_code=429,
+            detail=(
+                "Too many SSO sign-in attempts. "
+                f"Please wait {headers['Retry-After']} seconds and try again."
+            ),
+            headers={
+                **headers,
+                # X-Error-Code lets a client distinguish this from the generic SSO
+                # failures without matching on the message text. Nothing reads it
+                # yet - the frontend consumer is SSO_ONLY_MODE_SPEC.md criterion 15.
+                "X-Error-Code": "sso_rate_limited",
+            },
+        )
+
     try:
         result = await sso_service.get_authorization_url(return_url)
         return result
@@ -380,8 +428,17 @@ async def resolve_github_manual_link(
 
 
 @router.post("/test-connection")
-async def test_sso_connection(request: Request):
-    """Test SSO provider connection (for admin use)"""
+async def test_sso_connection(
+    request: Request,
+    current_user: User = Depends(deps.get_current_admin_user),
+):
+    """Test SSO provider connection. Admin only.
+
+    Each call makes the server perform an outbound token exchange against the
+    configured IdP and can echo provider configuration detail, so it must not be
+    reachable anonymously - the docstring always claimed admin use, but nothing
+    enforced it.
+    """
     try:
         result = await sso_service.test_connection()
         if result["success"]:

--- a/app/api/v1/endpoints/sso.py
+++ b/app/api/v1/endpoints/sso.py
@@ -34,9 +34,10 @@ sso_service = SSOService()
 # Throttles the unauthenticated /initiate endpoint, which is what stops an
 # anonymous caller from minting SSO state entries without bound. Keyed per IP.
 #
-# The limits are read from settings at import time, so a test that patches
-# settings.SSO_RATE_LIMIT_* must call _initiate_limiter.reconfigure() to apply the
-# override to this instance.
+# The limits are read from settings at import time, so patching
+# settings.SSO_RATE_LIMIT_* has no effect on this instance. A test overrides
+# max_requests / window_seconds on the object directly and calls reset() to clear
+# counters - see the limiter_ceiling fixture in tests/api/conftest.py.
 _initiate_limiter = SlidingWindowRateLimiter(
     max_requests=settings.SSO_RATE_LIMIT_ATTEMPTS,
     window_seconds=settings.SSO_RATE_LIMIT_WINDOW_MINUTES * 60,

--- a/app/api/v1/endpoints/system.py
+++ b/app/api/v1/endpoints/system.py
@@ -6,8 +6,6 @@ Provides system configuration and logging level information for frontend integra
 """
 
 import os
-import time
-from collections import defaultdict, deque
 from datetime import datetime
 from typing import Any, Dict
 
@@ -25,6 +23,7 @@ from app.core.logging.constants import (
     validate_log_level,
 )
 from app.core.logging.helpers import log_security_event
+from app.core.utils.rate_limit import SlidingWindowRateLimiter, get_client_ip
 from app.services.release_notes_service import get_release_notes_service
 
 # Constants
@@ -37,90 +36,9 @@ app_logger = get_logger(__name__, "app")
 security_logger = get_logger(__name__, "security")
 
 
-# Simple rate limiting implementation (10 requests per minute)
-# Using collections for efficiency and automatic cleanup
-class SimpleRateLimiter:
-    """
-    Simple in-memory rate limiter for log level endpoint.
-    Tracks requests per IP address with automatic cleanup.
-    """
-
-    def __init__(self, max_requests: int = 10, window_minutes: int = 1):
-        self.max_requests = max_requests
-        self.window_seconds = window_minutes * 60
-        self.requests: Dict[str, deque] = defaultdict(deque)
-
-    def is_allowed(self, client_ip: str) -> bool:
-        """
-        Check if client IP is allowed to make a request.
-
-        Args:
-            client_ip: IP address of the client
-
-        Returns:
-            True if allowed, False if rate limited
-        """
-        now = time.time()
-        client_requests = self.requests[client_ip]
-
-        # Remove old requests outside the window
-        while client_requests and client_requests[0] <= now - self.window_seconds:
-            client_requests.popleft()
-
-        # Check if under limit
-        if len(client_requests) < self.max_requests:
-            client_requests.append(now)
-            return True
-
-        return False
-
-    def get_remaining_requests(self, client_ip: str) -> int:
-        """Get number of remaining requests for client."""
-        now = time.time()
-        client_requests = self.requests[client_ip]
-
-        # Remove old requests
-        while client_requests and client_requests[0] <= now - self.window_seconds:
-            client_requests.popleft()
-
-        return max(0, self.max_requests - len(client_requests))
-
-    def get_reset_time(self, client_ip: str) -> float:
-        """Get timestamp when rate limit resets for client."""
-        client_requests = self.requests[client_ip]
-        if not client_requests:
-            return time.time()
-        return client_requests[0] + self.window_seconds
-
-
 # Initialize rate limiter for log level endpoint
 # 60 requests per minute = 1 per second (reasonable for frontend usage)
-rate_limiter = SimpleRateLimiter(max_requests=60, window_minutes=1)
-
-
-def get_client_ip(request: Request) -> str:
-    """
-    Safely extract client IP address from request.
-
-    Args:
-        request: FastAPI request object
-
-    Returns:
-        Sanitized client IP address
-    """
-    # Try various headers for real IP (useful behind proxies)
-    potential_ips = [
-        request.headers.get("x-forwarded-for", "").split(",")[0].strip(),
-        request.headers.get("x-real-ip", ""),
-        getattr(request.client, "host", "unknown") if request.client else "unknown",
-    ]
-
-    # Return first non-empty IP, sanitized
-    for ip in potential_ips:
-        if ip and ip != "unknown":
-            return sanitize_log_input(ip, max_length=45)  # IPv6 max length
-
-    return "unknown"
+rate_limiter = SlidingWindowRateLimiter(max_requests=60, window_seconds=60)
 
 
 @router.get("/log-level")
@@ -146,9 +64,8 @@ def get_log_level(request: Request) -> Dict[str, Any]:
     try:
         # Apply rate limiting
         if not rate_limiter.is_allowed(client_ip):
-            remaining_requests = rate_limiter.get_remaining_requests(client_ip)
-            reset_time = rate_limiter.get_reset_time(client_ip)
-            reset_datetime = datetime.fromtimestamp(reset_time)
+            headers = rate_limiter.rate_limit_headers(client_ip)
+            reset_datetime = datetime.fromtimestamp(float(headers["X-RateLimit-Reset"]))
 
             # Log rate limit violation for security monitoring
             log_security_event(
@@ -157,19 +74,17 @@ def get_log_level(request: Request) -> Dict[str, Any]:
                 request,
                 f"Rate limit exceeded for log level endpoint from {client_ip}",
                 endpoint="/api/v1/system/log-level",
-                remaining_requests=remaining_requests,
+                remaining_requests=headers["X-RateLimit-Remaining"],
                 reset_time=reset_datetime.isoformat(),
             )
 
             raise HTTPException(
                 status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-                detail="Rate limit exceeded. Maximum 60 requests per minute.",
-                headers={
-                    "X-RateLimit-Limit": "60",
-                    "X-RateLimit-Remaining": str(remaining_requests),
-                    "X-RateLimit-Reset": str(int(reset_time)),
-                    "Retry-After": str(int(reset_time - time.time())),
-                },
+                detail=(
+                    "Rate limit exceeded. Maximum "
+                    f"{rate_limiter.max_requests} requests per minute."
+                ),
+                headers=headers,
             )
 
         # Log successful access attempt for app monitoring
@@ -225,8 +140,8 @@ def get_log_level(request: Request) -> Dict[str, Any]:
             "timestamp": datetime.utcnow().isoformat() + "Z",
             "rate_limit_info": {
                 "requests_remaining": remaining_requests,
-                "requests_limit": 60,
-                "window_seconds": 60,
+                "requests_limit": rate_limiter.max_requests,
+                "window_seconds": rate_limiter.window_seconds,
                 "reset_time": datetime.fromtimestamp(reset_time).isoformat() + "Z",
             },
         }
@@ -341,9 +256,6 @@ def get_log_rotation_config(request: Request) -> Dict[str, Any]:
     try:
         # Apply rate limiting
         if not rate_limiter.is_allowed(client_ip):
-            remaining_requests = rate_limiter.get_remaining_requests(client_ip)
-            reset_time = rate_limiter.get_reset_time(client_ip)
-
             log_security_event(
                 security_logger,
                 "rate_limit_exceeded",
@@ -354,12 +266,11 @@ def get_log_rotation_config(request: Request) -> Dict[str, Any]:
 
             raise HTTPException(
                 status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-                detail="Rate limit exceeded. Maximum 60 requests per minute.",
-                headers={
-                    "X-RateLimit-Limit": "60",
-                    "X-RateLimit-Remaining": str(remaining_requests),
-                    "X-RateLimit-Reset": str(int(reset_time)),
-                },
+                detail=(
+                    "Rate limit exceeded. Maximum "
+                    f"{rate_limiter.max_requests} requests per minute."
+                ),
+                headers=rate_limiter.rate_limit_headers(client_ip),
             )
 
         # Log access

--- a/app/auth/sso/providers.py
+++ b/app/auth/sso/providers.py
@@ -57,6 +57,7 @@ class GitHubProvider(SSOProvider):
         return SSOUserInfo(
             sub=str(raw_data["id"]),  # GitHub uses numeric IDs
             email=raw_data.get("email"),
+            username=raw_data.get("login"),
             name=name,
         )
 

--- a/app/core/http/error_handling.py
+++ b/app/core/http/error_handling.py
@@ -581,6 +581,7 @@ _HTTP_STATUS_TO_CODE = {
     403: ExceptionCode.FORBIDDEN,
     404: ExceptionCode.NOT_FOUND,
     409: ExceptionCode.CONFLICT,
+    429: ExceptionCode.RATE_LIMITED,
 }
 
 
@@ -644,6 +645,10 @@ def setup_error_handling(app: FastAPI):
         return JSONResponse(
             status_code=api_exception.http_status_code,
             content=api_exception.to_response_model().model_dump(exclude_none=False),
+            # Carry through headers the raiser set. Dropping them silently voided
+            # every Retry-After and X-RateLimit-* this app has ever raised on a 429,
+            # and WWW-Authenticate on a 401.
+            headers=exc.headers or None,
         )
 
     logger.info(

--- a/app/core/http/response_models.py
+++ b/app/core/http/response_models.py
@@ -99,6 +99,13 @@ class ExceptionCode:
         "A resource with the same identifier already exists",
     )
 
+    # 429 Too Many Requests
+    RATE_LIMITED = ExceptionCodeDefinition(
+        "RATE-429",
+        "Too Many Requests",
+        "The rate limit for this endpoint has been exceeded",
+    )
+
     # 500 Internal Server Error
     INTERNAL_SERVER_ERROR = ExceptionCodeDefinition(
         "ISE-500", "Internal Server Error", "An unexpected error occurred on the server"

--- a/app/core/utils/rate_limit.py
+++ b/app/core/utils/rate_limit.py
@@ -96,9 +96,13 @@ class SlidingWindowRateLimiter:
 
     def is_allowed(self, key: Hashable) -> bool:
         """Record a request and return whether it is under the limit."""
-        now = time.time()
-
         with self._lock:
+            # Read the clock under the lock, not before it. A thread that stamps its
+            # timestamp and then waits on the lock would append a value older than
+            # one already recorded, leaving the deque out of order - and _prune pops
+            # from the left only while the leftmost is expired, so it assumes order.
+            now = time.time()
+
             self._maybe_sweep(now)
             window = self._prune(key, now)
 
@@ -120,24 +124,32 @@ class SlidingWindowRateLimiter:
             return max(0, self.max_requests - used)
 
     def get_reset_time(self, key: Hashable) -> float:
-        """Unix timestamp at which this key's oldest request leaves the window."""
+        """Unix timestamp at which this key's oldest request leaves the window.
+
+        Returns now for a key with no live requests - there is nothing to wait for.
+        """
         with self._lock:
-            window = self._requests.get(key)
+            now = time.time()
+            # Prune first: reading an unpruned window would report a reset time
+            # derived from an already-expired timestamp, i.e. one in the past.
+            window = self._prune(key, now)
             if not window:
-                return time.time()
+                return now
             return window[0] + self.window_seconds
 
     def get_retry_after(self, key: Hashable) -> int:
         """Whole seconds a limited caller should wait, for the Retry-After header.
 
         Rounded up and floored at 1 - a Retry-After of 0 invites an immediate retry
-        that would be rejected again.
+        that would be rejected again. A key with no live requests returns 0, since
+        there is no limit in force to wait out.
         """
         with self._lock:
-            window = self._requests.get(key)
+            now = time.time()
+            window = self._prune(key, now)
             if not window:
                 return 0
-            return max(1, math.ceil(window[0] + self.window_seconds - time.time()))
+            return max(1, math.ceil(window[0] + self.window_seconds - now))
 
     def rate_limit_headers(self, key: Hashable) -> Dict[str, str]:
         """Standard `429` headers for a rejected request.

--- a/app/core/utils/rate_limit.py
+++ b/app/core/utils/rate_limit.py
@@ -10,6 +10,7 @@ survive a restart. That is adequate for abuse prevention, not for hard quotas.
 """
 
 import math
+import threading
 import time
 from collections import deque
 from collections.abc import Hashable
@@ -28,22 +29,35 @@ class SlidingWindowRateLimiter:
     does not accumulate an empty deque per key ever seen. Pruning is lazy, though:
     it happens when a key is looked up again, which never comes for a key seen once.
     ``_SWEEP_THRESHOLD`` bounds that residue.
+
+    Thread-safe. FastAPI runs non-``async`` endpoints in a threadpool, and three of
+    the call sites are plain ``def``, so requests genuinely execute in parallel:
+    without the lock, two threads can pass the limit check before either records its
+    request, and a sweep iterating the dict while another thread inserts raises
+    ``RuntimeError: dictionary changed size during iteration``.
     """
 
-    # Past this many tracked keys, a request sweeps every stale key rather than only
-    # its own. Amortized O(1), and it caps the residue of one-shot keys - which for
-    # an IP-keyed limiter on an unauthenticated endpoint is one entry per address a
-    # distributed source cares to use. Well above any legitimate concurrent-client
-    # count, so a real deployment never pays for the sweep.
+    # Past this many tracked keys, a request sweeps stale keys rather than only its
+    # own, which caps the residue of one-shot keys - for an IP-keyed limiter on an
+    # unauthenticated endpoint, one entry per address a distributed source cares to
+    # use. Well above any legitimate concurrent-client count, so a real deployment
+    # never pays for the sweep.
     _SWEEP_THRESHOLD = 10000
 
     def __init__(self, max_requests: int, window_seconds: int):
         self.max_requests = max_requests
         self.window_seconds = window_seconds
         self._requests: Dict[Hashable, Deque[float]] = {}
+        # Re-entrant so rate_limit_headers can call the public getters, which take
+        # the lock themselves, without deadlocking.
+        self._lock = threading.RLock()
+        self._last_sweep = 0.0
 
     def _prune(self, key: Hashable, now: float) -> Optional[Deque[float]]:
-        """Drop timestamps outside the window; return the live deque or None."""
+        """Drop timestamps outside the window; return the live deque or None.
+
+        Caller must hold ``_lock``.
+        """
         window = self._requests.get(key)
         if window is None:
             return None
@@ -57,8 +71,20 @@ class SlidingWindowRateLimiter:
 
         return window
 
-    def _sweep_stale_keys(self, now: float) -> None:
-        """Drop every key whose window has fully aged out."""
+    def _maybe_sweep(self, now: float) -> None:
+        """Drop keys whose windows have fully aged out, at most once per window.
+
+        Throttled because the scan is O(tracked keys): a store held above the
+        threshold by *live* keys would otherwise be rescanned on every request, so
+        the defense against one-shot-key growth would itself become the amplifier.
+        Caller must hold ``_lock``.
+        """
+        if len(self._requests) <= self._SWEEP_THRESHOLD:
+            return
+        if now - self._last_sweep < self.window_seconds:
+            return
+
+        self._last_sweep = now
         cutoff = now - self.window_seconds
         stale = [
             key
@@ -72,33 +98,34 @@ class SlidingWindowRateLimiter:
         """Record a request and return whether it is under the limit."""
         now = time.time()
 
-        if len(self._requests) > self._SWEEP_THRESHOLD:
-            self._sweep_stale_keys(now)
+        with self._lock:
+            self._maybe_sweep(now)
+            window = self._prune(key, now)
 
-        window = self._prune(key, now)
+            if window is None:
+                window = deque()
 
-        if window is None:
-            window = deque()
+            if len(window) < self.max_requests:
+                window.append(now)
+                self._requests[key] = window
+                return True
 
-        if len(window) < self.max_requests:
-            window.append(now)
-            self._requests[key] = window
-            return True
-
-        return False
+            return False
 
     def get_remaining_requests(self, key: Hashable) -> int:
         """Requests still available to this key in the current window."""
-        window = self._prune(key, time.time())
-        used = len(window) if window else 0
-        return max(0, self.max_requests - used)
+        with self._lock:
+            window = self._prune(key, time.time())
+            used = len(window) if window else 0
+            return max(0, self.max_requests - used)
 
     def get_reset_time(self, key: Hashable) -> float:
         """Unix timestamp at which this key's oldest request leaves the window."""
-        window = self._requests.get(key)
-        if not window:
-            return time.time()
-        return window[0] + self.window_seconds
+        with self._lock:
+            window = self._requests.get(key)
+            if not window:
+                return time.time()
+            return window[0] + self.window_seconds
 
     def get_retry_after(self, key: Hashable) -> int:
         """Whole seconds a limited caller should wait, for the Retry-After header.
@@ -106,10 +133,11 @@ class SlidingWindowRateLimiter:
         Rounded up and floored at 1 - a Retry-After of 0 invites an immediate retry
         that would be rejected again.
         """
-        window = self._requests.get(key)
-        if not window:
-            return 0
-        return max(1, math.ceil(window[0] + self.window_seconds - time.time()))
+        with self._lock:
+            window = self._requests.get(key)
+            if not window:
+                return 0
+            return max(1, math.ceil(window[0] + self.window_seconds - time.time()))
 
     def rate_limit_headers(self, key: Hashable) -> Dict[str, str]:
         """Standard `429` headers for a rejected request.
@@ -118,17 +146,20 @@ class SlidingWindowRateLimiter:
         the limit in particular was previously hardcoded per endpoint and went stale
         the moment the limiter was configured differently.
         """
-        return {
-            "Retry-After": str(self.get_retry_after(key)),
-            "X-RateLimit-Limit": str(self.max_requests),
-            "X-RateLimit-Remaining": str(self.get_remaining_requests(key)),
-            "X-RateLimit-Reset": str(int(self.get_reset_time(key))),
-        }
+        with self._lock:
+            return {
+                "Retry-After": str(self.get_retry_after(key)),
+                "X-RateLimit-Limit": str(self.max_requests),
+                "X-RateLimit-Remaining": str(self.get_remaining_requests(key)),
+                "X-RateLimit-Reset": str(int(self.get_reset_time(key))),
+            }
 
     def reset(self) -> None:
         """Discard all recorded requests. For tests - module-scope limiter state
         otherwise leaks between them."""
-        self._requests.clear()
+        with self._lock:
+            self._requests.clear()
+            self._last_sweep = 0.0
 
 
 def get_client_ip(request: Request) -> str:

--- a/app/core/utils/rate_limit.py
+++ b/app/core/utils/rate_limit.py
@@ -1,0 +1,152 @@
+"""Shared in-memory sliding-window rate limiting.
+
+One implementation, extracted from the two hand-rolled copies that previously lived
+in ``app.api.v1.endpoints.system`` (IP-keyed) and
+``app.api.v1.endpoints.medical_specialty`` (user-keyed). The key is opaque to the
+limiter, so callers choose what they throttle on.
+
+Counters live in process memory: they are not shared between workers and do not
+survive a restart. That is adequate for abuse prevention, not for hard quotas.
+"""
+
+import math
+import time
+from collections import deque
+from collections.abc import Hashable
+from typing import Deque, Dict, Optional
+
+from fastapi import Request
+
+from app.core.logging.constants import sanitize_log_input
+
+
+class SlidingWindowRateLimiter:
+    """Allow at most ``max_requests`` per key within a rolling ``window_seconds``.
+
+    Entries are created only when a request is actually recorded, and a key whose
+    window prunes to empty is deleted rather than left behind - so a ``defaultdict``
+    does not accumulate an empty deque per key ever seen. Pruning is lazy, though:
+    it happens when a key is looked up again, which never comes for a key seen once.
+    ``_SWEEP_THRESHOLD`` bounds that residue.
+    """
+
+    # Past this many tracked keys, a request sweeps every stale key rather than only
+    # its own. Amortized O(1), and it caps the residue of one-shot keys - which for
+    # an IP-keyed limiter on an unauthenticated endpoint is one entry per address a
+    # distributed source cares to use. Well above any legitimate concurrent-client
+    # count, so a real deployment never pays for the sweep.
+    _SWEEP_THRESHOLD = 10000
+
+    def __init__(self, max_requests: int, window_seconds: int):
+        self.max_requests = max_requests
+        self.window_seconds = window_seconds
+        self._requests: Dict[Hashable, Deque[float]] = {}
+
+    def _prune(self, key: Hashable, now: float) -> Optional[Deque[float]]:
+        """Drop timestamps outside the window; return the live deque or None."""
+        window = self._requests.get(key)
+        if window is None:
+            return None
+
+        while window and window[0] <= now - self.window_seconds:
+            window.popleft()
+
+        if not window:
+            del self._requests[key]
+            return None
+
+        return window
+
+    def _sweep_stale_keys(self, now: float) -> None:
+        """Drop every key whose window has fully aged out."""
+        cutoff = now - self.window_seconds
+        stale = [
+            key
+            for key, window in self._requests.items()
+            if not window or window[-1] <= cutoff
+        ]
+        for key in stale:
+            del self._requests[key]
+
+    def is_allowed(self, key: Hashable) -> bool:
+        """Record a request and return whether it is under the limit."""
+        now = time.time()
+
+        if len(self._requests) > self._SWEEP_THRESHOLD:
+            self._sweep_stale_keys(now)
+
+        window = self._prune(key, now)
+
+        if window is None:
+            window = deque()
+
+        if len(window) < self.max_requests:
+            window.append(now)
+            self._requests[key] = window
+            return True
+
+        return False
+
+    def get_remaining_requests(self, key: Hashable) -> int:
+        """Requests still available to this key in the current window."""
+        window = self._prune(key, time.time())
+        used = len(window) if window else 0
+        return max(0, self.max_requests - used)
+
+    def get_reset_time(self, key: Hashable) -> float:
+        """Unix timestamp at which this key's oldest request leaves the window."""
+        window = self._requests.get(key)
+        if not window:
+            return time.time()
+        return window[0] + self.window_seconds
+
+    def get_retry_after(self, key: Hashable) -> int:
+        """Whole seconds a limited caller should wait, for the Retry-After header.
+
+        Rounded up and floored at 1 - a Retry-After of 0 invites an immediate retry
+        that would be rejected again.
+        """
+        window = self._requests.get(key)
+        if not window:
+            return 0
+        return max(1, math.ceil(window[0] + self.window_seconds - time.time()))
+
+    def rate_limit_headers(self, key: Hashable) -> Dict[str, str]:
+        """Standard `429` headers for a rejected request.
+
+        Lives here so every call site reports the same set from the same numbers -
+        the limit in particular was previously hardcoded per endpoint and went stale
+        the moment the limiter was configured differently.
+        """
+        return {
+            "Retry-After": str(self.get_retry_after(key)),
+            "X-RateLimit-Limit": str(self.max_requests),
+            "X-RateLimit-Remaining": str(self.get_remaining_requests(key)),
+            "X-RateLimit-Reset": str(int(self.get_reset_time(key))),
+        }
+
+    def reset(self) -> None:
+        """Discard all recorded requests. For tests - module-scope limiter state
+        otherwise leaks between them."""
+        self._requests.clear()
+
+
+def get_client_ip(request: Request) -> str:
+    """Safely extract the client IP, preferring proxy headers.
+
+    Shared so every IP-keyed limiter resolves addresses the same way. If a
+    deployment's reverse proxy does not set these headers, this resolves to the
+    proxy's own address and one limiter bucket covers every user behind it - a
+    pre-existing, app-wide property of this resolution, not of any one caller.
+    """
+    potential_ips = [
+        request.headers.get("x-forwarded-for", "").split(",")[0].strip(),
+        request.headers.get("x-real-ip", ""),
+        getattr(request.client, "host", "unknown") if request.client else "unknown",
+    ]
+
+    for ip in potential_ips:
+        if ip and ip != "unknown":
+            return sanitize_log_input(ip, max_length=45)  # IPv6 max length
+
+    return "unknown"

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -101,6 +101,19 @@ class User(Base):
     # Indexes for performance
     __table_args__ = (Index("idx_users_email", "email"),)
 
+    @property
+    def has_usable_password(self) -> bool:
+        """False for accounts whose password_hash is a discarded random token.
+
+        SSO-created accounts (crud/user.py create_from_sso) are given a random
+        password that is never revealed to anyone, so password-based flows
+        (forced change, local login) cannot be satisfied. password_hash is
+        nullable=False, so there is no "no password" state to check directly -
+        auth_method is the only signal. Admin password reset promotes 'sso' to
+        'hybrid' precisely so this stays true.
+        """
+        return self.auth_method != "sso"
+
 
 class UserPreferences(Base):
     """Stores per-user settings including units, language, session timeout, and integrations."""

--- a/app/services/sso_service.py
+++ b/app/services/sso_service.py
@@ -1,3 +1,4 @@
+import heapq
 import secrets
 from datetime import datetime, timedelta
 from typing import Dict, Optional
@@ -13,8 +14,122 @@ from app.crud.user import user as user_crud
 
 logger = get_logger(__name__, "sso")
 
-# In-memory state storage for temporary SSO tokens
+# Lifetime of every entry in _state_storage. Shared by the CSRF state tokens, the
+# account-conflict tokens, and the GitHub manual-link tokens so the sweep and the
+# three expiry checks cannot drift apart.
+_STATE_TTL = timedelta(minutes=10)
+
+# Defensive ceiling on the state store. Sweep-on-write bounds the store to what is
+# minted inside one TTL window, which the per-IP rate limit on /auth/sso/initiate
+# caps per source - but a distributed source can still grow it linearly. Roughly
+# 1 MB of entries: far above any legitimate self-hosted load, far below anything
+# that threatens the process.
+_STATE_STORE_MAX_ENTRIES = 10000
+
+# In-memory state storage for temporary SSO tokens.
+#
+# This dict is per-process, so it requires the server to run with a single worker:
+# a callback handled by a different worker than the one that minted the state would
+# fail validation. docker/entrypoint.sh pins --workers 1 on every startup path
+# (lines 180, 187, 191). Anyone raising the worker count must move this store to
+# shared storage (database or Redis) first, or SSO will fail intermittently.
+#
+# Three unrelated flows share this dict, keyed as:
+#   <state>                        - CSRF state for the authorization redirect
+#   sso_conflict_<token>           - pending account-conflict resolution
+#   github_manual_link_<token>     - pending GitHub manual account link
+# Write through _store_state_entry, which stamps the timestamps every entry must
+# carry and keeps the store swept and bounded on every write path.
 _state_storage = {}
+
+
+def _sweep_expired_states() -> int:
+    """Drop expired entries of every kind. Returns the number reclaimed."""
+    now = datetime.utcnow()
+    # Build the key list before deleting - mutating a dict during iteration raises.
+    expired = [
+        key for key, value in _state_storage.items() if value["expires_at"] <= now
+    ]
+    for key in expired:
+        del _state_storage[key]
+
+    if expired:
+        # debug, not info: under SSO_AUTO_REDIRECT this runs on every unauthenticated
+        # page load.
+        logger.debug(
+            f"Swept {len(expired)} expired SSO state entries",
+            extra={
+                "category": "sso",
+                "event": "sso_state_store_swept",
+                "reclaimed": len(expired),
+                "remaining": len(_state_storage),
+            },
+        )
+    return len(expired)
+
+
+def _enforce_state_store_cap() -> int:
+    """Evict oldest entries until the store fits under the cap. Returns evictions.
+
+    Only reached if a sweep left the store above the ceiling, which means either an
+    attack or a wildly misconfigured deployment. Eviction is safe: an evicted entry
+    fails its callback with the same "invalid or expired" error as a natural expiry,
+    so a legitimate caught-in-the-crossfire user just retries.
+    """
+    overflow = len(_state_storage) - _STATE_STORE_MAX_ENTRIES
+    if overflow <= 0:
+        return 0
+
+    # nsmallest, not a full sort: the cap runs on every write, so overflow is 1 in
+    # practice and sorting all 10,000 entries to find one minimum would make the
+    # defense cost more than the memory it protects.
+    oldest = heapq.nsmallest(
+        overflow, _state_storage.items(), key=lambda item: item[1]["created_at"]
+    )
+    for key, _ in oldest:
+        del _state_storage[key]
+
+    logger.warning(
+        "SSO state store exceeded capacity - evicted oldest entries",
+        extra={
+            "category": "security",
+            "event": "sso_state_store_capacity_exceeded",
+            "evicted": overflow,
+            "capacity": _STATE_STORE_MAX_ENTRIES,
+        },
+    )
+    return overflow
+
+
+def _serialize_user_info(user_info) -> Dict:
+    """Reduce a provider user-info object to a plain dict for storage."""
+    if hasattr(user_info, "model_dump"):
+        return user_info.model_dump()
+    if hasattr(user_info, "__dict__"):
+        return user_info.__dict__
+    return user_info
+
+
+def _store_state_entry(key: str, payload: Dict) -> None:
+    """Stamp and store a state entry, keeping the store swept and under its cap.
+
+    The single write path for all three token kinds. Sweeping here means conflict and
+    github-link entries are reclaimed by any subsequent SSO activity rather than by
+    an action of their own - so a wholly idle instance retains them until the next
+    sign-in attempt. The cap is enforced after the insert, so the store never exceeds
+    the ceiling; the entry just written is the newest, so oldest-first eviction never
+    discards it.
+    """
+    _sweep_expired_states()
+
+    now = datetime.utcnow()
+    _state_storage[key] = {
+        **payload,
+        "created_at": now,
+        "expires_at": now + _STATE_TTL,
+    }
+
+    _enforce_state_store_cap()
 
 
 class SSOService:
@@ -34,34 +149,34 @@ class SSOService:
         # Generate CSRF state token
         state = secrets.token_urlsafe(32)
 
-        # Store state with expiration (10 minutes)
-        _state_storage[state] = {
-            "created_at": datetime.utcnow(),
-            "return_url": return_url,
-        }
-
+        # Build the authorization URL before storing anything. A state entry has no
+        # value until the user is actually sent to the IdP, and storing it first would
+        # orphan an entry on every misconfigured-provider attempt - nothing would ever
+        # consume or delete it.
         try:
             provider = create_sso_provider()
             auth_url = provider.get_auth_url(state)
-
-            logger.info(
-                f"SSO authorization initiated for provider: {settings.SSO_PROVIDER_TYPE}",
-                extra={"category": "sso", "event": "auth_initiated"},
-            )
-
-            return {
-                "auth_url": auth_url,
-                "state": state,
-                "provider": settings.SSO_PROVIDER_TYPE,
-            }
         except Exception as e:
             logger.error(f"Failed to generate SSO auth URL: {str(e)}")
             raise SSOAuthenticationError("Failed to start SSO authentication")
 
+        _store_state_entry(state, {"return_url": return_url})
+
+        logger.info(
+            f"SSO authorization initiated for provider: {settings.SSO_PROVIDER_TYPE}",
+            extra={"category": "sso", "event": "auth_initiated"},
+        )
+
+        return {
+            "auth_url": auth_url,
+            "state": state,
+            "provider": settings.SSO_PROVIDER_TYPE,
+        }
+
     async def complete_authentication(self, code: str, state: str, db: Session) -> Dict:
         """Complete SSO authentication - no retry for OAuth codes (they're single-use)"""
         # Validate state and consume it (single-use)
-        self._validate_and_consume_state(state)
+        state_data = self._validate_and_consume_state(state)
 
         try:
             provider = create_sso_provider()
@@ -141,20 +256,29 @@ class SSOService:
                 },
             )
 
+        # Carry the deep link the flow started from back to the caller. Ships inert -
+        # no frontend reads it yet (deep links currently survive via sessionStorage,
+        # which fails in private browsing). See SSO_ONLY_MODE_SPEC.md 8.8.
+        result["return_url"] = state_data.get("return_url")
+
         return result
 
-    def _validate_and_consume_state(self, state: str):
-        """Validate and consume CSRF state token (single-use)"""
+    def _validate_and_consume_state(self, state: str) -> Dict:
+        """Validate and consume CSRF state token (single-use).
+
+        Returns the consumed entry so callers can read the ``return_url`` that
+        ``/auth/sso/initiate`` was given.
+        """
         if state not in _state_storage:
             raise SSOAuthenticationError("Invalid or expired state parameter")
 
-        # Check if state is expired (10 minutes)
         state_data = _state_storage[state]
-        if datetime.utcnow() - state_data["created_at"] > timedelta(minutes=10):
+        if datetime.utcnow() > state_data["expires_at"]:
             del _state_storage[state]
             raise SSOAuthenticationError("State parameter expired")
 
         del _state_storage[state]
+        return state_data
 
     @staticmethod
     def _extract_oauth_error(exc: Exception) -> str:
@@ -373,16 +497,13 @@ class SSOService:
 
         # Store conflict data temporarily
         conflict_key = f"sso_conflict_{temp_token}"
-        _state_storage[conflict_key] = {
-            "created_at": datetime.utcnow(),
-            "existing_user_id": existing_user.id,
-            "sso_user_info": (
-                user_info.model_dump()
-                if hasattr(user_info, "model_dump")
-                else user_info.__dict__ if hasattr(user_info, "__dict__") else user_info
-            ),
-            "expires_at": datetime.utcnow() + timedelta(minutes=10),
-        }
+        _store_state_entry(
+            conflict_key,
+            {
+                "existing_user_id": existing_user.id,
+                "sso_user_info": _serialize_user_info(user_info),
+            },
+        )
 
         return {
             "conflict": True,
@@ -412,15 +533,9 @@ class SSOService:
 
         # Store GitHub user info temporarily
         github_key = f"github_manual_link_{temp_token}"
-        _state_storage[github_key] = {
-            "created_at": datetime.utcnow(),
-            "sso_user_info": (
-                user_info.model_dump()
-                if hasattr(user_info, "model_dump")
-                else user_info.__dict__ if hasattr(user_info, "__dict__") else user_info
-            ),
-            "expires_at": datetime.utcnow() + timedelta(minutes=10),
-        }
+        _store_state_entry(
+            github_key, {"sso_user_info": _serialize_user_info(user_info)}
+        )
 
         return {
             "github_manual_link": True,
@@ -522,8 +637,9 @@ class SSOService:
         if not existing_user:
             raise SSOAuthenticationError("Invalid username or password")
 
-        # Verify password
-        if not verify_password(password, existing_user.password):
+        # Verify password. The column is password_hash - User has no `password`
+        # attribute, and reading one raised AttributeError on every manual link.
+        if not verify_password(password, str(existing_user.password_hash)):
             raise SSOAuthenticationError("Invalid username or password")
 
         # Link the GitHub account to the existing user

--- a/docs/SSO_TECHNICAL_OVERVIEW.md
+++ b/docs/SSO_TECHNICAL_OVERVIEW.md
@@ -472,7 +472,18 @@ all are single-use — validated and deleted in the same operation.
 
 Because the store is in process memory, the server must run with **one worker**. A callback
 handled by a different worker than the one that minted the state fails validation.
-`docker/entrypoint.sh` pins `--workers 1` on every startup path.
+
+Every supported startup path satisfies this today:
+
+| Path | Why it is single-process |
+|---|---|
+| Docker | `docker/entrypoint.sh` passes `--workers 1` explicitly |
+| Windows EXE / tray (`run.py`) | Builds a `uvicorn.Config` and calls `uvicorn.Server(...).run()` directly; the multiprocess supervisor is only reachable through `uvicorn.run()` with `workers > 1`, so `WEB_CONCURRENCY` has no effect |
+| Dev (`run.py`, reload) | `uvicorn.run(reload=True)` takes uvicorn's reload supervisor, which is single-worker |
+
+Only the Docker path states the constraint explicitly; the other two hold by construction.
+Anyone switching `run.py` to `uvicorn.run(..., workers=N)`, or dropping `--workers 1` from
+the entrypoint, must move this store to shared storage (database or Redis) first.
 
 Expired entries are swept on every `/auth/sso/initiate` write, so an abandoned flow (a user
 who closes the tab at the IdP, a crawler, a monitoring probe) is reclaimed by the next

--- a/docs/SSO_TECHNICAL_OVERVIEW.md
+++ b/docs/SSO_TECHNICAL_OVERVIEW.md
@@ -456,17 +456,43 @@ CREATE INDEX ix_users_sso_provider ON users(sso_provider);
 CREATE INDEX ix_users_email_auth_method ON users(email, auth_method);
 ```
 
-### Session Management
+### State Token Storage
 
-```python
-# Store minimal data in session
-session["sso_state"] = state
-session["sso_return_url"] = return_url
+There is no server-side session. `app/services/sso_service.py` keeps an in-process dict,
+`_state_storage`, holding three kinds of short-lived token:
 
-# Clean up after use
-del session["sso_state"]
-del session["sso_return_url"]
-```
+| Key | Created by | Payload |
+|---|---|---|
+| `<state>` | `/auth/sso/initiate` | `return_url` |
+| `sso_conflict_<token>` | an email that matches an existing account | the SSO user info |
+| `github_manual_link_<token>` | a GitHub user whose email is not exposed | the SSO user info |
+
+All three share one TTL (`_STATE_TTL`, 10 minutes) and one expiry field (`expires_at`), and
+all are single-use — validated and deleted in the same operation.
+
+Because the store is in process memory, the server must run with **one worker**. A callback
+handled by a different worker than the one that minted the state fails validation.
+`docker/entrypoint.sh` pins `--workers 1` on every startup path.
+
+Expired entries are swept on every `/auth/sso/initiate` write, so an abandoned flow (a user
+who closes the tab at the IdP, a crawler, a monitoring probe) is reclaimed by the next
+sign-in rather than retained forever. A hard ceiling of 10,000 entries evicts oldest-first
+as a backstop, logging `sso_state_store_capacity_exceeded`. An evicted or expired token
+produces the ordinary "Invalid or expired state parameter" error; retrying the sign-in
+works.
+
+### Rate Limiting
+
+`POST /auth/sso/initiate` is unauthenticated and mints a state entry per call, so it is
+throttled per client IP by `SSO_RATE_LIMIT_ATTEMPTS` per `SSO_RATE_LIMIT_WINDOW_MINUTES`
+(defaults: 10 per 10 minutes). The check runs *before* the state entry is created, which is
+what bounds the store against an anonymous caller. Exceeding it returns 429 with
+`Retry-After`, `X-RateLimit-*`, and `X-Error-Code: sso_rate_limited`, and logs
+`sso_initiate_rate_limited`.
+
+The limiter is `app/core/utils/rate_limit.SlidingWindowRateLimiter`, shared with the
+system log-level and medical-specialty create endpoints. Counters are per-process and do
+not survive a restart.
 
 ## Monitoring and Logging
 

--- a/docs/developer-guide/02-api-reference.md
+++ b/docs/developer-guide/02-api-reference.md
@@ -86,6 +86,13 @@
 - File upload endpoints: 50 requests/hour
 - Search endpoints: 30 requests/minute
 - System monitoring endpoints: 60 requests/minute per IP (`/system/log-level`, `/system/log-rotation-config`)
+- SSO sign-in: `SSO_RATE_LIMIT_ATTEMPTS` per `SSO_RATE_LIMIT_WINDOW_MINUTES` per IP,
+  default 10 per 10 minutes (`/auth/sso/initiate`)
+- Medical specialty creation: 20 requests/hour per **user** (`POST /medical-specialties/`)
+
+Every rate-limited endpoint returns `429` with `Retry-After`, `X-RateLimit-Limit`,
+`X-RateLimit-Remaining`, and `X-RateLimit-Reset`. Limits are enforced per process and
+reset on restart, so they are abuse prevention rather than hard quotas.
 
 ---
 
@@ -229,8 +236,14 @@ Base path: `/api/v1/auth/sso`
 
 - **Purpose**: Start SSO authentication flow
 - **Authentication**: No
+- **Rate Limited**: yes — `SSO_RATE_LIMIT_ATTEMPTS` per client IP per
+  `SSO_RATE_LIMIT_WINDOW_MINUTES` (defaults: 10 per 10 minutes)
 - **Query Parameters**:
   - `return_url` (string, optional): URL to redirect after authentication
+- **Error Response** (429): rate limit exceeded. Carries `Retry-After`,
+  `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`, and
+  `X-Error-Code: sso_rate_limited` — branch on the status or `X-Error-Code`, not on
+  the message text. A rate-limited request creates no server-side state entry.
 - **Success Response** (200):
 
 ```json
@@ -271,9 +284,15 @@ Base path: `/api/v1/auth/sso`
     "auth_method": "google_sso"
   },
   "is_new_user": false,
-  "must_change_password": false
+  "must_change_password": false,
+  "return_url": "/patients/42"
 }
 ```
+
+- **`return_url`**: the `return_url` that `/auth/sso/initiate` was given for this
+  flow, carried through the server-side state entry, or `null` if none was supplied.
+  Provided so a client can restore a deep link without relying on `sessionStorage`
+  (which is unavailable in private browsing). No client consumes it yet.
 
 - **`must_change_password`**: when `true`, the client must route the user to the
   forced password change flow — every other endpoint returns 403 until it completes.
@@ -339,8 +358,10 @@ Base path: `/api/v1/auth/sso`
 
 `POST /auth/sso/test-connection`
 
-- **Purpose**: Test SSO provider connectivity (admin)
-- **Authentication**: No (but intended for admin use)
+- **Purpose**: Test SSO provider connectivity
+- **Authentication**: Yes — admin role required. Each call makes the server perform an
+  outbound token exchange against the configured IdP and can echo provider
+  configuration detail, so it is not reachable anonymously.
 - **Success Response** (200):
 
 ```json
@@ -5270,6 +5291,12 @@ Base path: `/api/v1/admin/models`
 - **Note**: Password fields cannot be updated through this endpoint
 - **Request Body**: Fields to update
 - **Success Response** (200): Updated record object
+- **Error Response** (400): for `model_name: "user"`, setting
+  `must_change_password: true` on an account with `auth_method: "sso"` is refused —
+  such an account has no local password to change, so the flag would lock it out.
+  Reset the user's password first (which promotes the account to `hybrid`), then set
+  the flag. Clearing the flag (`false`) is always allowed. Audited as
+  `forced_password_change_blocked_sso_account`.
 
 #### Delete Model Record
 
@@ -5301,6 +5328,12 @@ Base path: `/api/v1/admin/models`
 
 - **Validation**: Min 6 chars, must contain letter and number
 - **Success Response** (200): `{"message": "Password reset successfully"}`
+- **Side effect**: an account with `auth_method: "sso"` is promoted to `"hybrid"`.
+  This grants no new capability — `/auth/login` authenticates on the password hash
+  alone and never read `auth_method`, so local login already worked the moment the
+  password was set. The promotion makes the stored label match that reality, which is
+  what the forced-password-change guard and the SSO login flow both key off. Audited
+  as `sso_account_promoted_to_hybrid`. `local` and `hybrid` accounts are untouched.
 
 ### 15.3 Backup Operations
 

--- a/docs/developer-guide/04-deployment.md
+++ b/docs/developer-guide/04-deployment.md
@@ -491,8 +491,24 @@ TRASH_RETENTION_DAYS=60
 | `SSO_ISSUER_URL`                | string     | -       | For OIDC       | OIDC issuer URL                                                           |
 | `SSO_REDIRECT_URI`              | string     | -       | If SSO enabled | OAuth redirect URI                                                        |
 | `SSO_ALLOWED_DOMAINS`           | JSON array | `[]`    | No             | Allowed email domains                                                     |
-| `SSO_RATE_LIMIT_ATTEMPTS`       | integer    | `10`    | No             | Max SSO attempts per window                                               |
+| `SSO_RATE_LIMIT_ATTEMPTS`       | integer    | `10`    | No             | Max `POST /auth/sso/initiate` calls per IP per window                     |
 | `SSO_RATE_LIMIT_WINDOW_MINUTES` | integer    | `10`    | No             | Rate limit window                                                         |
+
+**SSO rate limiting:** these two variables throttle `POST /api/v1/auth/sso/initiate`,
+the unauthenticated endpoint that starts the sign-in redirect. Exceeding the limit
+returns `429` with `Retry-After` and `X-RateLimit-*` headers. The limit is **per client
+IP**, and counters live in process memory - they are not shared between workers and
+reset when the container restarts.
+
+Two consequences worth knowing before tuning these:
+
+- Behind a reverse proxy that does not set `X-Forwarded-For` or `X-Real-IP`, every
+  request resolves to the proxy's address and shares a single bucket. Set those
+  headers on your proxy.
+- Each sign-in attempt is one attempt against the limit. If a future release adds
+  automatic redirect-to-IdP on unauthenticated page loads, a household or CGNAT range
+  sharing one address could plausibly reach the default 10-per-10-minutes. Raise
+  `SSO_RATE_LIMIT_ATTEMPTS` if legitimate users report being turned away.
 
 **Example (Google):**
 

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -75,7 +75,13 @@ def make_sso_user(db_session: Session):
         # is discarded immediately, so no caller can present it. Handing these users
         # a known password would let a test "prove" an SSO-only account logs in
         # locally, which is true only after an admin reset promotes it to hybrid.
-        password = secrets.token_urlsafe(32) if auth_method == "sso" else LOCAL_PASSWORD
+        #
+        # The "A1" prefix is load-bearing: UserCreate requires at least one letter
+        # and one digit, and a bare token_urlsafe contains no digit about 1 time in
+        # 1500 - a flake that would surface as an unrelated ValidationError.
+        password = (
+            f"A1{secrets.token_urlsafe(32)}" if auth_method == "sso" else LOCAL_PASSWORD
+        )
 
         user = user_crud.create(
             db_session,

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -2,8 +2,10 @@
 Shared fixtures for API tests.
 """
 
-import pytest
+import secrets
 from datetime import date, timedelta
+
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -52,6 +54,11 @@ def limiter_ceiling():
         limiter.reset()
 
 
+# The password given to local and hybrid users built by make_sso_user. Pure-SSO
+# users get a random one instead - see the factory.
+LOCAL_PASSWORD = "localpassword123"
+
+
 @pytest.fixture
 def make_sso_user(db_session: Session):
     """Create a user with the SSO fields and flags a test needs."""
@@ -64,12 +71,18 @@ def make_sso_user(db_session: Session):
         is_active: bool = True,
         link_sso_identity: bool = True,
     ) -> User:
+        # Model create_from_sso: a pure-SSO account is given a random password that
+        # is discarded immediately, so no caller can present it. Handing these users
+        # a known password would let a test "prove" an SSO-only account logs in
+        # locally, which is true only after an admin reset promotes it to hybrid.
+        password = secrets.token_urlsafe(32) if auth_method == "sso" else LOCAL_PASSWORD
+
         user = user_crud.create(
             db_session,
             obj_in=UserCreate(
                 username=username,
                 email=f"{username}@example.com",
-                password="localpassword123",
+                password=password,
                 full_name="SSO Test User",
                 role="user",
             ),

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -8,8 +8,85 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from app.crud.patient import patient as patient_crud
+from app.crud.user import user as user_crud
+from app.models.models import User
 from app.schemas.patient import PatientCreate
+from app.schemas.user import UserCreate
+from app.services.sso_service import _state_storage
 from tests.utils.user import create_random_user, create_user_token_headers
+
+
+@pytest.fixture
+def clean_sso_state():
+    """Empty the SSO state store around a test.
+
+    ``_state_storage`` is module-level and leaks between tests otherwise. Opt in
+    with ``pytestmark = pytest.mark.usefixtures("clean_sso_state")``.
+    """
+    _state_storage.clear()
+    yield
+    _state_storage.clear()
+
+
+@pytest.fixture
+def limiter_ceiling():
+    """Temporarily lower a rate limiter's ceiling, restoring it afterwards.
+
+    Limiters are module-scope singletons built from settings at import time, so
+    patching a setting has no effect on the already-built object - a test sets the
+    attribute on the instance instead. Counters are cleared on both sides so limits
+    do not leak between tests.
+    """
+    originals = []
+
+    def apply(limiter, max_requests: int):
+        originals.append((limiter, limiter.max_requests))
+        limiter.reset()
+        limiter.max_requests = max_requests
+        return limiter
+
+    yield apply
+
+    for limiter, original in originals:
+        limiter.max_requests = original
+        limiter.reset()
+
+
+@pytest.fixture
+def make_sso_user(db_session: Session):
+    """Create a user with the SSO fields and flags a test needs."""
+
+    def factory(
+        *,
+        username: str = "ssouser",
+        auth_method: str = "sso",
+        must_change_password: bool = False,
+        is_active: bool = True,
+        link_sso_identity: bool = True,
+    ) -> User:
+        user = user_crud.create(
+            db_session,
+            obj_in=UserCreate(
+                username=username,
+                email=f"{username}@example.com",
+                password="localpassword123",
+                full_name="SSO Test User",
+                role="user",
+            ),
+            must_change_password=must_change_password,
+        )
+
+        user.auth_method = auth_method
+        user.is_active = is_active
+        if link_sso_identity:
+            user.external_id = f"external-{username}"
+            user.sso_provider = "google"
+        db_session.commit()
+        db_session.refresh(user)
+
+        return user
+
+    return factory
 
 
 @pytest.fixture

--- a/tests/api/test_admin_forced_password_change_guard.py
+++ b/tests/api/test_admin_forced_password_change_guard.py
@@ -1,0 +1,236 @@
+"""Tests for the forced-password-change guard and the auth_method promotion.
+
+A pure-SSO account's password_hash is a random token that was discarded at
+creation, so must_change_password can never be satisfied and locks the account out
+until its next SSO login clears it. Two changes make that coherent:
+
+1. Admin password reset promotes 'sso' to 'hybrid' - the account genuinely has a
+   usable local password from that moment, and /auth/login already accepted it.
+2. PUT /admin/models/user/{id} refuses to set the flag on an account that has no
+   usable password.
+
+The two interact: the admin UI resets first, then sets the flag, so the flag write
+sees a 'hybrid' account and is allowed.
+"""
+
+import logging
+
+import pytest
+
+from app.models.models import User
+
+ADMIN_MODELS_LOGGER = "medical_records.app.api.v1.admin.models"
+
+
+def user_url(user_id: int) -> str:
+    return f"/api/v1/admin/models/user/{user_id}"
+
+
+def reset_url(user_id: int) -> str:
+    return f"/api/v1/admin/models/users/{user_id}/reset-password"
+
+
+@pytest.fixture
+def make_user(make_sso_user):
+    """Create a user with a given auth_method and no linked SSO identity."""
+
+    def factory(
+        auth_method: str = "sso",
+        username: str = "guardtarget",
+        must_change_password: bool = False,
+    ) -> User:
+        return make_sso_user(
+            username=username,
+            auth_method=auth_method,
+            must_change_password=must_change_password,
+            link_sso_identity=False,
+        )
+
+    return factory
+
+
+class TestHasUsablePassword:
+    """The property the guard and the SSO login clear both key off."""
+
+    @pytest.mark.parametrize(
+        "auth_method, expected",
+        [("sso", False), ("local", True), ("hybrid", True)],
+    )
+    def test_property_for_each_auth_method(self, make_user, auth_method, expected):
+        user = make_user(auth_method=auth_method, username=f"prop{auth_method}")
+
+        assert user.has_usable_password is expected
+
+
+class TestForcedChangeGuard:
+    def test_setting_the_flag_on_an_sso_account_is_refused(
+        self, admin_client, make_user, db_session
+    ):
+        user = make_user(auth_method="sso")
+
+        response = admin_client.put(
+            user_url(user.id), json={"must_change_password": True}
+        )
+
+        assert response.status_code == 400
+        db_session.expire_all()
+        assert db_session.get(User, user.id).must_change_password is False
+
+    def test_refusal_message_says_what_to_do_instead(self, admin_client, make_user):
+        user = make_user(auth_method="sso", username="msgtarget")
+
+        response = admin_client.put(
+            user_url(user.id), json={"must_change_password": True}
+        )
+
+        body = str(response.json())
+        assert "SSO-only account" in body
+        assert "Reset the user's password first" in body
+
+    def test_refusal_emits_a_security_event(self, admin_client, make_user, caplog):
+        user = make_user(auth_method="sso", username="eventtarget")
+
+        with caplog.at_level(logging.WARNING, logger=ADMIN_MODELS_LOGGER):
+            admin_client.put(user_url(user.id), json={"must_change_password": True})
+
+        events = [getattr(record, "event", None) for record in caplog.records]
+        assert "forced_password_change_blocked_sso_account" in events
+
+    @pytest.mark.parametrize("auth_method", ["local", "hybrid"])
+    def test_setting_the_flag_on_a_password_account_still_works(
+        self, admin_client, make_user, db_session, auth_method
+    ):
+        user = make_user(auth_method=auth_method, username=f"allow{auth_method}")
+
+        response = admin_client.put(
+            user_url(user.id), json={"must_change_password": True}
+        )
+
+        assert response.status_code == 200
+        db_session.expire_all()
+        assert db_session.get(User, user.id).must_change_password is True
+
+    def test_clearing_the_flag_on_an_sso_account_is_always_allowed(
+        self, admin_client, make_user, db_session
+    ):
+        user = make_user(
+            auth_method="sso", username="clearme", must_change_password=True
+        )
+
+        response = admin_client.put(
+            user_url(user.id), json={"must_change_password": False}
+        )
+
+        assert response.status_code == 200
+        db_session.expire_all()
+        assert db_session.get(User, user.id).must_change_password is False
+
+    def test_unrelated_updates_to_an_sso_account_are_unaffected(
+        self, admin_client, make_user
+    ):
+        user = make_user(auth_method="sso", username="unrelated")
+
+        response = admin_client.put(user_url(user.id), json={"full_name": "New Name"})
+
+        assert response.status_code == 200
+
+
+class TestAuthMethodPromotion:
+    def test_reset_promotes_an_sso_account_to_hybrid(
+        self, admin_client, make_user, db_session
+    ):
+        user = make_user(auth_method="sso", username="promoteme")
+
+        response = admin_client.post(
+            reset_url(user.id), json={"new_password": "newpassword123"}
+        )
+
+        assert response.status_code == 200
+        db_session.expire_all()
+        assert db_session.get(User, user.id).auth_method == "hybrid"
+
+    def test_promotion_emits_a_security_event(self, admin_client, make_user, caplog):
+        user = make_user(auth_method="sso", username="promoteevent")
+
+        with caplog.at_level(logging.WARNING, logger=ADMIN_MODELS_LOGGER):
+            admin_client.post(
+                reset_url(user.id), json={"new_password": "newpassword123"}
+            )
+
+        events = [getattr(record, "event", None) for record in caplog.records]
+        assert "sso_account_promoted_to_hybrid" in events
+
+    @pytest.mark.parametrize("auth_method", ["local", "hybrid"])
+    def test_reset_leaves_other_auth_methods_untouched(
+        self, admin_client, make_user, db_session, auth_method
+    ):
+        user = make_user(auth_method=auth_method, username=f"keep{auth_method}")
+
+        admin_client.post(reset_url(user.id), json={"new_password": "newpassword123"})
+
+        db_session.expire_all()
+        assert db_session.get(User, user.id).auth_method == auth_method
+
+
+class TestResetThenForceChangeSequence:
+    """The order UserManagement.jsx issues these two calls in is load-bearing."""
+
+    def test_reset_then_force_change_succeeds_end_to_end(
+        self, admin_client, make_user, db_session
+    ):
+        user = make_user(auth_method="sso", username="sequence")
+
+        reset = admin_client.post(
+            reset_url(user.id), json={"new_password": "newpassword123"}
+        )
+        force = admin_client.put(user_url(user.id), json={"must_change_password": True})
+
+        assert reset.status_code == 200
+        assert force.status_code == 200
+
+        db_session.expire_all()
+        refreshed = db_session.get(User, user.id)
+        assert refreshed.auth_method == "hybrid"
+        assert refreshed.must_change_password is True
+
+    def test_force_change_before_any_reset_is_refused(self, admin_client, make_user):
+        """Documents the dependency: reversing the two calls breaks the flow."""
+        user = make_user(auth_method="sso", username="reversed")
+
+        response = admin_client.put(
+            user_url(user.id), json={"must_change_password": True}
+        )
+
+        assert response.status_code == 400
+
+    def test_reversing_the_order_would_also_wipe_the_flag(
+        self, admin_client, make_user, db_session
+    ):
+        """update_password clears must_change_password, so a reset after the flag
+        write would undo it even on an account that passes the guard."""
+        user = make_user(
+            auth_method="local", username="wipeorder", must_change_password=False
+        )
+
+        admin_client.put(user_url(user.id), json={"must_change_password": True})
+        admin_client.post(reset_url(user.id), json={"new_password": "newpassword123"})
+
+        db_session.expire_all()
+        assert db_session.get(User, user.id).must_change_password is False
+
+
+class TestPromotedAccountLogin:
+    def test_promoted_account_logs_in_locally_with_the_new_password(
+        self, admin_client, client, make_user
+    ):
+        """The promotion asserts a capability the account already had - prove it."""
+        user = make_user(auth_method="sso", username="localloginafterreset")
+
+        admin_client.post(reset_url(user.id), json={"new_password": "newpassword123"})
+
+        response = client.post(
+            "/api/v1/auth/login",
+            data={"username": "localloginafterreset", "password": "newpassword123"},
+        )
+
+        assert response.status_code == 200

--- a/tests/api/test_admin_forced_password_change_guard.py
+++ b/tests/api/test_admin_forced_password_change_guard.py
@@ -18,6 +18,7 @@ import logging
 import pytest
 
 from app.models.models import User
+from tests.api.conftest import LOCAL_PASSWORD
 
 ADMIN_MODELS_LOGGER = "medical_records.app.api.v1.admin.models"
 
@@ -220,6 +221,20 @@ class TestResetThenForceChangeSequence:
 
 
 class TestPromotedAccountLogin:
+    def test_sso_only_account_cannot_log_in_locally_before_a_reset(
+        self, client, make_user
+    ):
+        """The state has_usable_password describes: the account's password is a
+        random token nobody holds, so no local credential can satisfy /auth/login."""
+        make_user(auth_method="sso", username="nolocalpassword")
+
+        response = client.post(
+            "/api/v1/auth/login",
+            data={"username": "nolocalpassword", "password": LOCAL_PASSWORD},
+        )
+
+        assert response.status_code != 200
+
     def test_promoted_account_logs_in_locally_with_the_new_password(
         self, admin_client, client, make_user
     ):

--- a/tests/api/test_rate_limit_migration.py
+++ b/tests/api/test_rate_limit_migration.py
@@ -1,0 +1,115 @@
+"""Regression cover for the two endpoints migrated onto the shared rate limiter.
+
+Both previously had their own hand-rolled limiter class. Neither had a test, which
+is why the migration needs one: the observable behavior at each call site must be
+unchanged.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.v1.endpoints import medical_specialty as specialty_endpoint
+from app.api.v1.endpoints import system as system_endpoint
+
+LOG_LEVEL_URL = "/api/v1/system/log-level"
+SPECIALTY_URL = "/api/v1/medical-specialties/"
+
+
+@pytest.fixture
+def system_limit(limiter_ceiling):
+    """Set the log-level limiter's ceiling, restoring the shipped value after."""
+    return lambda n: limiter_ceiling(system_endpoint.rate_limiter, n)
+
+
+@pytest.fixture
+def specialty_limit(limiter_ceiling):
+    return lambda n: limiter_ceiling(specialty_endpoint._create_limiter, n)
+
+
+class TestSystemLogLevelStillRateLimits:
+    def test_requests_under_the_limit_succeed(self, client: TestClient, system_limit):
+        system_limit(2)
+
+        assert client.get(LOG_LEVEL_URL).status_code == 200
+        assert client.get(LOG_LEVEL_URL).status_code == 200
+
+    def test_over_the_limit_returns_429(self, client: TestClient, system_limit):
+        system_limit(1)
+        client.get(LOG_LEVEL_URL)
+
+        assert client.get(LOG_LEVEL_URL).status_code == 429
+
+    def test_429_still_returns_the_rate_limit_headers(
+        self, client: TestClient, system_limit
+    ):
+        system_limit(1)
+        client.get(LOG_LEVEL_URL)
+
+        response = client.get(LOG_LEVEL_URL)
+
+        # The limit reported must be the limiter's own, not a hardcoded constant.
+        assert response.headers["X-RateLimit-Limit"] == "1"
+        assert response.headers["X-RateLimit-Remaining"] == "0"
+        assert "X-RateLimit-Reset" in response.headers
+        assert int(response.headers["Retry-After"]) >= 1
+
+    def test_successful_response_still_reports_rate_limit_info(
+        self, client: TestClient, system_limit
+    ):
+        system_limit(5)
+
+        body = client.get(LOG_LEVEL_URL).json()
+
+        assert "rate_limit_info" in body
+
+    def test_limits_are_per_ip(self, client: TestClient, system_limit):
+        system_limit(1)
+        client.get(LOG_LEVEL_URL, headers={"X-Forwarded-For": "198.51.100.30"})
+
+        exhausted = client.get(
+            LOG_LEVEL_URL, headers={"X-Forwarded-For": "198.51.100.30"}
+        )
+        other = client.get(LOG_LEVEL_URL, headers={"X-Forwarded-For": "198.51.100.31"})
+
+        assert exhausted.status_code == 429
+        assert other.status_code == 200
+
+
+class TestSpecialtyCreateStillRateLimits:
+    def test_creates_under_the_limit_succeed(
+        self, authenticated_client: TestClient, specialty_limit
+    ):
+        specialty_limit(2)
+
+        first = authenticated_client.post(SPECIALTY_URL, json={"name": "Cardiology"})
+        second = authenticated_client.post(SPECIALTY_URL, json={"name": "Neurology"})
+
+        assert first.status_code in (200, 201)
+        assert second.status_code in (200, 201)
+
+    def test_over_the_limit_returns_429_with_retry_after(
+        self, authenticated_client: TestClient, specialty_limit
+    ):
+        specialty_limit(1)
+        authenticated_client.post(SPECIALTY_URL, json={"name": "Dermatology"})
+
+        response = authenticated_client.post(SPECIALTY_URL, json={"name": "Oncology"})
+
+        assert response.status_code == 429
+        assert int(response.headers["Retry-After"]) >= 1
+
+    def test_limit_is_keyed_per_user_not_per_ip(
+        self, authenticated_client: TestClient, specialty_limit, admin_token_headers
+    ):
+        """Users behind a shared NAT must not be limited collectively."""
+        specialty_limit(1)
+        authenticated_client.post(SPECIALTY_URL, json={"name": "Radiology"})
+        assert (
+            authenticated_client.post(SPECIALTY_URL, json={"name": "Urology"})
+        ).status_code == 429
+
+        other_user = authenticated_client.post(
+            SPECIALTY_URL, json={"name": "Pathology"}, headers=admin_token_headers
+        )
+
+        assert other_user.status_code in (200, 201)

--- a/tests/api/test_sso_github_manual_link.py
+++ b/tests/api/test_sso_github_manual_link.py
@@ -1,0 +1,234 @@
+"""Tests for GitHub manual account linking against real User rows.
+
+This flow was completely broken: the credential check read ``existing_user.password``,
+an attribute User does not have, so every attempt raised AttributeError and the
+endpoint's broad except turned it into a 500. It survived earlier work because the
+existing coverage patches ``sso_service.resolve_github_manual_link`` itself, so the
+credential check underneath never executed.
+
+These tests therefore call the real service method against a real user with a real
+password hash. Nothing here may patch resolve_github_manual_link.
+"""
+
+import inspect
+from datetime import datetime, timedelta
+
+import pytest
+
+from app.auth.sso.base_provider import SSOUserInfo
+from app.auth.sso.exceptions import SSOAuthenticationError
+from app.auth.sso.providers import GitHubProvider
+from app.core.utils.security import verify_password
+from app.crud.user import user as user_crud
+from app.models.models import User
+from app.schemas.user import UserCreate
+from app.services.sso_service import _STATE_TTL, SSOService, _state_storage
+
+PASSWORD = "linkpassword123"
+TEMP_TOKEN = "github-temp-token"
+
+
+pytestmark = pytest.mark.usefixtures("clean_sso_state")
+
+
+@pytest.fixture
+def service():
+    return SSOService()
+
+
+@pytest.fixture
+def local_user(db_session) -> User:
+    return user_crud.create(
+        db_session,
+        obj_in=UserCreate(
+            username="githublinker",
+            email="githublinker@example.com",
+            password=PASSWORD,
+            full_name="GitHub Linker",
+            role="user",
+        ),
+    )
+
+
+def store_link_token(token: str = TEMP_TOKEN, *, age: timedelta = timedelta(0)) -> str:
+    created_at = datetime.utcnow() - age
+    key = f"github_manual_link_{token}"
+    _state_storage[key] = {
+        "created_at": created_at,
+        "sso_user_info": {
+            "sub": "github-12345",
+            "email": None,
+            "name": "GitHub Linker",
+        },
+        "expires_at": created_at + _STATE_TTL,
+    }
+    return key
+
+
+class TestSuccessfulLink:
+    def test_correct_password_links_the_account(self, service, db_session, local_user):
+        key = store_link_token()
+
+        result = service.resolve_github_manual_link(
+            TEMP_TOKEN, "githublinker", PASSWORD, db_session
+        )
+
+        assert result["user"].id == local_user.id
+        assert result["is_new_user"] is False
+        assert key not in _state_storage  # single-use
+
+    def test_link_records_the_github_identity(self, service, db_session, local_user):
+        store_link_token()
+
+        service.resolve_github_manual_link(
+            TEMP_TOKEN, "githublinker", PASSWORD, db_session
+        )
+
+        db_session.refresh(local_user)
+        assert local_user.external_id == "github-12345"
+        assert local_user.last_sso_login is not None
+
+    def test_link_promotes_local_to_hybrid(self, service, db_session, local_user):
+        assert local_user.auth_method == "local"
+        store_link_token()
+
+        service.resolve_github_manual_link(
+            TEMP_TOKEN, "githublinker", PASSWORD, db_session
+        )
+
+        db_session.refresh(local_user)
+        assert local_user.auth_method == "hybrid"
+        assert local_user.account_linked_at is not None
+
+
+class TestRejectedCredentials:
+    def test_wrong_password_raises_the_auth_error_not_an_attribute_error(
+        self, service, db_session, local_user
+    ):
+        """The regression: this used to raise AttributeError, surfacing as a 500."""
+        store_link_token()
+
+        with pytest.raises(
+            SSOAuthenticationError, match="Invalid username or password"
+        ):
+            service.resolve_github_manual_link(
+                TEMP_TOKEN, "githublinker", "wrongpassword", db_session
+            )
+
+    def test_unknown_username_gives_the_same_error(
+        self, service, db_session, local_user
+    ):
+        """Identical responses - a differing one would enumerate usernames."""
+        store_link_token()
+
+        with pytest.raises(
+            SSOAuthenticationError, match="Invalid username or password"
+        ):
+            service.resolve_github_manual_link(
+                TEMP_TOKEN, "nosuchuser", PASSWORD, db_session
+            )
+
+    def test_failed_attempt_does_not_consume_the_token(
+        self, service, db_session, local_user
+    ):
+        """A typo must not force the user back through the whole OAuth redirect."""
+        key = store_link_token()
+
+        with pytest.raises(SSOAuthenticationError):
+            service.resolve_github_manual_link(
+                TEMP_TOKEN, "githublinker", "wrongpassword", db_session
+            )
+
+        assert key in _state_storage
+
+    def test_failed_attempt_does_not_link_the_account(
+        self, service, db_session, local_user
+    ):
+        store_link_token()
+
+        with pytest.raises(SSOAuthenticationError):
+            service.resolve_github_manual_link(
+                TEMP_TOKEN, "githublinker", "wrongpassword", db_session
+            )
+
+        db_session.refresh(local_user)
+        assert local_user.external_id is None
+        assert local_user.auth_method == "local"
+
+
+class TestTokenExpiry:
+    def test_expired_token_is_rejected_and_deleted(
+        self, service, db_session, local_user
+    ):
+        key = store_link_token(age=_STATE_TTL + timedelta(minutes=1))
+
+        with pytest.raises(SSOAuthenticationError, match="expired"):
+            service.resolve_github_manual_link(
+                TEMP_TOKEN, "githublinker", PASSWORD, db_session
+            )
+
+        assert key not in _state_storage
+
+    def test_unknown_token_is_rejected(self, service, db_session, local_user):
+        with pytest.raises(SSOAuthenticationError, match="Invalid or expired"):
+            service.resolve_github_manual_link(
+                "never-issued", "githublinker", PASSWORD, db_session
+            )
+
+
+class TestManualLinkPrompt:
+    """The prompt the user answers has to name the account it is asking about."""
+
+    def test_github_user_info_carries_the_login_name(self):
+        info = GitHubProvider("id", "secret", "https://app/callback").format_user_info(
+            {"id": 12345, "login": "octocat", "name": "The Octocat", "email": None}
+        )
+
+        assert info.username == "octocat"
+
+    def test_manual_link_response_uses_the_github_username(self, service):
+        info = SSOUserInfo(sub="github-1", email=None, username="octocat", name="Octo")
+
+        result = service._return_github_manual_linking(info)
+
+        assert result["github_user_info"]["github_username"] == "octocat"
+
+    def test_missing_login_falls_back_to_a_generic_label(self, service):
+        info = SSOUserInfo(sub="github-1", email=None, name="Octo")
+
+        result = service._return_github_manual_linking(info)
+
+        assert result["github_user_info"]["github_username"] == "GitHub User"
+
+
+class TestCoverageIsHonest:
+    """The defect this module covers survived precisely because the existing tests
+    patched the service method, so the credential check never ran. Assert that the
+    method these tests call is the real implementation, not a stand-in."""
+
+    def test_method_under_test_is_not_patched(self):
+        method = SSOService.resolve_github_manual_link
+
+        assert inspect.isfunction(method)
+        assert method.__module__ == "app.services.sso_service"
+
+    def test_credential_check_actually_runs(self, service, db_session, local_user):
+        """Fails if verify_password is never reached - the shape of the old bug."""
+        store_link_token()
+        calls = []
+
+        def spy(plain, hashed):
+            calls.append((plain, hashed))
+            # verify_password is imported into this module's namespace at import
+            # time, so this name still refers to the real function after the patch.
+            return verify_password(plain, hashed)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("app.core.utils.security.verify_password", spy)
+            service.resolve_github_manual_link(
+                TEMP_TOKEN, "githublinker", PASSWORD, db_session
+            )
+
+        assert len(calls) == 1
+        assert calls[0][0] == PASSWORD
+        assert calls[0][1] == local_user.password_hash

--- a/tests/api/test_sso_must_change_password.py
+++ b/tests/api/test_sso_must_change_password.py
@@ -201,6 +201,29 @@ class TestForcedChangePreservedForOtherAuthMethods:
         db_session.expire_all()
         assert db_session.get(User, user_id).must_change_password is True
 
+    def test_promoted_account_keeps_the_flag_on_the_next_sso_login(
+        self, client: TestClient, db_session: Session
+    ):
+        """An admin reset promotes 'sso' to 'hybrid', which is what makes the
+        forced change satisfiable. Before that promotion existed, this login
+        silently reverted an admin security action."""
+        user = make_sso_user(
+            db_session,
+            username="promoteduser",
+            auth_method="hybrid",
+            must_change_password=True,
+        )
+        user_id = user.id
+
+        with patch_callback(user):
+            response = client.post(CALLBACK_URL, json=CALLBACK_BODY)
+
+        assert response.status_code == 200
+        assert response.json()["must_change_password"] is True
+
+        db_session.expire_all()
+        assert db_session.get(User, user_id).must_change_password is True
+
     def test_password_login_leaves_flag_untouched(
         self, client: TestClient, db_session: Session
     ):

--- a/tests/api/test_sso_rate_limit.py
+++ b/tests/api/test_sso_rate_limit.py
@@ -1,0 +1,165 @@
+"""Tests for the rate limit on POST /auth/sso/initiate and the /test-connection guard.
+
+/initiate is unauthenticated and mints an in-memory state entry per call, so the
+limit is what bounds the state store against an anonymous caller. The assertion
+that a limited request mints *no* state entry is the point of the whole exercise.
+"""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.v1.endpoints import sso as sso_endpoint
+from app.services import sso_service as sso_module
+from app.services.sso_service import _state_storage
+
+INITIATE_URL = "/api/v1/auth/sso/initiate"
+TEST_CONNECTION_URL = "/api/v1/auth/sso/test-connection"
+
+SSO_ENDPOINT_LOGGER = "medical_records.sso.api.v1.endpoints.sso"
+
+
+pytestmark = pytest.mark.usefixtures("clean_sso_state")
+
+
+@pytest.fixture
+def limit_of(limiter_ceiling):
+    """Set the live limiter's ceiling, restoring the configured value afterwards."""
+    return lambda n: limiter_ceiling(sso_endpoint._initiate_limiter, n)
+
+
+@pytest.fixture
+def sso_working():
+    """SSO enabled with a provider that builds an auth URL."""
+    with patch.object(sso_module.settings, "SSO_ENABLED", True):
+        with patch.object(sso_module, "create_sso_provider") as factory:
+            factory.return_value.get_auth_url.return_value = "https://idp/authorize"
+            yield factory
+
+
+class TestInitiateRateLimit:
+    def test_requests_up_to_the_limit_succeed(
+        self, client: TestClient, sso_working, limit_of
+    ):
+        limit_of(3)
+
+        for _ in range(3):
+            assert client.post(INITIATE_URL).status_code == 200
+
+    def test_the_next_request_is_rejected_with_429(
+        self, client: TestClient, sso_working, limit_of
+    ):
+        limit_of(2)
+        for _ in range(2):
+            client.post(INITIATE_URL)
+
+        response = client.post(INITIATE_URL)
+
+        assert response.status_code == 429
+
+    def test_429_carries_retry_after_and_rate_limit_headers(
+        self, client: TestClient, sso_working, limit_of
+    ):
+        limit_of(1)
+        client.post(INITIATE_URL)
+
+        response = client.post(INITIATE_URL)
+
+        assert int(response.headers["Retry-After"]) >= 1
+        assert response.headers["X-RateLimit-Limit"] == "1"
+        assert response.headers["X-RateLimit-Remaining"] == "0"
+        assert "X-RateLimit-Reset" in response.headers
+
+    def test_429_is_machine_distinguishable_from_other_sso_failures(
+        self, client: TestClient, sso_working, limit_of
+    ):
+        """PR 5 must be able to branch on this without matching the message text."""
+        limit_of(1)
+        client.post(INITIATE_URL)
+
+        response = client.post(INITIATE_URL)
+
+        assert response.headers["X-Error-Code"] == "sso_rate_limited"
+
+    def test_429_emits_a_security_event(
+        self, client: TestClient, sso_working, limit_of, caplog
+    ):
+        limit_of(1)
+        client.post(INITIATE_URL)
+
+        with caplog.at_level(logging.WARNING, logger=SSO_ENDPOINT_LOGGER):
+            client.post(INITIATE_URL)
+
+        events = [getattr(record, "event", None) for record in caplog.records]
+        assert "sso_initiate_rate_limited" in events
+
+    def test_a_limited_request_mints_no_state_entry(
+        self, client: TestClient, sso_working, limit_of
+    ):
+        """The whole point of pairing the limit with the state store sweep."""
+        limit_of(1)
+        client.post(INITIATE_URL)
+        assert len(_state_storage) == 1
+
+        response = client.post(INITIATE_URL)
+
+        assert response.status_code == 429
+        assert len(_state_storage) == 1
+
+    def test_limits_are_per_ip(self, client: TestClient, sso_working, limit_of):
+        limit_of(1)
+        client.post(INITIATE_URL, headers={"X-Forwarded-For": "198.51.100.1"})
+
+        exhausted = client.post(
+            INITIATE_URL, headers={"X-Forwarded-For": "198.51.100.1"}
+        )
+        other_ip = client.post(
+            INITIATE_URL, headers={"X-Forwarded-For": "198.51.100.2"}
+        )
+
+        assert exhausted.status_code == 429
+        assert other_ip.status_code == 200
+
+    def test_window_reset_allows_the_next_request(
+        self, client: TestClient, sso_working, limit_of
+    ):
+        limit_of(1)
+
+        with patch("app.core.utils.rate_limit.time.time", return_value=5000.0):
+            assert client.post(INITIATE_URL).status_code == 200
+            assert client.post(INITIATE_URL).status_code == 429
+
+        window = sso_endpoint._initiate_limiter.window_seconds
+        with patch(
+            "app.core.utils.rate_limit.time.time", return_value=5000.0 + window + 1
+        ):
+            assert client.post(INITIATE_URL).status_code == 200
+
+
+class TestTestConnectionRequiresAdmin:
+    """The endpoint makes the server do outbound network I/O on demand and can echo
+    provider configuration detail, so it must not be anonymous."""
+
+    def test_anonymous_caller_is_rejected(self, client: TestClient):
+        response = client.post(TEST_CONNECTION_URL)
+
+        assert response.status_code in (401, 403)
+
+    def test_non_admin_user_is_rejected(self, authenticated_client: TestClient):
+        response = authenticated_client.post(TEST_CONNECTION_URL)
+
+        assert response.status_code == 403
+
+    def test_admin_still_reaches_the_endpoint(self, admin_client: TestClient):
+        with patch.object(
+            sso_endpoint.sso_service,
+            "test_connection",
+            return_value={"success": True, "message": "ok"},
+        ) as mocked:
+            mocked.return_value = {"success": True, "message": "ok"}
+            response = admin_client.post(TEST_CONNECTION_URL)
+
+        assert response.status_code == 200
+        assert response.json()["success"] is True

--- a/tests/api/test_sso_return_url.py
+++ b/tests/api/test_sso_return_url.py
@@ -1,0 +1,108 @@
+"""The return_url given to /initiate is carried through to the /callback response.
+
+Ships inert - no frontend reads this field yet. Deep links currently survive SSO via
+sessionStorage, which does not work in private browsing; the consumer for this field
+is a later PR (SSO_ONLY_MODE_SPEC.md 8.8). Tested now because the field is easy to
+drop silently while nothing depends on it.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.models.models import User
+from app.services import sso_service as sso_module
+from app.services.sso_service import _state_storage
+
+INITIATE_URL = "/api/v1/auth/sso/initiate"
+CALLBACK_URL = "/api/v1/auth/sso/callback"
+
+
+pytestmark = pytest.mark.usefixtures("clean_sso_state")
+
+
+@pytest.fixture
+def sso_user(make_sso_user) -> User:
+    return make_sso_user(username="returnurluser")
+
+
+@pytest.fixture
+def sso_flow(sso_user):
+    """SSO enabled, with the provider and token exchange stubbed out.
+
+    The state entry is real - only the outbound IdP calls are replaced - so the
+    return_url genuinely travels through the state store.
+    """
+    with patch.object(sso_module.settings, "SSO_ENABLED", True):
+        with patch.object(sso_module, "create_sso_provider") as factory:
+            factory.return_value.get_auth_url.return_value = "https://idp/authorize"
+            with patch.object(
+                sso_module.SSOService,
+                "_find_or_create_user",
+                return_value={
+                    "user": sso_user,
+                    "is_new_user": False,
+                    "auth_method": "sso",
+                },
+            ):
+                yield factory
+
+
+def stub_token_exchange(factory):
+    """Make the provider return a token and user info without network access."""
+    provider = factory.return_value
+
+    async def exchange(_code):
+        return {"access_token": "token"}
+
+    async def user_info(_token):
+        class Info:
+            sub = "external-returnurl"
+            email = "returnurluser@example.com"
+            name = "Return URL User"
+
+        return Info()
+
+    provider.exchange_code_for_token = exchange
+    provider.get_user_info = user_info
+
+
+def test_callback_returns_the_return_url_that_initiate_was_given(
+    client: TestClient, sso_flow
+):
+    stub_token_exchange(sso_flow)
+
+    initiate = client.post(INITIATE_URL, params={"return_url": "/patients/42"})
+    state = initiate.json()["state"]
+
+    response = client.post(CALLBACK_URL, json={"code": "authcode", "state": state})
+
+    assert response.status_code == 200
+    assert response.json()["return_url"] == "/patients/42"
+
+
+def test_flow_started_without_a_return_url_yields_null(client: TestClient, sso_flow):
+    stub_token_exchange(sso_flow)
+
+    initiate = client.post(INITIATE_URL)
+    state = initiate.json()["state"]
+
+    response = client.post(CALLBACK_URL, json={"code": "authcode", "state": state})
+
+    assert response.status_code == 200
+    assert response.json()["return_url"] is None
+
+
+def test_the_state_entry_is_still_single_use(client: TestClient, sso_flow):
+    stub_token_exchange(sso_flow)
+
+    initiate = client.post(INITIATE_URL, params={"return_url": "/patients/42"})
+    state = initiate.json()["state"]
+
+    first = client.post(CALLBACK_URL, json={"code": "authcode", "state": state})
+    second = client.post(CALLBACK_URL, json={"code": "authcode", "state": state})
+
+    assert first.status_code == 200
+    assert second.status_code != 200
+    assert state not in _state_storage

--- a/tests/api/test_sso_state_store.py
+++ b/tests/api/test_sso_state_store.py
@@ -1,0 +1,367 @@
+"""Tests for the in-memory SSO state store: expiry sweeping and the hard cap.
+
+The store holds three unrelated entry shapes - the CSRF ``state`` for the
+authorization redirect, ``sso_conflict_*`` for a pending account conflict, and
+``github_manual_link_*`` for a pending GitHub link. They were written with two
+different expiry conventions, so a sweep that only ever saw ``state`` entries in
+tests would raise on the first real conflict flow. Every sweep test below runs
+against a store holding all three.
+"""
+
+import logging
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from app.services import sso_service as sso_module
+from app.services.sso_service import (
+    _STATE_STORE_MAX_ENTRIES,
+    _STATE_TTL,
+    SSOService,
+    _state_storage,
+    _sweep_expired_states,
+)
+from app.auth.sso.exceptions import SSOAuthenticationError
+
+pytestmark = pytest.mark.usefixtures("clean_sso_state")
+
+
+def put_state(key: str, *, age: timedelta = timedelta(0), return_url=None) -> str:
+    """Insert a CSRF state entry created ``age`` ago."""
+    created_at = datetime.utcnow() - age
+    _state_storage[key] = {
+        "created_at": created_at,
+        "expires_at": created_at + _STATE_TTL,
+        "return_url": return_url,
+    }
+    return key
+
+
+def put_conflict(token: str, *, age: timedelta = timedelta(0)) -> str:
+    """Insert an account-conflict entry created ``age`` ago."""
+    created_at = datetime.utcnow() - age
+    key = f"sso_conflict_{token}"
+    _state_storage[key] = {
+        "created_at": created_at,
+        "existing_user_id": 1,
+        "sso_user_info": {
+            "sub": "external-1",
+            "email": "conflict@example.com",
+            "name": "Conflict User",
+        },
+        "expires_at": created_at + _STATE_TTL,
+    }
+    return key
+
+
+def put_github_link(token: str, *, age: timedelta = timedelta(0)) -> str:
+    """Insert a GitHub manual-link entry created ``age`` ago."""
+    created_at = datetime.utcnow() - age
+    key = f"github_manual_link_{token}"
+    _state_storage[key] = {
+        "created_at": created_at,
+        "sso_user_info": {
+            "sub": "github-1",
+            "email": None,
+            "name": "GitHub User",
+        },
+        "expires_at": created_at + _STATE_TTL,
+    }
+    return key
+
+
+EXPIRED = _STATE_TTL + timedelta(minutes=1)
+
+# get_logger() namespaces by category, so the module's logger is not named after
+# its import path.
+SSO_LOGGER_NAME = "medical_records.sso.services.sso_service"
+
+
+@pytest.fixture
+def service():
+    """An SSOService built while SSO is disabled.
+
+    SSOService.__init__ runs validate_sso_config() when SSO_ENABLED is true, which
+    a test environment cannot satisfy. Constructing here and enabling SSO afterwards
+    keeps the tests focused on the state store rather than on provider config.
+    """
+    with patch.object(sso_module.settings, "SSO_ENABLED", False):
+        instance = SSOService()
+    return instance
+
+
+@pytest.fixture
+def sso_enabled():
+    with patch.object(sso_module.settings, "SSO_ENABLED", True):
+        yield
+
+
+@pytest.fixture
+def working_provider():
+    with patch.object(sso_module, "create_sso_provider") as factory:
+        factory.return_value.get_auth_url.return_value = "https://idp/authorize"
+        yield factory
+
+
+class TestSweep:
+    def test_sweep_of_empty_store_does_not_raise(self):
+        assert _sweep_expired_states() == 0
+
+    def test_expired_entry_is_reclaimed(self):
+        put_state("stale", age=EXPIRED)
+
+        assert _sweep_expired_states() == 1
+        assert "stale" not in _state_storage
+
+    def test_live_entry_survives(self):
+        put_state("fresh")
+
+        assert _sweep_expired_states() == 0
+        assert "fresh" in _state_storage
+
+    def test_mixed_store_drops_only_expired_entries_of_each_kind(self):
+        """A sweep must handle all three shapes in one pass without raising."""
+        stale_state = put_state("stale-state", age=EXPIRED)
+        stale_conflict = put_conflict("stale", age=EXPIRED)
+        stale_github = put_github_link("stale", age=EXPIRED)
+        live_state = put_state("live-state")
+        live_conflict = put_conflict("live")
+        live_github = put_github_link("live")
+
+        assert _sweep_expired_states() == 3
+
+        for key in (stale_state, stale_conflict, stale_github):
+            assert key not in _state_storage
+        for key in (live_state, live_conflict, live_github):
+            assert key in _state_storage
+
+    def test_expired_conflict_entry_retains_no_pii(self):
+        """conflict entries carry email and display name - reclaiming them matters."""
+        key = put_conflict("stale", age=EXPIRED)
+
+        _sweep_expired_states()
+
+        assert key not in _state_storage
+        assert not any(
+            "conflict@example.com" in str(value) for value in _state_storage.values()
+        )
+
+
+class TestSweepOnWrite:
+    """get_authorization_url is the only sweep trigger."""
+
+    @pytest.mark.asyncio
+    async def test_write_reclaims_expired_entries_of_every_kind(
+        self, service, sso_enabled, working_provider
+    ):
+        put_state("stale-state", age=EXPIRED)
+        put_conflict("stale", age=EXPIRED)
+        put_github_link("stale", age=EXPIRED)
+
+        result = await service.get_authorization_url()
+
+        # Only the entry just minted remains.
+        assert list(_state_storage) == [result["state"]]
+
+    @pytest.mark.asyncio
+    async def test_live_entry_survives_another_users_write(
+        self, service, sso_enabled, working_provider
+    ):
+        put_state("someone-elses-live-flow")
+
+        await service.get_authorization_url()
+
+        assert "someone-elses-live-flow" in _state_storage
+
+    @pytest.mark.asyncio
+    async def test_new_entry_carries_expires_at_and_return_url(
+        self, service, sso_enabled, working_provider
+    ):
+        result = await service.get_authorization_url("/dashboard")
+
+        entry = _state_storage[result["state"]]
+        assert entry["return_url"] == "/dashboard"
+        assert entry["expires_at"] == entry["created_at"] + _STATE_TTL
+
+    @pytest.mark.asyncio
+    async def test_consumed_state_is_still_single_use_after_a_sweep(
+        self, service, sso_enabled, working_provider
+    ):
+        result = await service.get_authorization_url()
+        state = result["state"]
+
+        service._validate_and_consume_state(state)
+
+        # A later sweep must not resurrect it or mask the second consumption.
+        _sweep_expired_states()
+        with pytest.raises(SSOAuthenticationError):
+            service._validate_and_consume_state(state)
+
+
+class TestOrphanOnFailure:
+    """A failed initiate must leave no entry behind - nothing would ever delete it."""
+
+    @pytest.mark.asyncio
+    async def test_provider_construction_failure_stores_nothing(
+        self, service, sso_enabled
+    ):
+        with patch.object(
+            sso_module, "create_sso_provider", side_effect=ValueError("bad config")
+        ):
+            with pytest.raises(SSOAuthenticationError):
+                await service.get_authorization_url()
+
+        assert len(_state_storage) == 0
+
+    @pytest.mark.asyncio
+    async def test_auth_url_failure_stores_nothing(self, service, sso_enabled):
+        with patch.object(sso_module, "create_sso_provider") as factory:
+            factory.return_value.get_auth_url.side_effect = ValueError("no issuer")
+            with pytest.raises(SSOAuthenticationError):
+                await service.get_authorization_url()
+
+        assert len(_state_storage) == 0
+
+
+class TestCapacityCap:
+    def fill_to_cap(self):
+        """Fill the store to the ceiling with entries that are all still live.
+
+        Ages are microseconds apart so ordering is well-defined while every entry
+        stays inside the TTL - otherwise the sweep would reclaim them and the cap
+        would never be reached.
+        """
+        base = datetime.utcnow()
+        for i in range(_STATE_STORE_MAX_ENTRIES):
+            created_at = base - timedelta(microseconds=_STATE_STORE_MAX_ENTRIES - i)
+            _state_storage[f"live-{i}"] = {
+                "created_at": created_at,
+                "expires_at": created_at + _STATE_TTL,
+                "return_url": None,
+            }
+
+    @pytest.mark.asyncio
+    async def test_exceeding_the_cap_evicts_oldest_first(
+        self, service, sso_enabled, working_provider
+    ):
+        self.fill_to_cap()
+
+        result = await service.get_authorization_url()
+
+        assert len(_state_storage) == _STATE_STORE_MAX_ENTRIES
+        assert "live-0" not in _state_storage  # oldest evicted
+        assert "live-1" in _state_storage
+        assert result["state"] in _state_storage  # the new entry survives
+
+    @pytest.mark.asyncio
+    async def test_cap_breach_emits_security_event(
+        self, service, sso_enabled, working_provider, caplog
+    ):
+        self.fill_to_cap()
+
+        with caplog.at_level(logging.WARNING, logger=SSO_LOGGER_NAME):
+            await service.get_authorization_url()
+
+        events = [getattr(record, "event", None) for record in caplog.records]
+        assert "sso_state_store_capacity_exceeded" in events
+
+    @pytest.mark.asyncio
+    async def test_evicted_state_fails_with_the_normal_invalid_state_error(
+        self, service, sso_enabled, working_provider
+    ):
+        """Eviction must look like expiry to the caller, not like a 500."""
+        victim = await service.get_authorization_url()
+        # Make the victim the oldest entry, then overfill.
+        _state_storage[victim["state"]]["created_at"] = datetime.utcnow() - timedelta(
+            minutes=1
+        )
+        self.fill_to_cap()
+
+        await service.get_authorization_url()
+
+        assert victim["state"] not in _state_storage
+        with pytest.raises(SSOAuthenticationError, match="Invalid or expired state"):
+            service._validate_and_consume_state(victim["state"])
+
+    def test_under_the_cap_evicts_nothing(self):
+        put_state("keep-me")
+
+        assert sso_module._enforce_state_store_cap() == 0
+        assert "keep-me" in _state_storage
+
+
+class TestConsumedStateReturnsEntry:
+    """spec 8.8 - the consumed entry is returned so return_url can be threaded out."""
+
+    def test_returns_the_stored_entry(self):
+        put_state("with-url", return_url="/patients/5")
+
+        entry = SSOService()._validate_and_consume_state("with-url")
+
+        assert entry["return_url"] == "/patients/5"
+        assert "with-url" not in _state_storage
+
+    def test_flow_started_without_a_return_url_yields_none(self):
+        put_state("no-url")
+
+        entry = SSOService()._validate_and_consume_state("no-url")
+
+        assert entry["return_url"] is None
+
+    def test_expired_state_is_rejected_and_deleted(self):
+        put_state("stale", age=EXPIRED)
+
+        with pytest.raises(SSOAuthenticationError, match="State parameter expired"):
+            SSOService()._validate_and_consume_state("stale")
+
+        assert "stale" not in _state_storage
+
+    def test_unknown_state_is_rejected(self):
+        with pytest.raises(SSOAuthenticationError, match="Invalid or expired state"):
+            SSOService()._validate_and_consume_state("never-existed")
+
+
+class TestNormalizedWritesStillExpireCorrectly:
+    """Regression cover for the two read sites the normalization touched."""
+
+    def test_expired_conflict_token_is_rejected_and_deleted(self, db_session):
+        key = put_conflict("stale", age=EXPIRED)
+
+        with pytest.raises(SSOAuthenticationError, match="expired"):
+            SSOService().resolve_account_conflict(
+                "stale", "link", "auto_link", db_session
+            )
+
+        assert key not in _state_storage
+
+    def test_expired_github_link_token_is_rejected_and_deleted(self, db_session):
+        key = put_github_link("stale", age=EXPIRED)
+
+        with pytest.raises(SSOAuthenticationError, match="expired"):
+            SSOService().resolve_github_manual_link(
+                "stale", "someuser", "somepassword", db_session
+            )
+
+        assert key not in _state_storage
+
+    def test_live_conflict_token_passes_the_expiry_check(self, db_session):
+        """A live token gets past expiry and fails later, on the missing user."""
+        put_conflict("live")
+        _state_storage["sso_conflict_live"]["existing_user_id"] = 999999
+
+        with pytest.raises(SSOAuthenticationError, match="Existing user not found"):
+            SSOService().resolve_account_conflict(
+                "live", "link", "auto_link", db_session
+            )
+
+    def test_live_github_token_passes_the_expiry_check(self, db_session):
+        """A live token gets past expiry and fails later, on the unknown username."""
+        put_github_link("live")
+
+        with pytest.raises(
+            SSOAuthenticationError, match="Invalid username or password"
+        ):
+            SSOService().resolve_github_manual_link(
+                "live", "nosuchuser", "somepassword", db_session
+            )

--- a/tests/core/test_rate_limit.py
+++ b/tests/core/test_rate_limit.py
@@ -1,0 +1,212 @@
+"""Unit tests for the shared sliding-window rate limiter.
+
+The limiter backs three endpoints with different keys (IP and user id), so the
+boundary behavior is tested here once rather than at each call site.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from app.core.utils.rate_limit import SlidingWindowRateLimiter, get_client_ip
+
+
+@pytest.fixture
+def limiter():
+    return SlidingWindowRateLimiter(max_requests=3, window_seconds=60)
+
+
+class FakeRequest:
+    """Minimal stand-in for a Request - get_client_ip reads headers and client."""
+
+    class _Client:
+        def __init__(self, host):
+            self.host = host
+
+    def __init__(self, headers=None, host="203.0.113.7"):
+        self.headers = headers or {}
+        self.client = self._Client(host) if host else None
+
+
+class TestLimitBoundary:
+    def test_requests_up_to_the_limit_are_allowed(self, limiter):
+        assert [limiter.is_allowed("k") for _ in range(3)] == [True, True, True]
+
+    def test_one_over_the_limit_is_rejected(self, limiter):
+        for _ in range(3):
+            limiter.is_allowed("k")
+
+        assert limiter.is_allowed("k") is False
+
+    def test_rejection_does_not_extend_the_window(self, limiter):
+        """A rejected request must not be recorded, or the window would never drain."""
+        for _ in range(3):
+            limiter.is_allowed("k")
+        first_reset = limiter.get_reset_time("k")
+
+        limiter.is_allowed("k")
+
+        assert limiter.get_reset_time("k") == first_reset
+
+    def test_keys_are_independent(self, limiter):
+        for _ in range(3):
+            limiter.is_allowed("first")
+
+        assert limiter.is_allowed("second") is True
+
+
+class TestWindowExpiry:
+    def test_first_request_after_a_full_window_is_allowed(self, limiter):
+        with patch("app.core.utils.rate_limit.time.time", return_value=1000.0):
+            for _ in range(3):
+                limiter.is_allowed("k")
+            assert limiter.is_allowed("k") is False
+
+        with patch("app.core.utils.rate_limit.time.time", return_value=1061.0):
+            assert limiter.is_allowed("k") is True
+
+    def test_partial_window_expiry_frees_exactly_one_slot(self, limiter):
+        with patch("app.core.utils.rate_limit.time.time", return_value=1000.0):
+            limiter.is_allowed("k")
+        with patch("app.core.utils.rate_limit.time.time", return_value=1030.0):
+            limiter.is_allowed("k")
+            limiter.is_allowed("k")
+
+        # At t=1061 only the first request has aged out.
+        with patch("app.core.utils.rate_limit.time.time", return_value=1061.0):
+            assert limiter.is_allowed("k") is True
+            assert limiter.is_allowed("k") is False
+
+    def test_pruned_to_empty_key_is_deleted(self, limiter):
+        """Idle keys must not accumulate - this is why it is not a defaultdict."""
+        with patch("app.core.utils.rate_limit.time.time", return_value=1000.0):
+            limiter.is_allowed("k")
+        assert "k" in limiter._requests
+
+        with patch("app.core.utils.rate_limit.time.time", return_value=1061.0):
+            limiter.get_remaining_requests("k")
+
+        assert "k" not in limiter._requests
+
+    def test_unseen_key_creates_no_entry(self, limiter):
+        limiter.get_remaining_requests("never-seen")
+        limiter.get_retry_after("never-seen")
+        limiter.get_reset_time("never-seen")
+
+        assert limiter._requests == {}
+
+
+class TestHeaderHelpers:
+    def test_remaining_counts_down(self, limiter):
+        assert limiter.get_remaining_requests("k") == 3
+        limiter.is_allowed("k")
+        assert limiter.get_remaining_requests("k") == 2
+
+    def test_remaining_is_zero_at_the_limit(self, limiter):
+        for _ in range(3):
+            limiter.is_allowed("k")
+
+        assert limiter.get_remaining_requests("k") == 0
+
+    def test_reset_time_is_the_oldest_request_plus_the_window(self, limiter):
+        with patch("app.core.utils.rate_limit.time.time", return_value=1000.0):
+            limiter.is_allowed("k")
+            assert limiter.get_reset_time("k") == 1060.0
+
+    def test_retry_after_is_never_zero_while_limited(self, limiter):
+        """A Retry-After of 0 invites an immediate retry that would fail again."""
+        with patch("app.core.utils.rate_limit.time.time", return_value=1000.0):
+            for _ in range(3):
+                limiter.is_allowed("k")
+
+        # 0.5s left in the window rounds up to 1, not down to 0.
+        with patch("app.core.utils.rate_limit.time.time", return_value=1059.5):
+            assert limiter.get_retry_after("k") == 1
+
+    def test_retry_after_is_zero_for_an_unknown_key(self, limiter):
+        assert limiter.get_retry_after("k") == 0
+
+
+class TestRateLimitHeaders:
+    """One header set, built from the limiter's own numbers, for every call site."""
+
+    def test_headers_report_the_limiters_configured_limit(self, limiter):
+        for _ in range(3):
+            limiter.is_allowed("k")
+
+        headers = limiter.rate_limit_headers("k")
+
+        assert headers["X-RateLimit-Limit"] == "3"
+        assert headers["X-RateLimit-Remaining"] == "0"
+
+    def test_limit_header_follows_a_reconfigured_ceiling(self, limiter):
+        """A hardcoded per-endpoint limit went stale the moment this changed."""
+        limiter.max_requests = 1
+        limiter.is_allowed("k")
+
+        assert limiter.rate_limit_headers("k")["X-RateLimit-Limit"] == "1"
+
+    def test_headers_carry_a_usable_retry_after_and_reset(self, limiter):
+        with patch("app.core.utils.rate_limit.time.time", return_value=1000.0):
+            for _ in range(3):
+                limiter.is_allowed("k")
+
+            headers = limiter.rate_limit_headers("k")
+
+        assert headers["Retry-After"] == "60"
+        assert headers["X-RateLimit-Reset"] == "1060"
+
+
+class TestKeyStoreIsBounded:
+    """Keys seen once are pruned only on lookup, so a threshold sweep bounds them."""
+
+    def test_stale_keys_are_swept_once_past_the_threshold(self, limiter):
+        with patch("app.core.utils.rate_limit.time.time", return_value=1000.0):
+            for i in range(limiter._SWEEP_THRESHOLD + 1):
+                limiter.is_allowed(f"one-shot-{i}")
+
+        assert len(limiter._requests) == limiter._SWEEP_THRESHOLD + 1
+
+        # A later request past the threshold sweeps every window that has aged out.
+        with patch("app.core.utils.rate_limit.time.time", return_value=1061.0):
+            limiter.is_allowed("fresh")
+
+        assert len(limiter._requests) == 1
+        assert "fresh" in limiter._requests
+
+    def test_sweep_does_not_drop_live_keys(self, limiter):
+        with patch("app.core.utils.rate_limit.time.time", return_value=1000.0):
+            for i in range(limiter._SWEEP_THRESHOLD + 1):
+                limiter.is_allowed(f"one-shot-{i}")
+
+        # Only 30s later - nothing has aged out of a 60s window.
+        with patch("app.core.utils.rate_limit.time.time", return_value=1030.0):
+            limiter.is_allowed("fresh")
+
+        assert len(limiter._requests) == limiter._SWEEP_THRESHOLD + 2
+
+    def test_reset_clears_recorded_requests(self, limiter):
+        for _ in range(3):
+            limiter.is_allowed("k")
+
+        limiter.reset()
+
+        assert limiter.is_allowed("k") is True
+
+
+class TestGetClientIp:
+    def test_prefers_x_forwarded_for(self):
+        request = FakeRequest({"x-forwarded-for": "198.51.100.4, 10.0.0.1"})
+
+        assert get_client_ip(request) == "198.51.100.4"
+
+    def test_falls_back_to_x_real_ip(self):
+        request = FakeRequest({"x-real-ip": "198.51.100.9"})
+
+        assert get_client_ip(request) == "198.51.100.9"
+
+    def test_falls_back_to_the_socket_address(self):
+        assert get_client_ip(FakeRequest()) == "203.0.113.7"
+
+    def test_returns_unknown_without_a_client(self):
+        assert get_client_ip(FakeRequest(host=None)) == "unknown"

--- a/tests/core/test_rate_limit.py
+++ b/tests/core/test_rate_limit.py
@@ -127,6 +127,37 @@ class TestHeaderHelpers:
     def test_retry_after_is_zero_for_an_unknown_key(self, limiter):
         assert limiter.get_retry_after("k") == 0
 
+    def test_retry_after_is_zero_once_the_window_has_expired(self, limiter):
+        """A fully-expired window is no limit at all - reading it unpruned would
+        floor to 1 and tell the caller to wait for a limit that has lapsed."""
+        with patch("app.core.utils.rate_limit.time.time", return_value=1000.0):
+            for _ in range(3):
+                limiter.is_allowed("k")
+
+        with patch("app.core.utils.rate_limit.time.time", return_value=1061.0):
+            assert limiter.get_retry_after("k") == 0
+
+    def test_reset_time_is_not_in_the_past_once_the_window_has_expired(self, limiter):
+        """Unpruned, this would report oldest + window - a timestamp already gone."""
+        with patch("app.core.utils.rate_limit.time.time", return_value=1000.0):
+            for _ in range(3):
+                limiter.is_allowed("k")
+
+        with patch("app.core.utils.rate_limit.time.time", return_value=1061.0):
+            assert limiter.get_reset_time("k") == 1061.0
+
+    def test_headers_are_self_consistent_after_expiry(self, limiter):
+        """Remaining prunes and the other two did not, so they could disagree."""
+        with patch("app.core.utils.rate_limit.time.time", return_value=1000.0):
+            for _ in range(3):
+                limiter.is_allowed("k")
+
+        with patch("app.core.utils.rate_limit.time.time", return_value=1061.0):
+            headers = limiter.rate_limit_headers("k")
+
+        assert headers["X-RateLimit-Remaining"] == "3"
+        assert headers["Retry-After"] == "0"
+
 
 class TestRateLimitHeaders:
     """One header set, built from the limiter's own numbers, for every call site."""
@@ -233,6 +264,12 @@ class TestThreadSafety:
             thread.join()
 
         assert sum(admitted) == 10
+
+        # Timestamps are read under the lock, so they land in lock-acquisition
+        # order. _prune pops from the left only while the leftmost is expired, so
+        # an out-of-order deque would strand expired entries.
+        recorded = list(limiter._requests["shared"])
+        assert recorded == sorted(recorded)
 
     def test_concurrent_mixed_operations_complete(self):
         """Smoke cover for the locked paths under real parallelism: reads nested

--- a/tests/core/test_rate_limit.py
+++ b/tests/core/test_rate_limit.py
@@ -4,6 +4,7 @@ The limiter backs three endpoints with different keys (IP and user id), so the
 boundary behavior is tested here once rather than at each call site.
 """
 
+import threading
 from unittest.mock import patch
 
 import pytest
@@ -184,6 +185,87 @@ class TestKeyStoreIsBounded:
             limiter.is_allowed("fresh")
 
         assert len(limiter._requests) == limiter._SWEEP_THRESHOLD + 2
+
+    def test_sweep_runs_at_most_once_per_window(self, limiter):
+        """A store held above the threshold by live keys must not be rescanned on
+        every request - that would make the defense the amplifier."""
+        with patch("app.core.utils.rate_limit.time.time", return_value=1000.0):
+            for i in range(limiter._SWEEP_THRESHOLD + 1):
+                limiter.is_allowed(f"live-{i}")
+            # The threshold is crossed by the final insert, so the next request is
+            # the first one to see an over-threshold store and sweep.
+            limiter.is_allowed("trigger")
+
+        assert limiter._last_sweep == 1000.0
+
+        # Still over the threshold, but inside the same window: no rescan.
+        with patch("app.core.utils.rate_limit.time.time", return_value=1030.0):
+            limiter.is_allowed("x")
+
+        assert limiter._last_sweep == 1000.0
+
+        # A full window later, one sweep is allowed again.
+        with patch("app.core.utils.rate_limit.time.time", return_value=1061.0):
+            limiter.is_allowed("y")
+
+        assert limiter._last_sweep == 1061.0
+
+
+class TestThreadSafety:
+    """Three of the four call sites are sync `def` endpoints, which FastAPI runs in
+    a threadpool - so these paths genuinely execute in parallel."""
+
+    def test_concurrent_requests_do_not_exceed_the_limit(self):
+        limiter = SlidingWindowRateLimiter(max_requests=10, window_seconds=60)
+        admitted = []
+        barrier = threading.Barrier(8)
+
+        def hammer():
+            barrier.wait()  # maximize overlap on the read-modify-write
+            for _ in range(20):
+                if limiter.is_allowed("shared"):
+                    admitted.append(1)
+
+        threads = [threading.Thread(target=hammer) for _ in range(8)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert sum(admitted) == 10
+
+    def test_concurrent_mixed_operations_complete(self):
+        """Smoke cover for the locked paths under real parallelism: reads nested
+        inside writes complete without error and without deadlocking.
+
+        The nesting matters - rate_limit_headers takes the lock and then calls
+        getters that take it again, so a plain Lock here would hang. It is a weaker
+        test than the over-admission one above: an interleaving that corrupts the
+        dict mid-sweep is possible in principle but did not reproduce on demand.
+        """
+        limiter = SlidingWindowRateLimiter(max_requests=1000, window_seconds=60)
+        for i in range(limiter._SWEEP_THRESHOLD + 1):
+            limiter.is_allowed(f"seed-{i}")
+
+        errors = []
+        barrier = threading.Barrier(4)
+
+        def hammer(worker: int):
+            barrier.wait()
+            try:
+                for i in range(200):
+                    limiter.is_allowed(f"w{worker}-{i}")
+                    limiter.rate_limit_headers(f"w{worker}-{i}")
+            except Exception as exc:  # noqa: BLE001 - the assertion is "none raised"
+                errors.append(exc)
+
+        threads = [threading.Thread(target=hammer, args=(n,)) for n in range(4)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert errors == []
 
     def test_reset_clears_recorded_requests(self, limiter):
         for _ in range(3):


### PR DESCRIPTION
## Summary

This pull request introduces a new shared in-memory rate limiter utility (`SlidingWindowRateLimiter`) and refactors several endpoints to use it instead of custom or duplicated rate limiting logic. It also improves SSO account handling, especially around password resets and forced password changes, and tightens access controls on sensitive endpoints. The changes enhance security, maintainability, and consistency across the codebase.

**Rate Limiting Improvements:**

* Replaced custom, per-endpoint rate limiter classes in `system.py` and `medical_specialty.py` with a shared `SlidingWindowRateLimiter` utility, simplifying the code and ensuring consistent rate limiting behavior. The new utility provides standard headers and methods for rate limit status, and is now used for endpoints like log level, SSO initiation, and specialty creation. [[1]](diffhunk://#diff-07b9a370716b6d241427783bdc73a96bb43d60e32441dbef3867e0f67dd3ee35L40-R41) [[2]](diffhunk://#diff-ad9a4d13dcb32e22b303be8b17e934e63e43054c7c06576f4836ee8f56a9684fL36-R40) [[3]](diffhunk://#diff-a725c777f5f5020730d97e1e27a293d5f5ae297f4e413691b4e02b674011bb96R21-R44)
* Updated endpoints to use the new rate limiter's methods and headers, improving the clarity of rate limit responses and making it easier for clients to handle rate limiting. [[1]](diffhunk://#diff-07b9a370716b6d241427783bdc73a96bb43d60e32441dbef3867e0f67dd3ee35L149-R68) [[2]](diffhunk://#diff-07b9a370716b6d241427783bdc73a96bb43d60e32441dbef3867e0f67dd3ee35L160-R87) [[3]](diffhunk://#diff-07b9a370716b6d241427783bdc73a96bb43d60e32441dbef3867e0f67dd3ee35L228-R144) [[4]](diffhunk://#diff-ad9a4d13dcb32e22b303be8b17e934e63e43054c7c06576f4836ee8f56a9684fL116-R85) [[5]](diffhunk://#diff-a725c777f5f5020730d97e1e27a293d5f5ae297f4e413691b4e02b674011bb96R246-R275)

**SSO and Account Security Enhancements:**

* Added a guard to prevent forcing a password change on SSO-only accounts, which would otherwise lock users out since they have no local password. The admin UI flow is documented to ensure correct ordering of password resets and flag setting.
* Improved the admin password reset flow: when an SSO-only account is given a password, it is promoted to "hybrid" authentication, and a security event is logged. This ensures the account's state matches its capabilities and that changes are auditable. [[1]](diffhunk://#diff-35cb08b1a967a8e907c5bdb64c4c44c8a156ceb65ee81b6b966329fcb475b24eL2080-R2116) [[2]](diffhunk://#diff-35cb08b1a967a8e907c5bdb64c4c44c8a156ceb65ee81b6b966329fcb475b24eR2126-R2135)
* Adjusted SSO login completion to clear forced password change flags based on the presence of a usable password, not just the authentication method, for more accurate handling.
* The SSO `/initiate` endpoint is now rate-limited per IP, with security logging and a specific error code for frontend handling, preventing abuse of the SSO state store.

**Access Control Tightening:**

* The `/auth/sso/test-connection` endpoint now explicitly requires admin authentication, enforcing the intended restriction that was previously only documented.

**Minor Enhancements and Cleanups:**

* Removed unused imports and legacy code in rate-limited endpoints, streamlining the codebase. [[1]](diffhunk://#diff-ad9a4d13dcb32e22b303be8b17e934e63e43054c7c06576f4836ee8f56a9684fL12-R13) [[2]](diffhunk://#diff-07b9a370716b6d241427783bdc73a96bb43d60e32441dbef3867e0f67dd3ee35L9-L10)
* Added support for passing through a `return_url` in SSO login responses for future deep-linking support.



## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Translation / i18n
- [ ] Other



## Checklist

- [x] Tests added or updated (or N/A with reason)
- [x] `npm run lint` and `npm run build` pass
- [x] Backend tests pass (`pytest`) if backend code changed
- [x] No PHI, secrets, or `console.log` left in the diff
- [x] User-facing strings go through `t()` translations
- [x] Documentation updated if API, schema, or service behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rate limiting for SSO sign-in, system requests, and medical-specialty creation, with retry guidance and rate-limit headers.
  * SSO callbacks now preserve the requested return URL.
  * SSO connection testing requires authenticated administrator access.
  * GitHub SSO now captures usernames for account linking.

* **Bug Fixes**
  * Improved password handling and hybrid-authentication promotion for SSO-only accounts.
  * Strengthened SSO state expiration, single-use enforcement, and capacity limits.

* **Documentation**
  * Updated API and deployment guides with rate-limit behavior and SSO requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->