### PR TITLE
feat(auth): Enhance SSO functionality with SSO_ONLY_MODE and auto-redirect options

### DIFF
--- a/app/api/v1/endpoints/auth.py
+++ b/app/api/v1/endpoints/auth.py
@@ -12,6 +12,7 @@ from app.api.activity_logging import log_create, safe_log_activity
 from app.api.deps import (
     BusinessLogicException,
     ConflictException,
+    ForbiddenException,
     UnauthorizedException,
 )
 from app.core.config import settings
@@ -41,7 +42,26 @@ security_logger = get_logger(__name__, "security")
 
 @router.get("/registration-status")
 def get_registration_status():
-    """Check if new user registration is enabled."""
+    """Check if new self-service (password) user registration is enabled.
+
+    Reports the *effective* answer, so SSO_ONLY_MODE is folded in: under that flag
+    POST /auth/register returns 403 regardless of ALLOW_USER_REGISTRATION, and an
+    endpoint that answers "can I create an account here" must not advertise a route
+    that refuses every caller.
+
+    Note this is not the same question as /auth/sso/config's registration_enabled,
+    which reports the raw ALLOW_USER_REGISTRATION setting because there it governs
+    whether SSO may provision new accounts - which SSO_ONLY_MODE does not disable.
+    """
+    if settings.SSO_ONLY_MODE:
+        return {
+            "registration_enabled": False,
+            "message": (
+                "This instance uses single sign-on. Sign in with your identity "
+                "provider, or contact an administrator for an account."
+            ),
+        }
+
     return {
         "registration_enabled": settings.ALLOW_USER_REGISTRATION,
         "message": (
@@ -66,6 +86,25 @@ def register(
     The password will be automatically hashed for security.
     A basic patient record is automatically created for the user.
     """
+    # Checked before ALLOW_USER_REGISTRATION and independently of it: under
+    # SSO_ONLY_MODE there is no password-registration route at all, and the event
+    # name has to say which of the two reasons applied.
+    if settings.SSO_ONLY_MODE:
+        log_security_event(
+            logger,
+            "registration_blocked_sso_only",
+            request,
+            f"Registration attempt blocked - SSO-only mode. Username: {user_in.username}",
+            username=user_in.username,
+        )
+        raise ForbiddenException(
+            message=(
+                "This instance uses single sign-on. Please sign in with your "
+                "identity provider instead of creating a password account."
+            ),
+            request=request,
+        )
+
     # Check if registration is enabled
     if not settings.ALLOW_USER_REGISTRATION:
         log_security_event(
@@ -251,6 +290,29 @@ def login(
 
     Returns a JWT token that can be used for authenticated requests.
     """
+    # Refused before any credential check, and before the login_attempt event: a
+    # request that cannot succeed is not a login attempt, and running authenticate()
+    # first would leave the endpoint answering "does this account exist" by timing
+    # under a flag whose whole purpose is to switch password login off.
+    #
+    # This is the security boundary for SSO-only mode. Hiding the form (frontend) is
+    # cosmetic - anyone can POST here directly.
+    if settings.SSO_ONLY_MODE:
+        log_security_event(
+            logger,
+            "password_login_blocked_sso_only",
+            request,
+            f"Password login blocked - SSO-only mode. Username: {form_data.username}",
+            username=form_data.username,
+        )
+        raise ForbiddenException(
+            message=(
+                "Password sign-in is disabled on this instance. Please sign in "
+                "with your identity provider."
+            ),
+            request=request,
+        )
+
     user_ip = (
         getattr(request.client, "host", "unknown") if request.client else "unknown"
     )
@@ -438,6 +500,15 @@ async def change_password(
     Change user password.
 
     Requires the current password to be provided for security.
+
+    Deliberately NOT gated on SSO_ONLY_MODE. It needs a session, which under that
+    flag can only have come from SSO - so this is not a way in, it is what a user
+    who is already in uses to set or rotate a local password. A hybrid account
+    carrying must_change_password completes its forced change here.
+
+    That local password is what makes the account usable again once SSO_ONLY_MODE is
+    turned off, which is the actual break-glass sequence; the flag itself can only be
+    cleared by an operator with access to the environment.
     """
     log_security_event(
         logger,

--- a/app/api/v1/endpoints/sso.py
+++ b/app/api/v1/endpoints/sso.py
@@ -214,8 +214,8 @@ def _complete_sso_login(
         "must_change_password": bool(sso_user.must_change_password),
         # The deep link /auth/sso/initiate was given, carried through the state entry.
         # Ships inert: no frontend reads it yet (deep links currently survive via
-        # sessionStorage, which fails in private browsing). See SSO_ONLY_MODE_SPEC.md
-        # 8.8 - the consumer is a later PR.
+        # sessionStorage, which fails in private browsing) - the consumer is a
+        # later PR.
         "return_url": result.get("return_url"),
     }
     response = JSONResponse(content=response_data)
@@ -281,7 +281,7 @@ async def initiate_sso_login(
                 **headers,
                 # X-Error-Code lets a client distinguish this from the generic SSO
                 # failures without matching on the message text. Nothing reads it
-                # yet - the frontend consumer is SSO_ONLY_MODE_SPEC.md criterion 15.
+                # yet - the frontend consumer arrives in a later PR.
                 "X-Error-Code": "sso_rate_limited",
             },
         )
@@ -296,6 +296,17 @@ async def initiate_sso_login(
     # same reason: the length cap lives inside is_safe_return_url and only decides
     # the rejection, so without this an oversized value would be written to the
     # security log in full.
+    #
+    # FastAPI binds a bare `?return_url=` to "", not None. That is "no deep link",
+    # not a hostile value: rejecting it would lock out any client that appends the
+    # parameter unconditionally, and under SSO_ONLY_MODE that client has no password
+    # login to fall back to. Collapsed to None rather than merely skipped, so the
+    # empty value is not stored and echoed back to the callback as "" where every
+    # consumer expects a path or null. Matches safeInternalPath, which returns null
+    # for an empty value rather than failing.
+    if not return_url:
+        return_url = None
+
     if return_url is not None and not is_safe_return_url(return_url):
         log_security_event(
             logger,

--- a/app/api/v1/endpoints/sso.py
+++ b/app/api/v1/endpoints/sso.py
@@ -11,6 +11,7 @@ from app.api.activity_logging import safe_log_activity
 from app.api.deps import UnauthorizedException
 from app.auth.sso.exceptions import *
 from app.core.config import settings
+from app.core.http.error_handling import MedicalRecordsAPIException
 from app.core.logging.config import get_logger
 from app.core.logging.helpers import (
     log_endpoint_access,
@@ -19,6 +20,7 @@ from app.core.logging.helpers import (
 )
 from app.core.utils.cookie_auth import set_auth_cookie
 from app.core.utils.rate_limit import SlidingWindowRateLimiter, get_client_ip
+from app.core.utils.return_url import is_safe_return_url
 from app.core.utils.security import create_access_token
 from app.crud.user_preferences import user_preferences
 from app.models.activity_log import ActionType, EntityType
@@ -42,6 +44,10 @@ _initiate_limiter = SlidingWindowRateLimiter(
     max_requests=settings.SSO_RATE_LIMIT_ATTEMPTS,
     window_seconds=settings.SSO_RATE_LIMIT_WINDOW_MINUTES * 60,
 )
+
+# How much of a rejected return_url reaches the security log. Enough to identify
+# what was attempted, short enough that an oversized value cannot pad the log.
+_LOGGED_RETURN_URL_CHARS = 200
 
 
 class SSOConflictRequest(BaseModel):
@@ -219,22 +225,28 @@ def _complete_sso_login(
 
 @router.get("/config")
 async def get_sso_config(request: Request):
-    """Check if SSO is enabled and get configuration info for frontend"""
-    try:
-        return {
-            "enabled": settings.SSO_ENABLED,
-            "provider_type": (
-                settings.SSO_PROVIDER_TYPE if settings.SSO_ENABLED else None
-            ),
-            "registration_enabled": settings.ALLOW_USER_REGISTRATION,
-        }
-    except Exception as e:
-        log_endpoint_error(logger, request, "Error getting SSO config", e)
-        return {
-            "enabled": False,
-            "provider_type": None,
-            "registration_enabled": settings.ALLOW_USER_REGISTRATION,
-        }
+    """Check if SSO is enabled and get configuration info for frontend
+
+    `registration_enabled` reports the raw ALLOW_USER_REGISTRATION setting, which in
+    this payload governs whether SSO may provision new accounts - something
+    SSO_ONLY_MODE does not disable. The question "can someone register with a
+    password" is answered by /auth/registration-status, which folds SSO_ONLY_MODE in.
+
+    No try/except here on purpose. The body is four settings reads and cannot fail;
+    the handler this used to carry synthesized `enabled: false, sso_only: false` on
+    error, which under SSO_ONLY_MODE is the one answer that strands the user - the
+    client hides the SSO button (SSO reported off) and shows a password form the
+    server refuses. A 500 is better: the client cannot mistake it for "SSO is off"
+    and shows its retry UI instead. Anything unexpected is handled by the global
+    handler in app/core/http/error_handling.py.
+    """
+    return {
+        "enabled": settings.SSO_ENABLED,
+        "provider_type": settings.SSO_PROVIDER_TYPE if settings.SSO_ENABLED else None,
+        "registration_enabled": settings.ALLOW_USER_REGISTRATION,
+        "sso_only": settings.SSO_ONLY_MODE,
+        "auto_redirect": settings.SSO_AUTO_REDIRECT,
+    }
 
 
 @router.post("/initiate")
@@ -274,6 +286,27 @@ async def initiate_sso_login(
             },
         )
 
+    # Outside the try below on purpose: an HTTPException raised inside it is caught
+    # by the broad handler and re-reported as a 500, which is the same defect this
+    # PR fixes on the three login endpoints.
+    #
+    # After the rate limit, so a caller probing this burns its quota. The rejected
+    # value is logged for the operator but deliberately not echoed in `detail` -
+    # it is attacker-controlled text that a client would render. Truncated for the
+    # same reason: the length cap lives inside is_safe_return_url and only decides
+    # the rejection, so without this an oversized value would be written to the
+    # security log in full.
+    if return_url is not None and not is_safe_return_url(return_url):
+        log_security_event(
+            logger,
+            "sso_return_url_rejected",
+            request,
+            "Rejected non-internal return_url on SSO initiate",
+            endpoint="/api/v1/auth/sso/initiate",
+            return_url=return_url[:_LOGGED_RETURN_URL_CHARS],
+        )
+        raise HTTPException(status_code=400, detail="Invalid return URL")
+
     try:
         result = await sso_service.get_authorization_url(return_url)
         return result
@@ -282,6 +315,12 @@ async def initiate_sso_login(
             logger, "sso_config_error", request, "SSO configuration error", error=str(e)
         )
         raise HTTPException(status_code=400, detail="SSO configuration error")
+    except (MedicalRecordsAPIException, HTTPException):
+        # Same guard the three login endpoints carry. This endpoint has no typed
+        # raise inside the try today - the return_url check sits above it precisely
+        # so its 400 cannot be swallowed - but leaving the fourth broad handler
+        # unguarded is what makes the next guard written inside it a silent 500.
+        raise
     except Exception as e:
         log_endpoint_error(logger, request, "Failed to initiate SSO", e)
         raise HTTPException(
@@ -346,6 +385,14 @@ async def sso_callback(
             error=str(e),
         )
         raise HTTPException(status_code=400, detail=str(e))
+    except (MedicalRecordsAPIException, HTTPException):
+        # A typed response is a deliberate answer, not a failure. Without this the
+        # broad handler below swallows it: _check_user_active raises
+        # UnauthorizedException from inside this try, so a deactivated user was
+        # told "SSO authentication failed" with a 500 instead of being told their
+        # account is deactivated. HTTPException is included so that any guard added
+        # inside this try later does not silently become a 500 too.
+        raise
     except Exception as e:
         log_endpoint_error(logger, req, "Unexpected error in SSO callback", e)
         raise HTTPException(status_code=500, detail="SSO authentication failed")
@@ -380,6 +427,9 @@ async def resolve_account_conflict(
             error=str(e),
         )
         raise HTTPException(status_code=400, detail=str(e))
+    except (MedicalRecordsAPIException, HTTPException):
+        # See /callback - a deactivated user's 401 must not become a 500.
+        raise
     except Exception as e:
         log_endpoint_error(
             logger, req, "Unexpected error in SSO conflict resolution", e
@@ -391,7 +441,13 @@ async def resolve_account_conflict(
 async def resolve_github_manual_link(
     req: Request, request: GitHubLinkRequest, db: Session = Depends(deps.get_db)
 ):
-    """Resolve GitHub manual linking by verifying user credentials"""
+    """Resolve GitHub manual linking by verifying user credentials
+
+    Deliberately NOT gated on SSO_ONLY_MODE. It verifies a password, which makes it
+    look like an alternative to SSO, but it is SSO flow machinery: every GitHub user
+    whose email the provider does not expose is routed here, so under SSO-only this
+    is their only route into the app.
+    """
     try:
         result = sso_service.resolve_github_manual_link(
             request.temp_token, request.username, request.password, db
@@ -417,6 +473,9 @@ async def resolve_github_manual_link(
             username=request.username,
         )
         raise HTTPException(status_code=400, detail=str(e))
+    except (MedicalRecordsAPIException, HTTPException):
+        # See /callback - a deactivated user's 401 must not become a 500.
+        raise
     except Exception as e:
         log_endpoint_error(
             logger,

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -241,6 +241,23 @@ class Settings:  # App Info
         os.getenv("SSO_RATE_LIMIT_WINDOW_MINUTES", "10")
     )
 
+    # SSO-only mode and IdP auto-redirect.
+    #
+    # Both default off, so a deployment upgrading to this release behaves exactly
+    # as before. Neither is meaningful without SSO_ENABLED, and the combination is
+    # refused at startup rather than silently ignored - see
+    # validate_auth_mode_config().
+    #
+    # Env-driven on purpose: there is deliberately no in-app toggle, so a broken
+    # IdP or an unlinked admin account cannot lock an operator out of their own
+    # instance permanently.
+    #
+    # SSO_ONLY_MODE     - the server refuses password login and password
+    #                     registration; the frontend hides the form.
+    # SSO_AUTO_REDIRECT - unauthenticated visitors are sent straight to the IdP.
+    SSO_ONLY_MODE: bool = os.getenv("SSO_ONLY_MODE", "False").lower() == "true"
+    SSO_AUTO_REDIRECT: bool = os.getenv("SSO_AUTO_REDIRECT", "False").lower() == "true"
+
     # Paperless-ngx Integration Configuration
     PAPERLESS_REQUEST_TIMEOUT: int = int(
         os.getenv("PAPERLESS_REQUEST_TIMEOUT", "30")
@@ -414,6 +431,78 @@ class Settings:  # App Info
             and not self.SSO_ISSUER_URL
         ):
             raise ValueError("SSO_ISSUER_URL is required for OIDC providers")
+
+    # The flags that only describe how SSO is used, and are therefore meaningless
+    # without it. Named once: validate_auth_mode_config reads the attributes by
+    # these names, so a new flag is added here and nowhere else.
+    SSO_DEPENDENT_FLAGS = ("SSO_ONLY_MODE", "SSO_AUTO_REDIRECT")
+
+    def validate_auth_mode_config(self) -> None:
+        """Validate the whole authentication-mode configuration at startup.
+
+        The single entry point for it: the flag checks below, **and** the provider
+        checks in validate_sso_config(), which this calls. Nothing else validates
+        SSO config any more - SSOService.__init__ used to, at module import, which
+        turned a bad config into an import traceback instead of the actionable
+        startup error below.
+
+        Deliberately not gated on SSO_ENABLED, unlike validate_sso_config(), which
+        returns early when it is false. That early return means it cannot catch a
+        flag set *without* SSO_ENABLED - the single most likely misconfiguration,
+        and the one that would otherwise boot cleanly into an instance whose login
+        form is hidden and whose SSO does not exist.
+
+        Raises ValueError with an actionable message. The caller (startup_event)
+        logs it and aborts the boot: failing loudly is the difference between "my
+        compose file has a typo" and "nobody can log into the medical records app
+        and I don't know why".
+        """
+        enabled_flags = [
+            name for name in self.SSO_DEPENDENT_FLAGS if getattr(self, name)
+        ]
+
+        if enabled_flags and not self.SSO_ENABLED:
+            flags = " and ".join(enabled_flags)
+            raise ValueError(
+                f"{flags} {'are' if len(enabled_flags) > 1 else 'is'} enabled but "
+                "SSO_ENABLED is not. These settings only control how SSO is used, "
+                "so without it there would be no way to sign in at all. Set "
+                f"SSO_ENABLED=true and configure an SSO provider, or unset {flags}."
+            )
+
+        # Unconditional: validate_sso_config() no-ops when SSO_ENABLED is false, and
+        # any flag reaching here implies it is true. A half-configured provider must
+        # fail the boot rather than the first login attempt.
+        self.validate_sso_config()
+
+    def auth_mode_warnings(self) -> list[tuple[str, str]]:
+        """Configurations that are legitimate but worth saying out loud at startup.
+
+        Returns (event_name, message) pairs, so a second warning added here carries
+        its own event rather than inheriting the first one's.
+
+        Separate from validate_auth_mode_config() because these must never fail a
+        boot, and separate from startup_event() because a policy inlined in a
+        200-line boot sequence can only be tested by reconstructing the whole boot.
+
+        Caller-sensitive: ALLOW_USER_REGISTRATION is admin-toggleable and persisted,
+        so this must be called *after* the stored settings are loaded or it reports
+        on a value that is not in effect.
+        """
+        warnings = []
+
+        if self.SSO_ONLY_MODE and not self.ALLOW_USER_REGISTRATION:
+            warnings.append(
+                (
+                    "sso_only_no_registration_route",
+                    "SSO_ONLY_MODE is enabled and user registration is disabled. No "
+                    "new user can be created by any self-service route; accounts "
+                    "must be created by an administrator. If this was not intended, "
+                    "enable registration or unset SSO_ONLY_MODE.",
+                )
+            )
+
+        return warnings
 
     def _ensure_directory_exists(self, directory: Path, directory_type: str) -> None:
         """Ensure directory exists with proper permission error handling for Docker bind mounts."""

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -106,6 +106,49 @@ def _derive_salt(purpose: str) -> str:
     return salt_from_env
 
 
+# Raw values of auth flags that _strict_bool() could not parse, keyed by variable
+# name. Populated at class definition time and reported by
+# validate_auth_mode_config() at startup - never raised from here, because a
+# ValueError at import is the import traceback that moving validation into the
+# lifespan hook exists to avoid.
+_AUTH_FLAG_PARSE_ERRORS: dict = {}
+
+_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+# "" included: `SSO_ONLY_MODE=` in a compose file means "unset", not "broken".
+_FALSE_VALUES = frozenset({"0", "false", "no", "off", ""})
+
+
+def _strict_bool(name: str, default: bool = False) -> bool:
+    """Parse a boolean env var, recording anything unrecognized instead of guessing.
+
+    The `.lower() == "true"` idiom used elsewhere in this file silently reads every
+    other value as False. For a flag that only relaxes behavior that is merely
+    annoying; for a flag that *is* a security control it is a failure to fail
+    closed. `SSO_ONLY_MODE=1`, a trailing space, or `SSO_ONLY_MODE=true # sso only`
+    in a compose env file (Compose does not strip inline comments) would each leave
+    password login accepting credentials while the operator believed it was off,
+    with nothing logged to say so - and the pairing check in
+    validate_auth_mode_config() cannot catch it either, because that only fires
+    when the flag parses True.
+
+    Deliberately not applied to the other booleans in this file. Changing what
+    `DEBUG=1` means is unrelated behavior with its own blast radius; this is scoped
+    to the flags where a misread value decides whether passwords are accepted.
+    """
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+
+    value = raw.strip().lower()
+    if value in _TRUE_VALUES:
+        return True
+    if value in _FALSE_VALUES:
+        return False
+
+    _AUTH_FLAG_PARSE_ERRORS[name] = raw
+    return default
+
+
 class Settings:  # App Info
     APP_NAME: str = "MediKeep"
     VERSION: str = "0.69.0"
@@ -255,8 +298,17 @@ class Settings:  # App Info
     # SSO_ONLY_MODE     - the server refuses password login and password
     #                     registration; the frontend hides the form.
     # SSO_AUTO_REDIRECT - unauthenticated visitors are sent straight to the IdP.
-    SSO_ONLY_MODE: bool = os.getenv("SSO_ONLY_MODE", "False").lower() == "true"
-    SSO_AUTO_REDIRECT: bool = os.getenv("SSO_AUTO_REDIRECT", "False").lower() == "true"
+    #
+    # Parsed strictly - see _strict_bool(). An unrecognized value fails the boot
+    # rather than reading as False, because False here means "password login is
+    # still open" on an instance whose operator believes it is closed.
+    SSO_ONLY_MODE: bool = _strict_bool("SSO_ONLY_MODE")
+    SSO_AUTO_REDIRECT: bool = _strict_bool("SSO_AUTO_REDIRECT")
+
+    # Snapshot of what the two calls above could not parse. An attribute rather
+    # than a module global so it is patchable like every other setting, and read
+    # after them so the class body has finished populating it.
+    AUTH_FLAG_PARSE_ERRORS: dict = dict(_AUTH_FLAG_PARSE_ERRORS)
 
     # Paperless-ngx Integration Configuration
     PAPERLESS_REQUEST_TIMEOUT: int = int(
@@ -457,6 +509,22 @@ class Settings:  # App Info
         compose file has a typo" and "nobody can log into the medical records app
         and I don't know why".
         """
+        # First, because every check below reads a parsed flag. A value this could
+        # not parse is not a flag that is off - it is a flag whose state is
+        # unknown, and the enabled_flags check would read it as off and pass.
+        if self.AUTH_FLAG_PARSE_ERRORS:
+            details = ", ".join(
+                f"{name}={raw!r}"
+                for name, raw in sorted(self.AUTH_FLAG_PARSE_ERRORS.items())
+            )
+            raise ValueError(
+                f"Unrecognized boolean value for {details}. Use true or false. "
+                "Note that a compose env file does not strip inline comments, so "
+                "'true # my note' is read as the whole string, not as true. "
+                "Refusing to start rather than guess: guessing wrong here leaves "
+                "password login open on an instance meant to be SSO-only."
+            )
+
         enabled_flags = [
             name for name in self.SSO_DEPENDENT_FLAGS if getattr(self, name)
         ]

--- a/app/core/startup.py
+++ b/app/core/startup.py
@@ -17,6 +17,22 @@ from app.services.notification_handlers import create_notification_handler
 logger = get_logger(__name__, "app")
 
 
+def _emit_auth_mode_warnings():
+    """Log the auth-mode configurations that are legal but worth saying out loud.
+
+    A function because startup_event() has two exits that need it: the normal path,
+    after the persisted settings load, and the SKIP_MIGRATIONS early return, which
+    never reaches that load. Emitting from only the first meant a deployment running
+    with SKIP_MIGRATIONS got no warning at all - including the sealed-instance case,
+    which is precisely the one an operator needs told.
+    """
+    for event, message in settings.auth_mode_warnings():
+        logger.warning(
+            message,
+            extra={LogFields.CATEGORY: "app", LogFields.EVENT: event},
+        )
+
+
 async def startup_event():
     """Initialize database tables on startup"""
     # Record the actual application startup time
@@ -86,6 +102,11 @@ async def startup_event():
     skip_migrations = os.getenv("SKIP_MIGRATIONS", "false").lower() == "true"
 
     if skip_migrations:
+        # This path never reaches load_persisted_settings(), so the warning site
+        # further down is unreachable from here. Emitting now is not a compromise:
+        # with no database there is no stored ALLOW_USER_REGISTRATION that could
+        # override the env value, so the env value is the one in force.
+        _emit_auth_mode_warnings()
         logger.info("⏭️ Skipping database operations (test mode)")
         logger.info("Application startup completed (test mode)")
         return
@@ -163,11 +184,7 @@ async def startup_event():
     # load_persisted_settings() immediately above. Warning any earlier would report
     # on a value that is not in force. A toggle flipped at runtime is still not
     # covered; a startup warning cannot reach it.
-    for event, message in settings.auth_mode_warnings():
-        logger.warning(
-            message,
-            extra={LogFields.CATEGORY: "app", LogFields.EVENT: event},
-        )
+    _emit_auth_mode_warnings()
 
     # Initialize standardized tests from LOINC
     try:

--- a/app/core/startup.py
+++ b/app/core/startup.py
@@ -31,6 +31,24 @@ async def startup_event():
         },
     )
 
+    # Validate the authentication-mode configuration before anything else runs.
+    # This is deliberately ahead of the database check and the SKIP_MIGRATIONS
+    # early return: the misconfiguration it catches is a compose-file typo, which
+    # must fail loudly whether or not the database happens to be reachable.
+    try:
+        settings.validate_auth_mode_config()
+    except ValueError as e:
+        error_msg = f"STARTUP FAILED: {e}"
+        logger.error(
+            error_msg,
+            extra={
+                LogFields.CATEGORY: "app",
+                LogFields.EVENT: "auth_mode_config_invalid",
+                LogFields.ERROR: str(e),
+            },
+        )
+        raise RuntimeError(str(e)) from e
+
     # Initialize the event system (event registry and bus)
     event_bus = setup_event_system()
     logger.info("Event system initialized")
@@ -138,6 +156,18 @@ async def startup_event():
     except Exception as e:
         logger.warning(f"Could not load persisted admin settings: {e}")
         # Non-fatal - app falls back to env-var defaults already in memory
+
+    # Emitted here, and not beside validate_auth_mode_config() above, because these
+    # warnings read ALLOW_USER_REGISTRATION - admin-toggleable and persisted in
+    # system_settings, so the stored value only takes effect at
+    # load_persisted_settings() immediately above. Warning any earlier would report
+    # on a value that is not in force. A toggle flipped at runtime is still not
+    # covered; a startup warning cannot reach it.
+    for event, message in settings.auth_mode_warnings():
+        logger.warning(
+            message,
+            extra={LogFields.CATEGORY: "app", LogFields.EVENT: event},
+        )
 
     # Initialize standardized tests from LOINC
     try:

--- a/app/core/utils/return_url.py
+++ b/app/core/utils/return_url.py
@@ -1,0 +1,79 @@
+"""Validation for the post-authentication return path.
+
+`POST /auth/sso/initiate` accepts a `return_url`, stores it against the OAuth state
+parameter, and `/auth/sso/callback` echoes it back so a deep link survives the round
+trip. That value is free text from an unauthenticated caller and it is consumed at
+the highest-trust moment in the app - immediately after a successful sign-in - so an
+unvalidated one is an open redirect.
+
+The frontend runs the same check before navigating (`frontend/src/utils/
+safeInternalPath.ts`), and that is the half that protects users. This half is what
+survives someone talking to the API directly: a hostile value is rejected at the door
+and never enters the state store, so any future consumer inherits the guarantee.
+
+They are not the same function, and should not be made into one. This is a
+predicate over a value about to be *stored* - "never persist something that points
+off-origin". The frontend one is a normalizer for *navigation* - "produce a path
+that is safe to hand the router" - and it also guards a value this module never
+sees, the `?next=` the frontend itself puts in the URL. Where they differ, they
+differ on purpose:
+
+| Input | Frontend | Here |
+|---|---|---|
+| `/login` | rejected - returning to the login page is a loop | accepted; loop avoidance is a navigation rule, and a 400 on a merely useless path would be a hard failure where the client already falls back to `/dashboard` |
+| `"  /dashboard"` | trimmed, then accepted | rejected - no trimming, so it does not start with `/`. Refusing is the safe direction for a value we are about to store |
+| `/a/b/../c` | normalized to `/a/c` | accepted and stored verbatim; the frontend normalizes it on the way out |
+
+What must stay in step is the core rule - nothing with a scheme, a host, or a
+protocol-relative form gets through either one.
+"""
+
+import re
+from urllib.parse import urlsplit
+
+# Longest path we will store. Well past any real route.
+MAX_RETURN_URL_LENGTH = 2048
+
+# Characters that make a path unsafe regardless of where they appear:
+#   \x00-\x1f, \x7f  control characters, including the tab and newline browsers
+#                    strip from URLs - "/\thttps://evil.example" would otherwise be
+#                    reinterpreted after stripping
+#   \\               backslashes, which some parsers treat as slashes, so
+#                    "/\evil.example" resolves off-origin
+# One compiled scan rather than a per-character Python loop plus a separate
+# membership test: this runs on every /auth/sso/initiate call, which becomes one
+# per unauthenticated page load under SSO_AUTO_REDIRECT.
+_UNSAFE_CHARS = re.compile(r"[\x00-\x1f\x7f\\]")
+
+
+def is_safe_return_url(value: object) -> bool:
+    """True if `value` is a root-relative internal path safe to store and echo.
+
+    Rejects anything that resolves off-origin. The cases that matter are the ones a
+    naive ``startswith("/")`` check misses: ``//evil.example`` and ``/\\evil.example``
+    are both absolute URLs to another host.
+
+    Callers decide what an absent value means; this returns False for None.
+    """
+    if not isinstance(value, str):
+        return False
+
+    if len(value) > MAX_RETURN_URL_LENGTH:
+        return False
+
+    if _UNSAFE_CHARS.search(value):
+        return False
+
+    try:
+        parts = urlsplit(value)
+    except ValueError:
+        return False
+
+    # Catches absolute ("https://evil.example") and protocol-relative
+    # ("//evil.example") forms alike.
+    if parts.scheme or parts.netloc:
+        return False
+
+    # Relative inputs like "../admin" have no scheme or netloc either, so the check
+    # above does not establish that the caller gave us a root-relative path.
+    return value.startswith("/")

--- a/app/core/utils/return_url.py
+++ b/app/core/utils/return_url.py
@@ -64,13 +64,22 @@ def is_safe_return_url(value: object) -> bool:
     if _UNSAFE_CHARS.search(value):
         return False
 
+    # Protocol-relative forms, checked textually and before urlsplit because
+    # urlsplit is what disagrees with the browser here. It reports a netloc only
+    # for exactly two leading slashes: "///evil.example" parses as a path with no
+    # netloc at all. A browser resolving that against a special scheme skips every
+    # leading slash and lands on evil.example, so any run of two or more is
+    # off-origin no matter what urlsplit says.
+    if value.startswith("//"):
+        return False
+
     try:
         parts = urlsplit(value)
     except ValueError:
         return False
 
-    # Catches absolute ("https://evil.example") and protocol-relative
-    # ("//evil.example") forms alike.
+    # Catches absolute forms ("https://evil.example"). Protocol-relative ones are
+    # already gone above; this still rejects them if that check ever moves.
     if parts.scheme or parts.netloc:
         return False
 

--- a/app/services/sso_service.py
+++ b/app/services/sso_service.py
@@ -263,7 +263,7 @@ class SSOService:
 
         # Carry the deep link the flow started from back to the caller. Ships inert -
         # no frontend reads it yet (deep links currently survive via sessionStorage,
-        # which fails in private browsing). See SSO_ONLY_MODE_SPEC.md 8.8.
+        # which fails in private browsing).
         result["return_url"] = state_data.get("return_url")
 
         return result

--- a/app/services/sso_service.py
+++ b/app/services/sso_service.py
@@ -133,11 +133,16 @@ def _store_state_entry(key: str, payload: Dict) -> None:
 
 
 class SSOService:
-    """Simple SSO service - clean and maintainable"""
+    """Simple SSO service - clean and maintainable.
 
-    def __init__(self):
-        if settings.SSO_ENABLED:
-            settings.validate_sso_config()
+    Construction has no side effects, deliberately. This class is instantiated at
+    module import (endpoints/sso.py), and the config validation that used to live in
+    __init__ therefore surfaced an invalid SSO config as an import traceback, before
+    the lifespan hook existed to report it properly. startup_event() ->
+    settings.validate_auth_mode_config() is the single authority now, and it still
+    fails the boot whenever SSO_ENABLED is true and the provider config is
+    incomplete.
+    """
 
     async def get_authorization_url(
         self, return_url: Optional[str] = None

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -40,6 +40,25 @@ SSO_CLIENT_SECRET=your-github-client-secret
 SSO_REDIRECT_URI=http://localhost:8005/auth/sso/callback
 SSO_ALLOWED_DOMAINS=[]
 
+# SSO-only mode and IdP auto-redirect. Both default to false; both require
+# SSO_ENABLED=true. The container refuses to start if either is set without it,
+# rather than booting into an instance nobody can sign in to.
+#
+# SSO_ONLY_MODE=true     The server refuses password login and password
+#                        registration (403). NOTE: in this release the login
+#                        page still shows the password form - the server just
+#                        refuses it. Hiding the form ships with the frontend
+#                        half of this feature.
+# SSO_AUTO_REDIRECT=true Unauthenticated visitors are sent straight to the
+#                        identity provider, with /login?local=1 to reach the
+#                        login page directly. NOTE: no effect yet in this
+#                        release; it ships with the same frontend half.
+#
+# To recover if the identity provider is unreachable: set SSO_ONLY_MODE=false,
+# restart, and sign in locally. There is deliberately no in-app toggle for these.
+#SSO_ONLY_MODE=false
+#SSO_AUTO_REDIRECT=false
+
 # Optional UID/GID for bind mounts
 #PUID=1000
 #PGID=1000

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -54,6 +54,12 @@ SSO_ALLOWED_DOMAINS=[]
 #                        login page directly. NOTE: no effect yet in this
 #                        release; it ships with the same frontend half.
 #
+# Accepted values are true/false (also 1/0, yes/no, on/off), and these two are
+# checked strictly: anything else fails the boot with an error naming the
+# variable, rather than being read as false. Note that a compose env file does
+# NOT strip inline comments, so `SSO_ONLY_MODE=true # my note` is the whole
+# string - put comments on their own line.
+#
 # To recover if the identity provider is unreachable: set SSO_ONLY_MODE=false,
 # restart, and sign in locally. There is deliberately no in-app toggle for these.
 #SSO_ONLY_MODE=false

--- a/docker/README_SSO.md
+++ b/docker/README_SSO.md
@@ -166,7 +166,11 @@ cannot make itself unfixable:
    for every account, including that one. Pair it with step 1.
 3. Startup validation refuses the most likely misconfiguration before it takes
    effect, so a typo in these variables surfaces as a logged startup failure rather
-   than a login page nobody can get past.
+   than a login page nobody can get past. That includes a value it cannot parse:
+   `SSO_ONLY_MODE` and `SSO_AUTO_REDIRECT` accept `true`/`false` (also `1`/`0`,
+   `yes`/`no`, `on`/`off`, any case), and anything else fails the boot instead of
+   being read as `false`. Watch for inline comments — a compose env file does not
+   strip them, so `SSO_ONLY_MODE=true # sso only` is the whole string.
 
 If registration is also disabled (`ALLOW_USER_REGISTRATION=false`, or the admin
 setting), no new user can enter by any self-service route. That is a legitimate

--- a/docker/README_SSO.md
+++ b/docker/README_SSO.md
@@ -118,25 +118,26 @@ it** — that is deliberate. Booting into an instance that refuses password logi
 has no working SSO means nobody can sign in, and the error is much harder to
 diagnose after the fact than at startup.
 
+> **This release ships the server-side half only.** Nothing in the web UI reads
+> these two settings yet. Under `SSO_ONLY_MODE` the login page still draws the
+> password form and every submission is refused with 403, and `SSO_AUTO_REDIRECT`
+> does nothing at all — no visitor is redirected anywhere. The table below is the
+> configuration contract; the rows marked *(UI half pending)* describe behavior that
+> arrives with the frontend half of this feature in a following release.
+
 | `SSO_ENABLED` | `SSO_ONLY_MODE` | `SSO_AUTO_REDIRECT` | Result |
 |---|---|---|---|
 | `false` | `false` | `false` | Current behavior, unchanged |
-| `false` | `true` or `true` | either flag set | **Startup failure** with an explicit error |
+| `false` | either flag set | either flag set | **Startup failure** with an explicit error |
 | `true` | `false` | `false` | Standard SSO — login form plus an SSO button |
 | `true` | `true` | `false` | `/auth/login` and `/auth/register` return 403; sign in with SSO |
-| `true` | `false` | `true` | Password login still works; visitors are sent to the IdP, and `/login?local=1` reaches the login page directly |
-| `true` | `true` | `true` | Pure SSO front door |
+| `true` | `false` | `true` | Password login still works; visitors are sent to the IdP, and `/login?local=1` reaches the login page directly *(UI half pending)* |
+| `true` | `true` | `true` | Pure SSO front door *(UI half pending)* |
 
 `SSO_ONLY_MODE` is enforced server-side: `POST /auth/login` and `POST /auth/register`
 return 403 before any credential check, and each refusal is recorded in the security
-log. That enforcement is the security boundary and it is complete — hiding the form
-is only cosmetic, since anyone can POST to the API directly.
-
-> **This release ships the server-side half only.** The login page does not yet hide
-> the password form, and `SSO_AUTO_REDIRECT` has no visible effect: nothing in the
-> web UI reads these settings yet. Under `SSO_ONLY_MODE` the form is still drawn and
-> every submission is refused with 403. The login-page behavior ships with the
-> frontend half of this feature in a following release.
+log. That enforcement is the security boundary and it is already complete — hiding
+the form is only cosmetic, since anyone can POST to the API directly.
 
 Still available under `SSO_ONLY_MODE`, by design:
 

--- a/docker/README_SSO.md
+++ b/docker/README_SSO.md
@@ -47,6 +47,11 @@ environment:
   SSO_ISSUER_URL: ${SSO_ISSUER_URL:-}
   SSO_REDIRECT_URI: ${SSO_REDIRECT_URI:-}
   SSO_ALLOWED_DOMAINS: ${SSO_ALLOWED_DOMAINS:-[]}
+
+  # Optional - see "SSO-Only Mode and Auto-Redirect" below. Both require
+  # SSO_ENABLED=true; the container refuses to start otherwise.
+  SSO_ONLY_MODE: ${SSO_ONLY_MODE:-false}
+  SSO_AUTO_REDIRECT: ${SSO_AUTO_REDIRECT:-false}
 ```
 
 ### 3. Restart the containers
@@ -97,6 +102,75 @@ SSO_ISSUER_URL=https://homelab.local/auth/realms/family
 | `SSO_REDIRECT_URI` | If SSO enabled | empty | Callback URL (use your domain + `/auth/sso/callback`) |
 | `SSO_ISSUER_URL` | If OIDC provider | empty | OIDC issuer URL |
 | `SSO_ALLOWED_DOMAINS` | No | `[]` | JSON array of allowed email domains |
+| `SSO_ONLY_MODE` | No | `false` | Refuse password login and password registration |
+| `SSO_AUTO_REDIRECT` | No | `false` | Send unauthenticated visitors straight to the IdP |
+
+## SSO-Only Mode and Auto-Redirect
+
+Two independent flags turn the identity provider into the instance's front door.
+They are kept separate because the behaviors are independently useful: an operator
+may want SSO-only while still presenting a landing page, or auto-redirect as a
+convenience while keeping password login available.
+
+Both default off, so upgrading changes nothing. **Neither is meaningful without
+`SSO_ENABLED=true`, and the container refuses to start if either is set without
+it** — that is deliberate. Booting into an instance that refuses password login and
+has no working SSO means nobody can sign in, and the error is much harder to
+diagnose after the fact than at startup.
+
+| `SSO_ENABLED` | `SSO_ONLY_MODE` | `SSO_AUTO_REDIRECT` | Result |
+|---|---|---|---|
+| `false` | `false` | `false` | Current behavior, unchanged |
+| `false` | `true` or `true` | either flag set | **Startup failure** with an explicit error |
+| `true` | `false` | `false` | Standard SSO — login form plus an SSO button |
+| `true` | `true` | `false` | `/auth/login` and `/auth/register` return 403; sign in with SSO |
+| `true` | `false` | `true` | Password login still works; visitors are sent to the IdP, and `/login?local=1` reaches the login page directly |
+| `true` | `true` | `true` | Pure SSO front door |
+
+`SSO_ONLY_MODE` is enforced server-side: `POST /auth/login` and `POST /auth/register`
+return 403 before any credential check, and each refusal is recorded in the security
+log. That enforcement is the security boundary and it is complete — hiding the form
+is only cosmetic, since anyone can POST to the API directly.
+
+> **This release ships the server-side half only.** The login page does not yet hide
+> the password form, and `SSO_AUTO_REDIRECT` has no visible effect: nothing in the
+> web UI reads these settings yet. Under `SSO_ONLY_MODE` the form is still drawn and
+> every submission is refused with 403. The login-page behavior ships with the
+> frontend half of this feature in a following release.
+
+Still available under `SSO_ONLY_MODE`, by design:
+
+- `POST /auth/change-password` — break-glass admins need it, and an account with
+  both a local password and a linked SSO identity (`hybrid`) completes a forced
+  password change here
+- Admin user creation — the administrative recovery path
+- GitHub manual account linking — SSO flow machinery, and the only route in for a
+  GitHub user whose email the provider does not expose
+
+### If you get locked out
+
+There is deliberately no in-app toggle for these settings, precisely so a broken IdP
+cannot make itself unfixable:
+
+1. **Set `SSO_ONLY_MODE=false` and restart, then sign in locally.** This is the
+   primary path, and the only one that restores access when the IdP is unreachable.
+2. **If SSO still works but no account has admin rights**, run
+   `app/scripts/create_emergency_admin.py --username <name> --promote` against an
+   account that can sign in through your IdP. Promotion writes directly to the
+   database and preserves the existing password, so the user signs in via SSO as
+   usual and is now an admin.
+
+   Note what this does **not** do: creating a *new* password admin with this script
+   does not get you in while `SSO_ONLY_MODE=true`, because password login is refused
+   for every account, including that one. Pair it with step 1.
+3. Startup validation refuses the most likely misconfiguration before it takes
+   effect, so a typo in these variables surfaces as a logged startup failure rather
+   than a login page nobody can get past.
+
+If registration is also disabled (`ALLOW_USER_REGISTRATION=false`, or the admin
+setting), no new user can enter by any self-service route. That is a legitimate
+configuration for a sealed instance, and it is logged as a startup warning so it is
+visible if it was not intended.
 
 ## Production Considerations
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -62,6 +62,10 @@ services:
       SSO_ISSUER_URL: ${SSO_ISSUER_URL:-}
       SSO_REDIRECT_URI: ${SSO_REDIRECT_URI:-}
       SSO_ALLOWED_DOMAINS: ${SSO_ALLOWED_DOMAINS:-[]}
+      # SSO-only front door. Both require SSO_ENABLED=true - the app refuses to
+      # start otherwise, rather than booting with no usable way to sign in.
+      SSO_ONLY_MODE: ${SSO_ONLY_MODE:-false}
+      SSO_AUTO_REDIRECT: ${SSO_AUTO_REDIRECT:-false}
 
       # Default Admin Password Configuration (optional - defaults to admin123 in app if not set)
       #ADMIN_DEFAULT_PASSWORD: ${ADMIN_DEFAULT_PASSWORD:-}

--- a/docker/unraid-template.xml
+++ b/docker/unraid-template.xml
@@ -84,6 +84,12 @@
   <Config Name="SSO Client Secret" Target="SSO_CLIENT_SECRET" Default="" Mode=""
     Description="SSO Client Secret (if SSO enabled)" Type="Variable" Display="advanced"
     Required="false" Mask="true" />
+  <Config Name="SSO Only Mode" Target="SSO_ONLY_MODE" Default="false" Mode=""
+    Description="Refuse password login and registration (403); sign in with SSO only. Requires SSO Enabled - the container will not start without it. Set back to false to recover if the identity provider is unreachable. Note: the login page still shows the password form in this release; the server refuses it."
+    Type="Variable" Display="advanced" Required="false" Mask="false">false</Config>
+  <Config Name="SSO Auto Redirect" Target="SSO_AUTO_REDIRECT" Default="false" Mode=""
+    Description="Send unauthenticated visitors straight to the identity provider, with /login?local=1 to reach the login page directly. Requires SSO Enabled - the container will not start without it. Note: not yet active in this release; it takes effect with the web UI half of this feature."
+    Type="Variable" Display="advanced" Required="false" Mask="false">false</Config>
   <Config Name="PUID" Target="PUID" Default="99" Mode="" Description="User ID" Type="Variable"
     Display="advanced" Required="false" Mask="false">99</Config>
   <Config Name="PGID" Target="PGID" Default="100" Mode="" Description="Group ID" Type="Variable"

--- a/docs/developer-guide/02-api-reference.md
+++ b/docs/developer-guide/02-api-reference.md
@@ -278,8 +278,11 @@ Base path: `/api/v1/auth/sso`
   - `return_url` (string, optional): where to send the user after authentication.
     Must be a **root-relative internal path** (`/patients/42`,
     `/lab-results?status=open`). Stored against the state token and echoed back by
-    `/auth/sso/callback`
-- **Error Response** (400): `return_url` is not a root-relative internal path.
+    `/auth/sso/callback`. An empty value (`?return_url=`) is treated as absent, not
+    as invalid, so a client may send the parameter unconditionally; the callback
+    reports `null` for it
+- **Error Response** (400): `return_url` is present, non-empty, and not a
+  root-relative internal path.
   Absolute (`https://evil.example`), protocol-relative (`//evil.example`,
   `/\evil.example`), and non-root-relative (`../admin`) values are all refused, and
   no state entry is created. The value never reaches the state store, so any

--- a/docs/developer-guide/02-api-reference.md
+++ b/docs/developer-guide/02-api-reference.md
@@ -104,7 +104,7 @@ Base path: `/api/v1/auth`
 
 `GET /auth/registration-status`
 
-- **Purpose**: Check if new user registration is enabled
+- **Purpose**: Check whether self-service (password) registration is available
 - **Authentication**: No
 - **Success Response** (200):
 
@@ -114,6 +114,13 @@ Base path: `/api/v1/auth`
   "message": null
 }
 ```
+
+- Reports the **effective** answer: `false` when `ALLOW_USER_REGISTRATION` is off
+  **or** `SSO_ONLY_MODE` is on, each with its own `message`. Under `SSO_ONLY_MODE`,
+  `POST /auth/register` returns 403 regardless of the registration setting, so this
+  endpoint must not advertise a route that refuses every caller
+- Not the same field as `registration_enabled` in `GET /auth/sso/config`, which
+  reports the raw setting because there it governs SSO account provisioning
 
 ### User Registration
 
@@ -148,7 +155,11 @@ Base path: `/api/v1/auth`
 
 - **Error Responses**:
   - `400`: Validation failed (weak password, invalid email)
-  - `403`: Registration disabled
+  - `401`: `ALLOW_USER_REGISTRATION=false`. Recorded as `registration_blocked`.
+    (401 rather than 403 is long-standing behavior, not a typo — do not branch on
+    403 alone to detect "registration unavailable")
+  - `403`: `SSO_ONLY_MODE=true`. Checked first and applies regardless of the
+    registration setting; recorded as `registration_blocked_sso_only`
   - `409`: Username or email already exists
 
 ### User Login
@@ -177,6 +188,9 @@ username=johndoe&password=SecurePass123!
 - **Note**: The response does NOT include a user object. Use `GET /users/me` to retrieve user details after login. The `session_timeout_minutes` reflects the user's session timeout preference (or system default if not set).
 - **Error Responses**:
   - `401`: Invalid credentials
+  - `403`: Password login disabled (`SSO_ONLY_MODE=true`). Returned before any
+    credential check, so valid credentials are refused too. Recorded as
+    `password_login_blocked_sso_only` in the security log
   - `429`: Too many login attempts (rate limited)
 
 ### Change Password
@@ -226,9 +240,27 @@ Base path: `/api/v1/auth/sso`
 {
   "enabled": true,
   "provider_type": "google",
-  "registration_enabled": true
+  "registration_enabled": true,
+  "sso_only": false,
+  "auto_redirect": false
 }
 ```
+
+- `sso_only` — `SSO_ONLY_MODE`. Password login and password registration are
+  refused server-side; the login form is hidden
+- `auto_redirect` — `SSO_AUTO_REDIRECT`. Unauthenticated visitors are sent to the
+  IdP without interaction
+- `registration_enabled` — the raw `ALLOW_USER_REGISTRATION` setting, which **in
+  this payload** governs whether SSO may provision new accounts. `SSO_ONLY_MODE`
+  does not disable that, so this field is unaffected by it. The different question
+  "can someone register with a password" is answered by
+  `GET /auth/registration-status`, which does fold `SSO_ONLY_MODE` in and reports
+  `false` under it
+- This endpoint does not degrade to a fallback payload on error. Reporting
+  `enabled: false, sso_only: false` would be indistinguishable from "SSO is
+  genuinely off", which under `SSO_ONLY_MODE` strands the caller — no SSO button,
+  and a password form the server refuses. A failure is a `500`, which a client can
+  tell apart and retry
 
 ### Initiate SSO Login
 
@@ -239,7 +271,16 @@ Base path: `/api/v1/auth/sso`
 - **Rate Limited**: yes — `SSO_RATE_LIMIT_ATTEMPTS` per client IP per
   `SSO_RATE_LIMIT_WINDOW_MINUTES` (defaults: 10 per 10 minutes)
 - **Query Parameters**:
-  - `return_url` (string, optional): URL to redirect after authentication
+  - `return_url` (string, optional): where to send the user after authentication.
+    Must be a **root-relative internal path** (`/patients/42`,
+    `/lab-results?status=open`). Stored against the state token and echoed back by
+    `/auth/sso/callback`
+- **Error Response** (400): `return_url` is not a root-relative internal path.
+  Absolute (`https://evil.example`), protocol-relative (`//evil.example`,
+  `/\evil.example`), and non-root-relative (`../admin`) values are all refused, and
+  no state entry is created. The value never reaches the state store, so any
+  consumer of `return_url` inherits the guarantee. Recorded as
+  `sso_return_url_rejected`. Checked after the rate limit
 - **Error Response** (429): rate limit exceeded. Carries `Retry-After`,
   `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`, and
   `X-Error-Code: sso_rate_limited` — branch on the status or `X-Error-Code`, not on

--- a/docs/developer-guide/02-api-reference.md
+++ b/docs/developer-guide/02-api-reference.md
@@ -246,10 +246,14 @@ Base path: `/api/v1/auth/sso`
 }
 ```
 
-- `sso_only` — `SSO_ONLY_MODE`. Password login and password registration are
-  refused server-side; the login form is hidden
-- `auto_redirect` — `SSO_AUTO_REDIRECT`. Unauthenticated visitors are sent to the
-  IdP without interaction
+- `sso_only` — `SSO_ONLY_MODE`. `POST /auth/login` and `POST /auth/register` are
+  refused server-side with `403`, before any credential check. The web UI does not
+  read this field yet, so the login page still draws the password form; hiding it
+  ships with the frontend half of this feature
+- `auto_redirect` — `SSO_AUTO_REDIRECT`. Advertised for clients that will send
+  unauthenticated visitors straight to the IdP. It has **no effect in this release**
+  — nothing reads it, and the backend behaves identically whether it is set or not
+  (beyond refusing to boot when it is set without `SSO_ENABLED`)
 - `registration_enabled` — the raw `ALLOW_USER_REGISTRATION` setting, which **in
   this payload** governs whether SSO may provision new accounts. `SSO_ONLY_MODE`
   does not disable that, so this field is unaffected by it. The different question

--- a/docs/developer-guide/04-deployment.md
+++ b/docs/developer-guide/04-deployment.md
@@ -514,13 +514,15 @@ Two consequences worth knowing before tuning these:
 
 **SSO-only mode and auto-redirect:** `SSO_ONLY_MODE` makes the identity provider the
 only way in — `POST /auth/login` and `POST /auth/register` return `403` before any
-credential check. `SSO_AUTO_REDIRECT` sends unauthenticated visitors to the IdP
-without interaction; `/login?local=1` reaches the login page without being redirected.
+credential check. `SSO_AUTO_REDIRECT` is intended to send unauthenticated visitors to
+the IdP without interaction, with `/login?local=1` reaching the login page directly.
 
 > **Server-side half only in this release.** No part of the web UI reads these two
 > settings yet: under `SSO_ONLY_MODE` the login page still draws the password form
-> (every submission is refused with `403`), and `SSO_AUTO_REDIRECT` has no visible
-> effect at all. The login-page behavior ships with the frontend half of this feature.
+> (every submission is refused with `403`), and `SSO_AUTO_REDIRECT` does nothing at
+> all — no visitor is redirected anywhere. The table below is the configuration
+> contract; rows marked *(UI half pending)* describe behavior that arrives with the
+> frontend half of this feature.
 
 | `SSO_ENABLED` | `SSO_ONLY_MODE` | `SSO_AUTO_REDIRECT` | Result                                                           |
 | ------------- | --------------- | ------------------- | ---------------------------------------------------------------- |
@@ -528,8 +530,8 @@ without interaction; `/login?local=1` reaches the login page without being redir
 | `false`       | either flag set | either flag set     | **Startup failure** with an explicit error                       |
 | `true`        | `false`         | `false`             | Standard SSO — login form plus an SSO button                     |
 | `true`        | `true`          | `false`             | `/auth/login` and `/auth/register` return `403`; sign in with SSO |
-| `true`        | `false`         | `true`              | Password login works, and visitors are sent to the IdP           |
-| `true`        | `true`          | `true`              | Pure SSO front door                                              |
+| `true`        | `false`         | `true`              | Password login works, and visitors are sent to the IdP *(UI half pending)* |
+| `true`        | `true`          | `true`              | Pure SSO front door *(UI half pending)*                          |
 
 **The app refuses to start** if *either* flag is set without `SSO_ENABLED`, or with an
 incomplete provider configuration. The failure is logged from the startup hook with

--- a/docs/developer-guide/04-deployment.md
+++ b/docs/developer-guide/04-deployment.md
@@ -493,6 +493,8 @@ TRASH_RETENTION_DAYS=60
 | `SSO_ALLOWED_DOMAINS`           | JSON array | `[]`    | No             | Allowed email domains                                                     |
 | `SSO_RATE_LIMIT_ATTEMPTS`       | integer    | `10`    | No             | Max `POST /auth/sso/initiate` calls per IP per window                     |
 | `SSO_RATE_LIMIT_WINDOW_MINUTES` | integer    | `10`    | No             | Rate limit window                                                         |
+| `SSO_ONLY_MODE`                 | boolean    | `false` | No             | Refuse password login and password registration; requires `SSO_ENABLED`   |
+| `SSO_AUTO_REDIRECT`             | boolean    | `false` | No             | Send unauthenticated visitors straight to the IdP; requires `SSO_ENABLED` |
 
 **SSO rate limiting:** these two variables throttle `POST /api/v1/auth/sso/initiate`,
 the unauthenticated endpoint that starts the sign-in redirect. Exceeding the limit
@@ -509,6 +511,48 @@ Two consequences worth knowing before tuning these:
   automatic redirect-to-IdP on unauthenticated page loads, a household or CGNAT range
   sharing one address could plausibly reach the default 10-per-10-minutes. Raise
   `SSO_RATE_LIMIT_ATTEMPTS` if legitimate users report being turned away.
+
+**SSO-only mode and auto-redirect:** `SSO_ONLY_MODE` makes the identity provider the
+only way in — `POST /auth/login` and `POST /auth/register` return `403` before any
+credential check. `SSO_AUTO_REDIRECT` sends unauthenticated visitors to the IdP
+without interaction; `/login?local=1` reaches the login page without being redirected.
+
+> **Server-side half only in this release.** No part of the web UI reads these two
+> settings yet: under `SSO_ONLY_MODE` the login page still draws the password form
+> (every submission is refused with `403`), and `SSO_AUTO_REDIRECT` has no visible
+> effect at all. The login-page behavior ships with the frontend half of this feature.
+
+| `SSO_ENABLED` | `SSO_ONLY_MODE` | `SSO_AUTO_REDIRECT` | Result                                                           |
+| ------------- | --------------- | ------------------- | ---------------------------------------------------------------- |
+| `false`       | `false`         | `false`             | Current behavior, unchanged                                      |
+| `false`       | either flag set | either flag set     | **Startup failure** with an explicit error                       |
+| `true`        | `false`         | `false`             | Standard SSO — login form plus an SSO button                     |
+| `true`        | `true`          | `false`             | `/auth/login` and `/auth/register` return `403`; sign in with SSO |
+| `true`        | `false`         | `true`              | Password login works, and visitors are sent to the IdP           |
+| `true`        | `true`          | `true`              | Pure SSO front door                                              |
+
+**The app refuses to start** if *either* flag is set without `SSO_ENABLED`, or with an
+incomplete provider configuration. The failure is logged from the startup hook with
+the offending variable named. This is deliberate: booting with password login refused
+and no working SSO means nobody can sign in, and that is far harder to diagnose after
+the fact.
+
+If `SSO_ONLY_MODE` is combined with registration disabled, no new user can enter by
+any self-service route. That is valid for a sealed instance and is logged as a startup
+warning rather than a failure.
+
+**Recovering from a locked-out instance.** There is deliberately no in-app toggle for
+these settings, so a broken IdP cannot make itself unfixable:
+
+1. Set `SSO_ONLY_MODE=false`, restart, sign in locally — the primary path, and the
+   only one that works when the IdP itself is unreachable.
+2. If SSO still works but no account has admin rights, run
+   `app/scripts/create_emergency_admin.py --username <name> --promote` against an
+   account that can sign in through the IdP; promotion preserves the existing
+   password and grants admin. Creating a *new* password admin does not help while
+   `SSO_ONLY_MODE=true` — password login is refused for that account too — so pair it
+   with step 1.
+3. Startup validation catches the most likely misconfiguration before it takes effect.
 
 **Example (Google):**
 

--- a/docs/developer-guide/04-deployment.md
+++ b/docs/developer-guide/04-deployment.md
@@ -539,6 +539,15 @@ the offending variable named. This is deliberate: booting with password login re
 and no working SSO means nobody can sign in, and that is far harder to diagnose after
 the fact.
 
+**These two flags are parsed strictly.** `true`/`false`, `1`/`0`, `yes`/`no`, and
+`on`/`off` are accepted in any case; an empty value means unset. Anything else fails
+the boot with an error naming the variable and showing what it was set to, rather
+than being read as `false`. Everywhere else `false` merely means "off", but for
+`SSO_ONLY_MODE` it means password login is still open, so a misread value would leave
+an instance accepting credentials its operator believes are refused — with nothing in
+the logs to say so. The most common cause is an inline comment: a compose env file
+does not strip them, so `SSO_ONLY_MODE=true # sso only` is read as the entire string.
+
 If `SSO_ONLY_MODE` is combined with registration disabled, no new user can enter by
 any self-service route. That is valid for a sealed instance and is logged as a startup
 warning rather than a failure.

--- a/frontend/src/components/auth/ProtectedRoute.redirect.test.jsx
+++ b/frontend/src/components/auth/ProtectedRoute.redirect.test.jsx
@@ -131,7 +131,7 @@ describe('ProtectedRoute login redirect', () => {
 
   /**
    * Storage being unavailable must not affect suppression at all - it travels in
-   * the URL specifically so it does not depend on storage. See criterion 10.
+   * the URL specifically so it does not depend on storage.
    */
   test('suppression works with sessionStorage throwing', () => {
     withThrowingSessionStorage(() => {

--- a/frontend/src/components/auth/SSOCallback.jsx
+++ b/frontend/src/components/auth/SSOCallback.jsx
@@ -20,7 +20,6 @@ import { takeSSOReturnUrl } from '../../utils/ssoReturnUrl';
  * The return path is preferred from the server, which keyed it to the OAuth state
  * parameter and hands it back on the callback. That survives private browsing and
  * disabled storage; sessionStorage, which used to be the only carrier, does not.
- * See SSO_ONLY_MODE_SPEC.md 8.8.
  *
  * Both sources are untrusted input - the backend stores return_url verbatim and
  * echoes it back - so both go through safeInternalPath before anyone navigates

--- a/frontend/src/components/auth/SSOCallback.returnUrl.test.jsx
+++ b/frontend/src/components/auth/SSOCallback.returnUrl.test.jsx
@@ -25,10 +25,9 @@ const SSO_USER = { id: 7, username: 'ssouser', role: 'user' };
 /**
  * Deep-link preservation across the SSO round trip used to rest entirely on
  * sessionStorage, which is exactly the mechanism that fails in private browsing
- * and with storage disabled - the case acceptance criterion 11 covers. The
- * backend now carries the return path in the state entry, keyed to the OAuth
- * state parameter, which survives anything sessionStorage does not.
- * See SSO_ONLY_MODE_SPEC.md 8.8 and 8.11.
+ * and with storage disabled. The backend now carries the return path in the
+ * state entry, keyed to the OAuth state parameter, which survives anything
+ * sessionStorage does not.
  */
 describe('SSOCallback return path', () => {
   beforeEach(() => {
@@ -105,7 +104,7 @@ describe('SSOCallback return path', () => {
   });
 
   /**
-   * This is criterion 11's real case: the mechanism must not depend on storage.
+   * The real case this exists for: the mechanism must not depend on storage.
    */
   test('works with sessionStorage unavailable', async () => {
     await withThrowingSessionStorage(async () => {

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -177,7 +177,7 @@ export function AuthProvider({ children }) {
   // session and only one of them is a button. The inactivity timeout used to
   // clear and dispatch by hand; under SSO_AUTO_REDIRECT that meant an idle user
   // was bounced to the IdP, silently re-authenticated, and returned to the app --
-  // the inactivity timeout disabled deployment-wide. See SSO_ONLY_MODE_SPEC.md 8.12.
+  // the inactivity timeout disabled deployment-wide.
   //
   // useCallback with no dependencies so the inactivity effect can depend on it
   // without being torn down and recreated on every render. dispatch is stable,
@@ -451,7 +451,7 @@ export function AuthProvider({ children }) {
     // Tracked so the `finally` can tell a clean logout from one where the server
     // never cleared the cookie. authService.logout() used to swallow a non-2xx
     // response, which made this catch unreachable for anything but a total
-    // network failure -- see SSO_ONLY_MODE_SPEC.md 8.7b.
+    // network failure.
     let serverLogoutFailed = false;
 
     try {

--- a/frontend/src/contexts/AuthContext.session.test.jsx
+++ b/frontend/src/contexts/AuthContext.session.test.jsx
@@ -128,7 +128,7 @@ describe('AuthContext session teardown', () => {
    * logout(). Suppression placed inside logout() would miss it entirely, and
    * under SSO_AUTO_REDIRECT an idle-timed-out user would be bounced to an IdP
    * that still holds a live session and signed straight back in - the timeout
-   * disabled for the whole deployment. See SSO_ONLY_MODE_SPEC.md 8.12.
+   * disabled for the whole deployment.
    */
   test('the inactivity timeout records session_expired', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
@@ -159,7 +159,7 @@ describe('AuthContext session teardown', () => {
    * simpleAuthService.logout() used to swallow a non-2xx from POST /auth/logout,
    * so the client cleared its state while the HttpOnly cookie stayed valid - a
    * logged-out UI over a live session. It now throws; this is what the app does
-   * with that. See SSO_ONLY_MODE_SPEC.md 8.7b.
+   * with that.
    */
   test('a failed server logout still tears down locally, and says so', async () => {
     const user = userEvent.setup();

--- a/frontend/src/pages/auth/Login.jsx
+++ b/frontend/src/pages/auth/Login.jsx
@@ -51,7 +51,7 @@ const Login = () => {
   // survives private browsing and disabled storage too. `from` stays as the
   // fallback for soft navigations, but a stale `from` must not beat a fresh
   // `next`. Both are untrusted - `next` is attacker-supplied in a link - so both
-  // go through safeInternalPath. See SSO_ONLY_MODE_SPEC.md 8.11.
+  // go through safeInternalPath.
   //
   // The reason is rendered below so a session that expired mid-use is
   // distinguishable from a random failure - the toast the HTTP clients used to

--- a/frontend/src/services/api/index.js
+++ b/frontend/src/services/api/index.js
@@ -99,7 +99,6 @@ class ApiService {
       // the app's traffic, so an expired session surfaced as a generic error
       // toast on whatever screen the user happened to be on, indistinguishable
       // from a server fault. Same rule as every other client now.
-      // See SSO_ONLY_MODE_SPEC.md 8.10.
       if (response.status === 401) {
         handleUnauthorized(url);
       }

--- a/frontend/src/services/api/unauthorized.test.js
+++ b/frontend/src/services/api/unauthorized.test.js
@@ -20,7 +20,7 @@ import { stubLocation } from '../../test-utils/browserStubs';
  * clients happened to make the request: baseApi redirected except on /admin/
  * URLs, apiClient redirected only for three hardcoded endpoints, and
  * services/api/index.js - which carries most of the traffic - did nothing at all.
- * These tests pin the one shared rule. See SSO_ONLY_MODE_SPEC.md 8.10.
+ * These tests pin the one shared rule.
  */
 
 const jsonResponse = (status, url, body = {}) => ({

--- a/frontend/src/services/apiClient.js
+++ b/frontend/src/services/apiClient.js
@@ -76,7 +76,7 @@ class APIClient {
     // /users/me, which are not the requests that need protecting - none of the
     // app's background polls goes through this client at all, so the swallow it
     // implemented protected nothing and the redirect it skipped mattered
-    // everywhere else. See SSO_ONLY_MODE_SPEC.md 8.10.
+    // everywhere else.
     //
     // The explanation is no longer raised here as a toast: this ends in a full
     // page load, which discarded the toast before it could render. It travels in

--- a/frontend/src/services/auth/simpleAuthService.js
+++ b/frontend/src/services/auth/simpleAuthService.js
@@ -397,7 +397,6 @@ class SimpleAuthService {
    * clear_auth_cookie would never run, and the HttpOnly cookie would stay valid --
    * the user is shown a logged-out UI while still holding a live session. Under
    * SSO_AUTO_REDIRECT that is unrecoverable rather than merely wrong.
-   * See SSO_ONLY_MODE_SPEC.md 8.7b.
    */
   async logout() {
     logger.info('Logging out user', { category: 'auth_logout' });
@@ -634,7 +633,7 @@ class SimpleAuthService {
         // entry. Keyed to the OAuth state parameter, so it survives private
         // browsing and disabled storage where sessionStorage does not.
         // Untrusted - the backend stores and echoes it verbatim; validate before
-        // navigating. See SSO_ONLY_MODE_SPEC.md 8.8 and 8.11.
+        // navigating.
         returnUrl: data.return_url || null,
       };
     } catch (error) {

--- a/frontend/src/utils/loginRedirect.ts
+++ b/frontend/src/utils/loginRedirect.ts
@@ -12,7 +12,7 @@
  * The answer travels in the URL rather than in sessionStorage or router state.
  * The URL survives a full page load (two of the HTTP clients hard-navigate),
  * survives private browsing and disabled storage, and is visible in the address
- * bar when a user reports a problem. See SSO_ONLY_MODE_SPEC.md section 6.
+ * bar when a user reports a problem.
  *
  * Importable from non-React modules - the HTTP clients are plain singletons with
  * no access to react-router's navigate.
@@ -185,7 +185,7 @@ export function redirectToLogin(options: LoginRedirectOptions = {}): void {
  * existed the app had four independent request paths and four different answers:
  * one redirected except on /admin/ URLs, one redirected only for three hardcoded
  * endpoints, and two did nothing at all - and the two that did nothing carried
- * most of the traffic. See SSO_ONLY_MODE_SPEC.md 8.10.
+ * most of the traffic.
  *
  * `simpleAuthService` is the deliberate exception and must stay one: its 401s
  * ARE the auth state rather than a symptom of it. A rejected login, a missing

--- a/tests/api/test_sso_inactive_user.py
+++ b/tests/api/test_sso_inactive_user.py
@@ -1,0 +1,151 @@
+"""A deactivated user signing in via SSO must be told so, not shown a 500.
+
+`_check_user_active` raises UnauthorizedException from inside each SSO endpoint's
+try block, and the broad `except Exception` underneath converted it into
+`500 SSO authentication failed`. The account was refused - correctly - but the
+message said the identity provider had failed.
+
+This blocks more than tidiness. The redirect design rejects a silent bounce back to
+the IdP specifically because it "completely hides the deactivated-account case", so
+the error page the frontend is about to grow has nothing accurate to render until
+the status code tells the truth (SSO_ONLY_MODE_SPEC.md 8.6, criterion 17).
+
+All three login endpoints are tested separately: each carries its own try/except and
+a fix applied to one is easy to miss on the others.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.v1.endpoints import sso as sso_endpoint
+from app.services import sso_service as sso_module
+
+CALLBACK_URL = "/api/v1/auth/sso/callback"
+RESOLVE_CONFLICT_URL = "/api/v1/auth/sso/resolve-conflict"
+RESOLVE_GITHUB_URL = "/api/v1/auth/sso/resolve-github-link"
+
+DEACTIVATED = "deactivated"
+
+
+pytestmark = pytest.mark.usefixtures("clean_sso_state")
+
+
+@pytest.fixture
+def inactive_user(make_sso_user):
+    return make_sso_user(username="inactivessouser", is_active=False)
+
+
+@pytest.fixture
+def sso_result(inactive_user):
+    """What a service call returns once authentication itself has succeeded.
+
+    The user really is deactivated in the database; only the outbound IdP work is
+    replaced. What is under test is the endpoint's exception handling, so the
+    service is stubbed as the collaborator it is.
+    """
+    return {"user": inactive_user, "is_new_user": False, "auth_method": "sso"}
+
+
+@pytest.fixture
+def callback_flow(sso_result):
+    """A /callback that reaches _check_user_active with a real inactive user."""
+    with patch.object(sso_module.settings, "SSO_ENABLED", True):
+        with patch.object(sso_module, "create_sso_provider") as factory:
+            factory.return_value.get_auth_url.return_value = "https://idp/authorize"
+
+            async def exchange(_code):
+                return {"access_token": "token"}
+
+            async def user_info(_token):
+                class Info:
+                    sub = "external-inactivessouser"
+                    email = "inactivessouser@example.com"
+                    name = "Inactive SSO User"
+
+                return Info()
+
+            factory.return_value.exchange_code_for_token = exchange
+            factory.return_value.get_user_info = user_info
+
+            with patch.object(
+                sso_module.SSOService, "_find_or_create_user", return_value=sso_result
+            ):
+                yield
+
+
+def assert_deactivation_response(response):
+    assert (
+        response.status_code == 401
+    ), "not a 500 - the account was refused, not the IdP"
+    assert DEACTIVATED in response.json()["message"].lower()
+
+
+class TestCallback:
+    def test_a_deactivated_user_gets_the_deactivation_message(
+        self, client: TestClient, callback_flow
+    ):
+        initiate = client.post("/api/v1/auth/sso/initiate")
+        state = initiate.json()["state"]
+
+        response = client.post(CALLBACK_URL, json={"code": "authcode", "state": state})
+
+        assert_deactivation_response(response)
+
+    def test_an_unexpected_error_is_still_a_500(
+        self, client: TestClient, callback_flow
+    ):
+        """The broad handler still does its job for genuine failures."""
+        with patch.object(
+            sso_module.SSOService,
+            "complete_authentication",
+            side_effect=RuntimeError("boom"),
+        ):
+            response = client.post(
+                CALLBACK_URL, json={"code": "authcode", "state": "anything"}
+            )
+
+        assert response.status_code == 500
+
+
+class TestResolveConflict:
+    def test_a_deactivated_user_gets_the_deactivation_message(
+        self, client: TestClient, sso_result
+    ):
+        with patch.object(
+            sso_endpoint.sso_service,
+            "resolve_account_conflict",
+            return_value=sso_result,
+        ):
+            response = client.post(
+                RESOLVE_CONFLICT_URL,
+                json={
+                    "temp_token": "token",
+                    "action": "link",
+                    "preference": "auto_link",
+                },
+            )
+
+        assert_deactivation_response(response)
+
+
+class TestResolveGitHubLink:
+    def test_a_deactivated_user_gets_the_deactivation_message(
+        self, client: TestClient, sso_result
+    ):
+        with patch.object(
+            sso_endpoint.sso_service,
+            "resolve_github_manual_link",
+            return_value=sso_result,
+        ):
+            response = client.post(
+                RESOLVE_GITHUB_URL,
+                json={
+                    "temp_token": "token",
+                    "username": "inactivessouser",
+                    "password": "irrelevant",
+                },
+            )
+
+        assert_deactivation_response(response)

--- a/tests/api/test_sso_inactive_user.py
+++ b/tests/api/test_sso_inactive_user.py
@@ -8,7 +8,7 @@ message said the identity provider had failed.
 This blocks more than tidiness. The redirect design rejects a silent bounce back to
 the IdP specifically because it "completely hides the deactivated-account case", so
 the error page the frontend is about to grow has nothing accurate to render until
-the status code tells the truth (SSO_ONLY_MODE_SPEC.md 8.6, criterion 17).
+the status code tells the truth.
 
 All three login endpoints are tested separately: each carries its own try/except and
 a fix applied to one is easy to miss on the others.

--- a/tests/api/test_sso_must_change_password.py
+++ b/tests/api/test_sso_must_change_password.py
@@ -305,11 +305,11 @@ class TestEdgeCases:
         with patch_callback(user):
             response = client.post(CALLBACK_URL, json=CALLBACK_BODY)
 
-        # Login does not succeed, so the clear never runs. The status is currently
-        # 500 rather than 401 because the endpoint's broad `except Exception`
-        # swallows UnauthorizedException - a pre-existing defect tracked separately
-        # in TECHNICAL_DEBT.md, deliberately not changed here.
-        assert response.status_code != 200
+        # Login does not succeed, so the clear never runs. 401, not the 500 this
+        # used to return: the endpoint's broad `except Exception` no longer swallows
+        # UnauthorizedException (SSO_ONLY_MODE_SPEC.md 8.6). The deactivation case is
+        # covered directly in test_sso_inactive_user.py.
+        assert response.status_code == 401
 
         db_session.expire_all()
         assert db_session.get(User, user_id).must_change_password is True

--- a/tests/api/test_sso_must_change_password.py
+++ b/tests/api/test_sso_must_change_password.py
@@ -307,7 +307,7 @@ class TestEdgeCases:
 
         # Login does not succeed, so the clear never runs. 401, not the 500 this
         # used to return: the endpoint's broad `except Exception` no longer swallows
-        # UnauthorizedException (SSO_ONLY_MODE_SPEC.md 8.6). The deactivation case is
+        # UnauthorizedException. The deactivation case is
         # covered directly in test_sso_inactive_user.py.
         assert response.status_code == 401
 

--- a/tests/api/test_sso_only_mode.py
+++ b/tests/api/test_sso_only_mode.py
@@ -1,0 +1,243 @@
+"""Tests for SSO_ONLY_MODE's server-side enforcement.
+
+Hiding the login form is cosmetic - anyone can POST to /auth/login directly - so
+these guards are the security boundary for the feature. The login test uses *valid*
+credentials on purpose: a test with bad ones passes against an implementation that
+never guards anything and simply returns 401.
+
+What must keep working under the flag is as important as what must not:
+/auth/change-password is the break-glass route for an admin and the completion route
+for a hybrid account's forced password change.
+"""
+
+import logging
+from unittest.mock import PropertyMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.config import settings
+from app.main import app
+from tests.utils.user import create_random_user
+
+LOGIN_URL = "/api/v1/auth/login"
+REGISTER_URL = "/api/v1/auth/register"
+REGISTRATION_STATUS_URL = "/api/v1/auth/registration-status"
+CHANGE_PASSWORD_URL = "/api/v1/auth/change-password"
+SSO_CONFIG_URL = "/api/v1/auth/sso/config"
+
+AUTH_LOGGER = "medical_records.app.api.v1.endpoints.auth"
+
+
+@pytest.fixture
+def sso_only():
+    """Turn on SSO-only mode for the duration of a test.
+
+    Patched inside the test rather than around the client fixture: startup
+    validation refuses to boot with this flag set and SSO_ENABLED false, and the
+    lifespan has already run by the time a test body executes.
+    """
+    with patch.object(settings, "SSO_ONLY_MODE", True):
+        yield
+
+
+def registration_payload(username: str = "newlocaluser") -> dict:
+    return {
+        "username": username,
+        "email": f"{username}@example.com",
+        "password": "password123",
+        "full_name": "New Local User",
+    }
+
+
+class TestPasswordLoginIsRefused:
+    def test_valid_credentials_are_refused_with_403(
+        self, client: TestClient, db_session, sso_only
+    ):
+        user_data = create_random_user(db_session)
+
+        response = client.post(
+            LOGIN_URL,
+            data={
+                "username": user_data["username"],
+                "password": user_data["password"],
+            },
+        )
+
+        assert response.status_code == 403
+
+    def test_no_token_and_no_cookie_are_issued(
+        self, client: TestClient, db_session, sso_only
+    ):
+        user_data = create_random_user(db_session)
+
+        response = client.post(
+            LOGIN_URL,
+            data={
+                "username": user_data["username"],
+                "password": user_data["password"],
+            },
+        )
+
+        assert "access_token" not in response.json()
+        assert not response.cookies
+
+    def test_the_refusal_emits_a_security_event(
+        self, client: TestClient, db_session, sso_only, caplog
+    ):
+        user_data = create_random_user(db_session)
+
+        with caplog.at_level(logging.INFO, logger=AUTH_LOGGER):
+            client.post(
+                LOGIN_URL,
+                data={
+                    "username": user_data["username"],
+                    "password": user_data["password"],
+                },
+            )
+
+        events = [getattr(record, "event", None) for record in caplog.records]
+        assert "password_login_blocked_sso_only" in events
+        # The blocked request is not a login attempt, and must not be counted as one.
+        assert "login_attempt" not in events
+
+    def test_login_still_works_with_the_flag_off(self, client: TestClient, db_session):
+        user_data = create_random_user(db_session)
+
+        response = client.post(
+            LOGIN_URL,
+            data={
+                "username": user_data["username"],
+                "password": user_data["password"],
+            },
+        )
+
+        assert response.status_code == 200
+        assert "access_token" in response.json()
+
+
+class TestRegistrationIsRefused:
+    @pytest.mark.parametrize("allow_registration", [True, False])
+    def test_registration_is_refused_regardless_of_the_registration_setting(
+        self, client: TestClient, sso_only, allow_registration
+    ):
+        with patch.object(settings, "ALLOW_USER_REGISTRATION", allow_registration):
+            response = client.post(REGISTER_URL, json=registration_payload())
+
+        assert response.status_code == 403
+
+    def test_the_refusal_emits_its_own_security_event(
+        self, client: TestClient, sso_only, caplog
+    ):
+        with caplog.at_level(logging.INFO, logger=AUTH_LOGGER):
+            client.post(REGISTER_URL, json=registration_payload())
+
+        events = [getattr(record, "event", None) for record in caplog.records]
+        # Distinct from registration_blocked, which means ALLOW_USER_REGISTRATION.
+        assert "registration_blocked_sso_only" in events
+        assert "registration_blocked" not in events
+
+    def test_registration_still_works_with_the_flag_off(self, client: TestClient):
+        with patch.object(settings, "ALLOW_USER_REGISTRATION", True):
+            response = client.post(
+                REGISTER_URL, json=registration_payload("flagoffuser")
+            )
+
+        assert response.status_code == 200
+
+
+class TestBreakGlassRoutesStayOpen:
+    def test_change_password_still_works(self, client: TestClient, db_session):
+        """A hybrid account's forced change and an admin's recovery both land here.
+
+        The session is established before the flag goes on, which is the real
+        sequence: an operator enables SSO-only, and an already-signed-in admin (or a
+        hybrid user sent to the forced-change form) must still be able to finish.
+        """
+        user_data = create_random_user(db_session)
+        login = client.post(
+            LOGIN_URL,
+            data={
+                "username": user_data["username"],
+                "password": user_data["password"],
+            },
+        )
+        assert login.status_code == 200, "sign in before the flag goes on"
+        headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+
+        with patch.object(settings, "SSO_ONLY_MODE", True):
+            response = client.post(
+                CHANGE_PASSWORD_URL,
+                json={
+                    "currentPassword": user_data["password"],
+                    "newPassword": "newpassword123",
+                },
+                headers=headers,
+            )
+
+        assert response.status_code == 200
+
+
+class TestConfigPayload:
+    def test_the_flags_are_exposed(self, client: TestClient):
+        with patch.object(settings, "SSO_ONLY_MODE", True):
+            with patch.object(settings, "SSO_AUTO_REDIRECT", True):
+                body = client.get(SSO_CONFIG_URL).json()
+
+        assert body["sso_only"] is True
+        assert body["auto_redirect"] is True
+
+    def test_the_flags_default_off(self, client: TestClient):
+        body = client.get(SSO_CONFIG_URL).json()
+
+        assert body["sso_only"] is False
+        assert body["auto_redirect"] is False
+
+    def test_a_failure_is_not_reported_as_sso_being_off(self, client: TestClient):
+        """The endpoint must not synthesize a plausible-looking payload on error.
+
+        `enabled: false, sso_only: false` is the one answer that strands a user
+        under SSO-only: the client hides the SSO button and shows a password form
+        the server refuses. A 500 cannot be mistaken for "SSO is off", so the client
+        retries instead.
+        """
+        # Its own client: the shared fixture sets raise_server_exceptions=True, which
+        # re-raises instead of letting the app's registered handler produce the
+        # response the client would actually receive. Built before the patch, since
+        # startup validation reads the attribute being made to raise.
+        with TestClient(app, raise_server_exceptions=False) as unguarded:
+            with patch.object(settings, "SSO_ONLY_MODE", True), patch.object(
+                type(settings),
+                "SSO_ENABLED",
+                new_callable=PropertyMock,
+                side_effect=RuntimeError("settings unavailable"),
+            ):
+                response = unguarded.get(SSO_CONFIG_URL)
+
+        assert response.status_code == 500
+        assert response.json().get("enabled") is None
+
+
+class TestRegistrationStatus:
+    def test_it_reports_the_effective_value_under_sso_only(
+        self, client: TestClient, sso_only
+    ):
+        """Registration is refused under the flag, so the endpoint must say so.
+
+        /auth/sso/config keeps reporting the raw setting, because there the field
+        governs whether SSO may provision accounts - which this flag does not stop.
+        """
+        with patch.object(settings, "ALLOW_USER_REGISTRATION", True):
+            status = client.get(REGISTRATION_STATUS_URL).json()
+            sso_config = client.get(SSO_CONFIG_URL).json()
+
+        assert status["registration_enabled"] is False
+        assert status["message"]
+        assert sso_config["registration_enabled"] is True
+
+    def test_it_is_unchanged_with_the_flag_off(self, client: TestClient):
+        with patch.object(settings, "ALLOW_USER_REGISTRATION", True):
+            body = client.get(REGISTRATION_STATUS_URL).json()
+
+        assert body["registration_enabled"] is True
+        assert body["message"] is None

--- a/tests/api/test_sso_return_url.py
+++ b/tests/api/test_sso_return_url.py
@@ -3,7 +3,7 @@
 The frontend now consumes this field, and validates it before navigating. This module
 also covers the server-side half of that guard: a value that is not a root-relative
 internal path is refused at /initiate, so it is never written into the state store and
-any future consumer inherits the guarantee (SSO_ONLY_MODE_SPEC.md 8.11, criterion 18).
+any future consumer inherits the guarantee.
 
 A client-only check is defeated by anyone talking to the API directly, and the value
 is consumed at the highest-trust moment in the app - immediately after a successful
@@ -177,6 +177,31 @@ def test_the_rate_limit_is_checked_before_the_return_url(
 @pytest.mark.parametrize("value", ["/patients/42", "/lab-results?status=open", "/"])
 def test_internal_paths_are_still_accepted(client: TestClient, sso_flow, value: str):
     assert client.post(INITIATE_URL, params={"return_url": value}).status_code == 200
+
+
+def test_an_empty_return_url_is_treated_as_absent(client: TestClient, sso_flow):
+    """`?return_url=` means "no deep link", not a value to reject.
+
+    FastAPI binds a bare parameter to "" rather than None, so a `is not None` guard
+    sends it to is_safe_return_url, which refuses it. A client that appends the
+    parameter unconditionally would then be unable to start SSO at all - and under
+    SSO_ONLY_MODE it has no password login to fall back to.
+    """
+    response = client.post(INITIATE_URL, params={"return_url": ""})
+
+    assert response.status_code == 200
+
+
+def test_an_empty_return_url_carries_through_as_null(client: TestClient, sso_flow):
+    stub_token_exchange(sso_flow)
+
+    initiate = client.post(INITIATE_URL, params={"return_url": ""})
+    state = initiate.json()["state"]
+
+    response = client.post(CALLBACK_URL, json={"code": "authcode", "state": state})
+
+    assert response.status_code == 200
+    assert response.json()["return_url"] is None
 
 
 def test_the_state_entry_is_still_single_use(client: TestClient, sso_flow):

--- a/tests/api/test_sso_return_url.py
+++ b/tests/api/test_sso_return_url.py
@@ -1,16 +1,22 @@
 """The return_url given to /initiate is carried through to the /callback response.
 
-Ships inert - no frontend reads this field yet. Deep links currently survive SSO via
-sessionStorage, which does not work in private browsing; the consumer for this field
-is a later PR (SSO_ONLY_MODE_SPEC.md 8.8). Tested now because the field is easy to
-drop silently while nothing depends on it.
+The frontend now consumes this field, and validates it before navigating. This module
+also covers the server-side half of that guard: a value that is not a root-relative
+internal path is refused at /initiate, so it is never written into the state store and
+any future consumer inherits the guarantee (SSO_ONLY_MODE_SPEC.md 8.11, criterion 18).
+
+A client-only check is defeated by anyone talking to the API directly, and the value
+is consumed at the highest-trust moment in the app - immediately after a successful
+sign-in.
 """
 
+import logging
 from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
 
+from app.api.v1.endpoints import sso as sso_endpoint
 from app.models.models import User
 from app.services import sso_service as sso_module
 from app.services.sso_service import _state_storage
@@ -18,8 +24,23 @@ from app.services.sso_service import _state_storage
 INITIATE_URL = "/api/v1/auth/sso/initiate"
 CALLBACK_URL = "/api/v1/auth/sso/callback"
 
+SSO_ENDPOINT_LOGGER = "medical_records.sso.api.v1.endpoints.sso"
+
 
 pytestmark = pytest.mark.usefixtures("clean_sso_state")
+
+
+@pytest.fixture(autouse=True)
+def fresh_rate_limiter():
+    """Clear the per-IP counter on /initiate around every test in this module.
+
+    The limiter is a module-scope singleton keyed by client IP, and every test here
+    calls the same endpoint from the same address, so without this the later tests
+    in the file are throttled by the earlier ones.
+    """
+    sso_endpoint._initiate_limiter.reset()
+    yield
+    sso_endpoint._initiate_limiter.reset()
 
 
 @pytest.fixture
@@ -92,6 +113,65 @@ def test_flow_started_without_a_return_url_yields_null(client: TestClient, sso_f
 
     assert response.status_code == 200
     assert response.json()["return_url"] is None
+
+
+HOSTILE_RETURN_URLS = [
+    "https://evil.example",
+    # The forms a naive startswith("/") check waves through.
+    "//evil.example",
+    "/\\evil.example",
+    "../admin",
+    "javascript:alert(1)",
+]
+
+
+@pytest.mark.parametrize("hostile", HOSTILE_RETURN_URLS)
+def test_a_non_internal_return_url_is_refused(
+    client: TestClient, sso_flow, hostile: str
+):
+    response = client.post(INITIATE_URL, params={"return_url": hostile})
+
+    # 400, specifically. The endpoint's broad `except Exception` re-reports anything
+    # raised inside its try block as a 500, so a test asserting only "not 200" would
+    # pass against a guard written in the wrong place.
+    assert response.status_code == 400
+
+
+@pytest.mark.parametrize("hostile", HOSTILE_RETURN_URLS)
+def test_a_refused_return_url_mints_no_state_entry(
+    client: TestClient, sso_flow, hostile: str
+):
+    """The point of the exercise: a hostile value never enters the store."""
+    client.post(INITIATE_URL, params={"return_url": hostile})
+
+    assert _state_storage == {}
+
+
+def test_the_refusal_is_logged_as_a_security_event(
+    client: TestClient, sso_flow, caplog
+):
+    with caplog.at_level(logging.INFO, logger=SSO_ENDPOINT_LOGGER):
+        client.post(INITIATE_URL, params={"return_url": "https://evil.example"})
+
+    events = [getattr(record, "event", None) for record in caplog.records]
+    assert "sso_return_url_rejected" in events
+
+
+def test_the_rate_limit_is_checked_before_the_return_url(
+    client: TestClient, sso_flow, limiter_ceiling
+):
+    """Deliberate ordering: a caller probing this endpoint burns its quota."""
+    limiter_ceiling(sso_endpoint._initiate_limiter, 1)
+    client.post(INITIATE_URL, params={"return_url": "/dashboard"})
+
+    response = client.post(INITIATE_URL, params={"return_url": "https://evil.example"})
+
+    assert response.status_code == 429
+
+
+@pytest.mark.parametrize("value", ["/patients/42", "/lab-results?status=open", "/"])
+def test_internal_paths_are_still_accepted(client: TestClient, sso_flow, value: str):
+    assert client.post(INITIATE_URL, params={"return_url": value}).status_code == 200
 
 
 def test_the_state_entry_is_still_single_use(client: TestClient, sso_flow):

--- a/tests/api/test_sso_return_url.py
+++ b/tests/api/test_sso_return_url.py
@@ -119,6 +119,11 @@ HOSTILE_RETURN_URLS = [
     "https://evil.example",
     # The forms a naive startswith("/") check waves through.
     "//evil.example",
+    # And the ones urlsplit itself waves through: it reports a netloc only for
+    # exactly two leading slashes, while a browser skips every leading slash and
+    # resolves all of these off-origin.
+    "///evil.example",
+    "////evil.example",
     "/\\evil.example",
     "../admin",
     "javascript:alert(1)",

--- a/tests/api/test_sso_startup_validation.py
+++ b/tests/api/test_sso_startup_validation.py
@@ -1,0 +1,238 @@
+"""Tests for the startup validation of SSO_ONLY_MODE / SSO_AUTO_REDIRECT.
+
+The case that matters most is SSO_ONLY_MODE=true with SSO_ENABLED unset. Until this
+work it was guarded out twice over - validate_sso_config() returns early when
+SSO_ENABLED is false, and its only caller was gated on the same flag - so the
+instance booted cleanly into a state where the login form was hidden and SSO did not
+exist. That is the compose-file typo the whole validation exists to catch.
+
+Failures are asserted through TestClient's lifespan rather than by calling the
+validator directly: the point is that the *app* refuses to come up, and that it does
+so from the lifespan hook rather than as an import traceback.
+"""
+
+import asyncio
+import logging
+from contextlib import ExitStack, contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.config import settings
+from app.main import app
+
+STARTUP_LOGGER = "medical_records.app.core.startup"
+
+# A provider configuration complete enough for validate_sso_config() to pass.
+VALID_SSO = {
+    "SSO_ENABLED": True,
+    "SSO_PROVIDER_TYPE": "keycloak",
+    "SSO_CLIENT_ID": "client-id",
+    "SSO_CLIENT_SECRET": "client-secret",
+    "SSO_REDIRECT_URI": "https://medikeep.example/auth/sso/callback",
+    "SSO_ISSUER_URL": "https://idp.example/realms/medikeep",
+}
+
+
+@contextmanager
+def configured(**overrides):
+    """Patch settings with a valid SSO config plus the given overrides.
+
+    A context manager rather than a fixture because the patches have to be in
+    place *before* TestClient(app) is constructed - the lifespan, and so the
+    validation under test, runs on __enter__.
+    """
+    values = {**VALID_SSO, **overrides}
+    with ExitStack() as stack:
+        for name, value in values.items():
+            stack.enter_context(patch.object(settings, name, value))
+        yield
+
+
+class TestBootFailure:
+    @pytest.mark.parametrize("flag", ["SSO_ONLY_MODE", "SSO_AUTO_REDIRECT"])
+    def test_a_flag_without_sso_enabled_aborts_the_boot(self, flag):
+        with configured(SSO_ENABLED=False, **{flag: True}):
+            with pytest.raises(RuntimeError) as excinfo:
+                with TestClient(app):
+                    pass
+
+        # The message is the deliverable - it is read by a self-hoster whose
+        # medical records app will not start - so it has to name the variable.
+        assert flag in str(excinfo.value)
+        assert "SSO_ENABLED" in str(excinfo.value)
+
+    def test_the_failure_is_logged_before_it_is_raised(self, caplog):
+        with configured(SSO_ENABLED=False, SSO_ONLY_MODE=True):
+            with caplog.at_level(logging.ERROR, logger=STARTUP_LOGGER):
+                with pytest.raises(RuntimeError):
+                    with TestClient(app):
+                        pass
+
+        events = [getattr(record, "event", None) for record in caplog.records]
+        assert "auth_mode_config_invalid" in events
+        assert any("STARTUP FAILED" in record.message for record in caplog.records)
+
+    def test_a_flag_with_an_incomplete_provider_config_aborts_the_boot(self):
+        with configured(SSO_ONLY_MODE=True, SSO_CLIENT_SECRET=""):
+            with pytest.raises(RuntimeError) as excinfo:
+                with TestClient(app):
+                    pass
+
+        assert "SSO_CLIENT_SECRET" in str(excinfo.value)
+
+    def test_an_incomplete_provider_config_aborts_the_boot_without_any_flag(self):
+        """Unchanged behavior, moved. This used to raise at import time.
+
+        SSOService.__init__ validated on construction, and endpoints/sso.py builds
+        one at module import, so an operator saw a traceback instead of the
+        actionable startup error. The boot must still fail - just from the lifespan.
+        """
+        with configured(SSO_ISSUER_URL=""):
+            with pytest.raises(RuntimeError) as excinfo:
+                with TestClient(app):
+                    pass
+
+        assert "SSO_ISSUER_URL" in str(excinfo.value)
+
+
+class TestBootSuccess:
+    def test_a_coherent_sso_only_configuration_boots(self):
+        with configured(SSO_ONLY_MODE=True, SSO_AUTO_REDIRECT=True):
+            with TestClient(app) as booted:
+                assert booted.get("/api/v1/auth/sso/config").json()["sso_only"] is True
+
+    def test_the_flags_default_off_and_do_not_affect_startup(self):
+        # The regression that matters for criterion 1: an existing deployment sees
+        # no change. Every other test in the suite boots this way already.
+        assert settings.SSO_ONLY_MODE is False
+        assert settings.SSO_AUTO_REDIRECT is False
+
+        with TestClient(app):
+            pass
+
+
+class TestValidationRunsFromTheLifespanNotAtImport:
+    def test_importing_the_sso_endpoints_with_an_invalid_config_does_not_raise(self):
+        """Criterion 2 asks for a logged startup failure, not an import traceback.
+
+        Re-importing the module with a broken config is what used to blow up, via
+        the module-level SSOService() construction.
+        """
+        import importlib
+
+        from app.api.v1.endpoints import sso as sso_endpoint
+
+        try:
+            with configured(SSO_CLIENT_ID=""):
+                importlib.reload(sso_endpoint)
+        finally:
+            # Reload again with the real config so the module other tests import
+            # is not left holding the broken one.
+            importlib.reload(sso_endpoint)
+
+    def test_constructing_the_service_with_an_invalid_config_does_not_raise(self):
+        from app.services.sso_service import SSOService
+
+        with configured(SSO_CLIENT_SECRET=""):
+            SSOService()
+
+
+class TestSealedInstanceWarning:
+    """SSO_ONLY_MODE with registration disabled: warn, never fail.
+
+    The policy itself is a pure method on Settings, so most of this is cheap. What
+    is not cheap, and is tested separately below, is *when* startup calls it:
+    ALLOW_USER_REGISTRATION is admin-toggleable and persisted in system_settings,
+    and the stored value only overrides the env default part-way through startup, so
+    a call placed beside the boot-failure validation would report on a value that is
+    not in effect.
+    """
+
+    @pytest.fixture(autouse=True)
+    def restore_registration_setting(self):
+        """These tests write ALLOW_USER_REGISTRATION directly; put it back."""
+        original = settings.ALLOW_USER_REGISTRATION
+        yield
+        settings.ALLOW_USER_REGISTRATION = original
+
+    @pytest.mark.parametrize(
+        "sso_only, registration_enabled, expected",
+        [
+            (True, False, True),
+            (True, True, False),
+            (False, False, False),
+            (False, True, False),
+        ],
+    )
+    def test_the_policy(self, sso_only, registration_enabled, expected):
+        with configured(SSO_ONLY_MODE=sso_only):
+            settings.ALLOW_USER_REGISTRATION = registration_enabled
+
+            events = [event for event, _ in settings.auth_mode_warnings()]
+
+        assert ("sso_only_no_registration_route" in events) is expected
+
+    @staticmethod
+    def run_startup(persisted_registration: bool):
+        """Run startup_event() to completion with the database work stubbed out.
+
+        `persisted_registration` is what the database says, applied by the stubbed
+        load_persisted_settings exactly where the real one applies it.
+        """
+
+        def load(_db):
+            settings.ALLOW_USER_REGISTRATION = persisted_registration
+
+        scheduler = MagicMock()
+        scheduler.start = AsyncMock()
+
+        with patch.dict("os.environ", {"SKIP_MIGRATIONS": "false"}), patch(
+            "app.core.database.database.check_database_connection", return_value=True
+        ), patch(
+            "app.core.startup.check_database_connection", return_value=True
+        ), patch(
+            "app.core.startup.database_migrations", return_value=True
+        ), patch(
+            "app.core.startup.create_default_user"
+        ), patch(
+            "app.core.startup.check_sequences_on_startup", new_callable=AsyncMock
+        ), patch(
+            "app.core.startup.run_startup_data_migrations"
+        ), patch(
+            "app.core.persisted_settings.load_persisted_settings", side_effect=load
+        ), patch(
+            "app.core.utils.test_initialization.ensure_tests_initialized"
+        ), patch(
+            "app.services.backup_scheduler_service.BackupSchedulerService.get_instance",
+            return_value=scheduler,
+        ), patch(
+            "app.services.medication_reminder_scheduler."
+            "MedicationReminderSchedulerService.get_instance",
+            return_value=scheduler,
+        ):
+            from app.core.startup import startup_event
+
+            asyncio.run(startup_event())
+
+    def test_startup_reads_the_value_the_database_supplied(self, caplog):
+        """The ordering test, and the reason the mock stack above is worth paying for.
+
+        Env says registration is on; the stored setting says otherwise. If the
+        warning were emitted beside the boot-failure validation it would see the env
+        value and stay silent.
+        """
+        with configured(SSO_ONLY_MODE=True):
+            settings.ALLOW_USER_REGISTRATION = True
+            with caplog.at_level(logging.WARNING, logger=STARTUP_LOGGER):
+                self.run_startup(persisted_registration=False)
+
+        events = [getattr(record, "event", None) for record in caplog.records]
+        assert "sso_only_no_registration_route" in events
+
+    def test_the_sealed_combination_does_not_fail_the_boot(self):
+        with configured(SSO_ONLY_MODE=True, SSO_ENABLED=True):
+            settings.ALLOW_USER_REGISTRATION = False
+            with TestClient(app):
+                pass

--- a/tests/api/test_sso_startup_validation.py
+++ b/tests/api/test_sso_startup_validation.py
@@ -13,12 +13,14 @@ so from the lifespan hook rather than as an import traceback.
 
 import asyncio
 import logging
+import os
 from contextlib import ExitStack, contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
+from app.core import config
 from app.core.config import settings
 from app.main import app
 
@@ -104,8 +106,8 @@ class TestBootSuccess:
                 assert booted.get("/api/v1/auth/sso/config").json()["sso_only"] is True
 
     def test_the_flags_default_off_and_do_not_affect_startup(self):
-        # The regression that matters for criterion 1: an existing deployment sees
-        # no change. Every other test in the suite boots this way already.
+        # The regression that matters: an existing deployment sees no change.
+        # Every other test in the suite boots this way already.
         assert settings.SSO_ONLY_MODE is False
         assert settings.SSO_AUTO_REDIRECT is False
 
@@ -113,9 +115,105 @@ class TestBootSuccess:
             pass
 
 
+class TestFlagParsing:
+    """An unrecognized value fails the boot rather than reading as False.
+
+    `.lower() == "true"` - the idiom every other boolean in config.py uses - reads
+    `SSO_ONLY_MODE=1`, a trailing space, or `SSO_ONLY_MODE=true # sso only` (a
+    compose env file does not strip inline comments) as False. Here False means
+    password login is still accepted, so a silent misparse is a security control
+    failing open, and the pairing check above cannot catch it: that only fires when
+    the flag parses True.
+    """
+
+    @pytest.fixture(autouse=True)
+    def clean_parse_errors(self):
+        """_strict_bool records into module state; do not leak it between tests."""
+        original = dict(config._AUTH_FLAG_PARSE_ERRORS)
+        config._AUTH_FLAG_PARSE_ERRORS.clear()
+        yield
+        config._AUTH_FLAG_PARSE_ERRORS.clear()
+        config._AUTH_FLAG_PARSE_ERRORS.update(original)
+
+    @pytest.mark.parametrize(
+        "raw", ["true", "TRUE", "True", "1", "yes", "on", " true "]
+    )
+    def test_the_spellings_that_mean_on(self, raw):
+        with patch.dict(os.environ, {"SSO_ONLY_MODE": raw}):
+            assert config._strict_bool("SSO_ONLY_MODE") is True
+
+        assert config._AUTH_FLAG_PARSE_ERRORS == {}
+
+    @pytest.mark.parametrize("raw", ["false", "FALSE", "0", "no", "off", ""])
+    def test_the_spellings_that_mean_off(self, raw):
+        with patch.dict(os.environ, {"SSO_ONLY_MODE": raw}):
+            assert config._strict_bool("SSO_ONLY_MODE") is False
+
+        # "" included deliberately: `SSO_ONLY_MODE=` in a compose file is an unset
+        # variable, not a typo, and must not fail anyone's boot.
+        assert config._AUTH_FLAG_PARSE_ERRORS == {}
+
+    def test_an_unset_variable_takes_the_default(self):
+        with patch.dict(os.environ):
+            os.environ.pop("SSO_ONLY_MODE", None)
+            assert config._strict_bool("SSO_ONLY_MODE") is False
+
+        assert config._AUTH_FLAG_PARSE_ERRORS == {}
+
+    @pytest.mark.parametrize("raw", ["true # sso only", "1 # sso only", "maybe", "tru"])
+    def test_an_unrecognized_value_is_recorded_rather_than_guessed(self, raw):
+        with patch.dict(os.environ, {"SSO_ONLY_MODE": raw}):
+            config._strict_bool("SSO_ONLY_MODE")
+
+        assert config._AUTH_FLAG_PARSE_ERRORS == {"SSO_ONLY_MODE": raw}
+
+    def test_a_recorded_value_aborts_the_boot(self):
+        with configured(AUTH_FLAG_PARSE_ERRORS={"SSO_ONLY_MODE": "true # sso only"}):
+            with pytest.raises(RuntimeError) as excinfo:
+                with TestClient(app):
+                    pass
+
+        # Both halves are the deliverable: the operator has to know which variable
+        # and what it was actually set to, or the inline-comment case is invisible.
+        message = str(excinfo.value)
+        assert "SSO_ONLY_MODE" in message
+        assert "true # sso only" in message
+
+    def test_it_aborts_even_though_the_flag_itself_reads_false(self):
+        """The case the pairing check cannot reach.
+
+        Everything else in this file is reachable only once a flag parses True. A
+        value that failed to parse is not a flag that is off - it is a flag whose
+        state nobody knows - and the configuration is otherwise entirely valid, so
+        without this check the instance boots clean.
+        """
+        with configured(
+            SSO_ONLY_MODE=False,
+            AUTH_FLAG_PARSE_ERRORS={"SSO_ONLY_MODE": "maybe"},
+        ):
+            with pytest.raises(RuntimeError):
+                with TestClient(app):
+                    pass
+
+    def test_the_failure_is_logged_before_it_is_raised(self, caplog):
+        with configured(AUTH_FLAG_PARSE_ERRORS={"SSO_AUTO_REDIRECT": "maybe"}):
+            with caplog.at_level(logging.ERROR, logger=STARTUP_LOGGER):
+                with pytest.raises(RuntimeError):
+                    with TestClient(app):
+                        pass
+
+        events = [getattr(record, "event", None) for record in caplog.records]
+        assert "auth_mode_config_invalid" in events
+
+    def test_a_clean_environment_records_nothing(self):
+        """The default state: the real settings object carries no parse errors."""
+        assert settings.AUTH_FLAG_PARSE_ERRORS == {}
+
+
 class TestValidationRunsFromTheLifespanNotAtImport:
     def test_importing_the_sso_endpoints_with_an_invalid_config_does_not_raise(self):
-        """Criterion 2 asks for a logged startup failure, not an import traceback.
+        """An invalid config must surface as a logged startup failure, not an
+        import traceback.
 
         Re-importing the module with a broken config is what used to blow up, via
         the module-level SSOService() construction.
@@ -230,6 +328,49 @@ class TestSealedInstanceWarning:
 
         events = [getattr(record, "event", None) for record in caplog.records]
         assert "sso_only_no_registration_route" in events
+
+    @staticmethod
+    def run_startup_in_test_mode():
+        """Run startup_event() with SKIP_MIGRATIONS set, as the test compose file does.
+
+        Barely any stubbing: that flag *is* an early return, and everything above it
+        is in-memory.
+        """
+        with patch.dict("os.environ", {"SKIP_MIGRATIONS": "true"}):
+            from app.core.startup import startup_event
+
+            asyncio.run(startup_event())
+
+    def test_skip_migrations_still_warns(self, caplog):
+        """The early return must not swallow the warning.
+
+        SKIP_MIGRATIONS returns from startup_event() above the warning site, so a
+        deployment running with it set - `tests/docker-compose.test.yml` does, and
+        operators can - got no warning at all for the sealed-instance combination.
+        That is exactly the configuration that needs saying out loud: nobody can
+        create an account by any self-service route.
+
+        Reading the env value here is correct rather than a compromise: with no
+        database there is no stored ALLOW_USER_REGISTRATION to override it.
+        """
+        with configured(SSO_ONLY_MODE=True):
+            settings.ALLOW_USER_REGISTRATION = False
+            with caplog.at_level(logging.WARNING, logger=STARTUP_LOGGER):
+                self.run_startup_in_test_mode()
+
+        events = [getattr(record, "event", None) for record in caplog.records]
+        assert "sso_only_no_registration_route" in events
+
+    def test_skip_migrations_stays_silent_when_there_is_nothing_to_warn_about(
+        self, caplog
+    ):
+        with configured(SSO_ONLY_MODE=True):
+            settings.ALLOW_USER_REGISTRATION = True
+            with caplog.at_level(logging.WARNING, logger=STARTUP_LOGGER):
+                self.run_startup_in_test_mode()
+
+        events = [getattr(record, "event", None) for record in caplog.records]
+        assert "sso_only_no_registration_route" not in events
 
     def test_the_sealed_combination_does_not_fail_the_boot(self):
         with configured(SSO_ONLY_MODE=True, SSO_ENABLED=True):

--- a/tests/api/test_sso_state_store.py
+++ b/tests/api/test_sso_state_store.py
@@ -80,11 +80,11 @@ SSO_LOGGER_NAME = "medical_records.sso.services.sso_service"
 
 @pytest.fixture
 def service():
-    """An SSOService built while SSO is disabled.
+    """An SSOService, constructed with SSO disabled.
 
-    SSOService.__init__ runs validate_sso_config() when SSO_ENABLED is true, which
-    a test environment cannot satisfy. Constructing here and enabling SSO afterwards
-    keeps the tests focused on the state store rather than on provider config.
+    The constructor no longer validates provider configuration - startup_event()
+    owns that now - so this is a plain construction. SSO stays off here to keep the
+    tests focused on the state store rather than on provider config.
     """
     with patch.object(sso_module.settings, "SSO_ENABLED", False):
         instance = SSOService()

--- a/tests/core/test_return_url.py
+++ b/tests/core/test_return_url.py
@@ -48,6 +48,14 @@ class TestRejected:
             ("http://evil.example/dashboard", "absolute URL with a path"),
             ("//evil.example", "protocol-relative"),
             ("//evil.example/dashboard", "protocol-relative with a path"),
+            # urlsplit reports a netloc only for exactly two leading slashes -
+            # "///evil.example" parses as a path - but a browser skips every
+            # leading slash and resolves all of these to http://evil.example.
+            ("///evil.example", "three leading slashes"),
+            ("////evil.example", "four leading slashes"),
+            ("///evil.example/dashboard", "three leading slashes with a path"),
+            ("//", "bare double slash"),
+            ("///", "bare triple slash"),
             ("/\\evil.example", "backslash form of protocol-relative"),
             ("\\\\evil.example", "UNC-style backslashes"),
             ("/dashboard\\..\\admin", "backslash anywhere"),

--- a/tests/core/test_return_url.py
+++ b/tests/core/test_return_url.py
@@ -1,0 +1,77 @@
+"""Unit tests for is_safe_return_url.
+
+This is the backend half of the open-redirect guard: the value it screens is stored
+against the OAuth state parameter and echoed back by /auth/sso/callback, so anything
+it lets through is consumed immediately after a successful sign-in.
+
+The protocol-relative forms are named individually on purpose. They are the cases a
+naive startswith("/") check waves through, and they are the reason this function
+exists rather than an inline one-liner at the endpoint.
+"""
+
+import pytest
+
+from app.core.utils.return_url import MAX_RETURN_URL_LENGTH, is_safe_return_url
+
+
+class TestAccepted:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "/",
+            "/dashboard",
+            "/patients/42",
+            "/lab-results?status=open",
+            "/lab-results?status=open#results",
+            "/patients/42/",
+            # Not rejected here even though the frontend refuses it as a return
+            # path: loop avoidance is a navigation rule, and a 400 would be a hard
+            # failure where the client already falls back to /dashboard.
+            "/login",
+        ],
+    )
+    def test_root_relative_paths_are_accepted(self, value):
+        assert is_safe_return_url(value) is True
+
+    def test_a_path_at_the_length_limit_is_accepted(self):
+        value = "/" + "a" * (MAX_RETURN_URL_LENGTH - 1)
+
+        assert len(value) == MAX_RETURN_URL_LENGTH
+        assert is_safe_return_url(value) is True
+
+
+class TestRejected:
+    @pytest.mark.parametrize(
+        "value, why",
+        [
+            ("https://evil.example", "absolute URL"),
+            ("http://evil.example/dashboard", "absolute URL with a path"),
+            ("//evil.example", "protocol-relative"),
+            ("//evil.example/dashboard", "protocol-relative with a path"),
+            ("/\\evil.example", "backslash form of protocol-relative"),
+            ("\\\\evil.example", "UNC-style backslashes"),
+            ("/dashboard\\..\\admin", "backslash anywhere"),
+            ("../admin", "relative, not root-relative"),
+            ("dashboard", "bare relative path"),
+            ("javascript:alert(1)", "scheme"),
+            ("data:text/html,<script>", "data scheme"),
+            ("/\thttps://evil.example", "tab a browser would strip"),
+            ("/dashboard\nSet-Cookie: x", "newline"),
+            ("", "empty"),
+            ("   ", "whitespace only, not root-relative"),
+        ],
+    )
+    def test_off_origin_and_malformed_values_are_rejected(self, value, why):
+        assert is_safe_return_url(value) is False, why
+
+    def test_none_is_rejected(self):
+        # Callers decide what "no return URL" means; the endpoint treats None as
+        # absent and never calls this.
+        assert is_safe_return_url(None) is False
+
+    @pytest.mark.parametrize("value", [42, [], {"path": "/dashboard"}])
+    def test_non_strings_are_rejected(self, value):
+        assert is_safe_return_url(value) is False
+
+    def test_an_over_long_path_is_rejected(self):
+        assert is_safe_return_url("/" + "a" * MAX_RETURN_URL_LENGTH) is False


### PR DESCRIPTION
## Summary

This pull request introduces robust support for SSO-only and auto-redirect authentication modes, improves configuration validation at startup, and enhances error handling and logging for authentication endpoints. The changes ensure that password-based login and registration are properly disabled when SSO-only mode is active, that misconfigurations are caught early with clear error messages, and that security and operational logs are more informative.

**Authentication Mode Enforcement and Validation**

* Added `SSO_ONLY_MODE` and `SSO_AUTO_REDIRECT` settings to `config.py`, with clear documentation and environment-variable control; these settings are now validated at startup to prevent misconfiguration that could lock out users. (`app/core/config.py`, `app/core/startup.py`) [[1]](diffhunk://#diff-46319cab8aa9cca75fe586084b86c07f241657d02b324944bb7d300ce560039bR244-R260) [[2]](diffhunk://#diff-46319cab8aa9cca75fe586084b86c07f241657d02b324944bb7d300ce560039bR435-R506) [[3]](diffhunk://#diff-466a7afa664d527d092be08e614c5543e8eb4f8d3b6ba4040581f66bc232b69cR34-R51)
* The `startup_event` now validates authentication mode configuration before proceeding, logging and aborting startup on error. Warnings for legitimate but potentially problematic configurations are logged after persisted settings are loaded. (`app/core/startup.py`) [[1]](diffhunk://#diff-466a7afa664d527d092be08e614c5543e8eb4f8d3b6ba4040581f66bc232b69cR34-R51) [[2]](diffhunk://#diff-466a7afa664d527d092be08e614c5543e8eb4f8d3b6ba4040581f66bc232b69cR160-R171)

**API Behavior and Security**

* `/auth/register` and `/auth/login` endpoints now explicitly block password registration and login when `SSO_ONLY_MODE` is enabled, logging attempts and returning clear error messages. (`app/api/v1/endpoints/auth.py`) [[1]](diffhunk://#diff-58cbf6b3617b377d3a8851669ad55bc36905fa9a231e7c942e1d2470d2c5f091R89-R107) [[2]](diffhunk://#diff-58cbf6b3617b377d3a8851669ad55bc36905fa9a231e7c942e1d2470d2c5f091R293-R315)
* The `/auth/registration-status` endpoint now reports the effective registration capability, taking SSO-only mode into account, and provides clear messaging for users. (`app/api/v1/endpoints/auth.py`)
* The SSO config endpoint (`/auth/sso/config`) now reports raw registration settings and includes additional flags for frontend use. It no longer swallows errors, ensuring misconfigurations are surfaced clearly. (`app/api/v1/endpoints/sso.py`)

**Error Handling and Logging Improvements**

* SSO login and callback endpoints now properly distinguish between expected errors (e.g., deactivated user) and unexpected failures, ensuring correct HTTP responses and better log clarity. (`app/api/v1/endpoints/sso.py`) [[1]](diffhunk://#diff-a725c777f5f5020730d97e1e27a293d5f5ae297f4e413691b4e02b674011bb96R318-R323) [[2]](diffhunk://#diff-a725c777f5f5020730d97e1e27a293d5f5ae297f4e413691b4e02b674011bb96R388-R395) [[3]](diffhunk://#diff-a725c777f5f5020730d97e1e27a293d5f5ae297f4e413691b4e02b674011bb96R430-R432) [[4]](diffhunk://#diff-a725c777f5f5020730d97e1e27a293d5f5ae297f4e413691b4e02b674011bb96R476-R478)
* Added logging and validation for unsafe `return_url` parameters in SSO flows, truncating logged values to prevent log flooding with attacker-controlled input. (`app/api/v1/endpoints/sso.py`) [[1]](diffhunk://#diff-a725c777f5f5020730d97e1e27a293d5f5ae297f4e413691b4e02b674011bb96R48-R51) [[2]](diffhunk://#diff-a725c777f5f5020730d97e1e27a293d5f5ae297f4e413691b4e02b674011bb96R289-R309)

**Documentation and Policy Clarification**

* Extensive inline documentation added to clarify the intent and security boundaries of each change, especially regarding SSO-only mode, user registration, and password management. (`app/api/v1/endpoints/auth.py`, `app/api/v1/endpoints/sso.py`, `app/core/config.py`) [[1]](diffhunk://#diff-58cbf6b3617b377d3a8851669ad55bc36905fa9a231e7c942e1d2470d2c5f091R503-R511) [[2]](diffhunk://#diff-a725c777f5f5020730d97e1e27a293d5f5ae297f4e413691b4e02b674011bb96L394-R450)

These changes collectively ensure that authentication flows behave as expected under all configurations, reduce the risk of accidental lockout, and provide clear operational visibility for administrators.

## Related issue

<!-- e.g. "Closes #123" or "N/A" -->

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Translation / i18n
- [ ] Other

## Testing

<!-- How did you verify this works? Manual steps, screenshots, or test names. -->

## Checklist

- [x] Tests added or updated (or N/A with reason)
- [x] `npm run lint` and `npm run build` pass
- [x] Backend tests pass (`pytest`) if backend code changed
- [x] No PHI, secrets, or `console.log` left in the diff
- [ ] User-facing strings go through `t()` translations
- [x] Documentation updated if API, schema, or service behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SSO-only authentication mode, blocking password registration and login when enabled.
  * Added strict validation for internal redirect URLs in SSO sign-in flows.
  * SSO status now reports configured authentication settings, including SSO-only mode and automatic redirect options.

* **Bug Fixes**
  * Improved responses for inactive SSO accounts and authentication errors.
  * Invalid authentication settings now prevent startup with clear diagnostics.
  * Unsafe redirect requests are rejected without exposing submitted URLs.

* **Documentation**
  * Updated deployment, configuration, and API guidance, including recovery procedures and password-change availability for authenticated SSO users.
  * Clarified that automatic SSO redirection is not yet active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->