### PR TITLE
fix: fixed external ID lookup for GitHub SSO users and update routing logic

### DIFF
--- a/app/crud/user.py
+++ b/app/crud/user.py
@@ -57,6 +57,44 @@ class CRUDUser(CRUDBase[User, UserCreate, UserUpdate]):
         )
         return users[0] if users else None
 
+    def get_by_external_id(
+        self, db: Session, *, external_id: str, sso_provider: str
+    ) -> Optional[User]:
+        """
+        Retrieve a user by the identifier their SSO provider issued for them.
+
+        Args:
+            db: SQLAlchemy database session
+            external_id: The provider's identifier for the user (user_info.sub)
+            sso_provider: The provider that issued it, e.g. "github"
+
+        Returns:
+            User object if a linked account exists, None otherwise
+
+        Example:
+            user = user_crud.get_by_external_id(
+                db, external_id="12345", sso_provider="github"
+            )
+        """
+        # Both columns are nullable, so a None here would match every unlinked
+        # account rather than none of them.
+        if not external_id or not sso_provider:
+            return None
+
+        # Scoped by provider even though external_id is unique - the value only
+        # means anything within the provider that issued it. Direct query rather
+        # than self.query(), which lowercases string filters (crud/base.py) while
+        # external_id is stored verbatim: GitHub's numeric ids hide that, a
+        # mixed-case OIDC sub would not.
+        return (
+            db.query(self.model)
+            .filter(
+                self.model.external_id == external_id,
+                self.model.sso_provider == sso_provider,
+            )
+            .first()
+        )
+
     def create(
         self, db: Session, *, obj_in: UserCreate, must_change_password: bool = False
     ) -> User:

--- a/app/services/sso_service.py
+++ b/app/services/sso_service.py
@@ -245,11 +245,20 @@ class SSOService:
             )
             raise SSOAuthenticationError("Failed to create or link user account")
 
-        # Log success (handle both regular and conflict responses)
+        # Log success (handle regular, conflict and manual-link responses)
         if result.get("conflict"):
             logger.info(
                 f"SSO authentication detected conflict for {user_info.email}",
                 extra={"category": "sso", "event": "auth_conflict"},
+            )
+        elif result.get("github_manual_link"):
+            # No account has been identified yet, so there is no authentication to
+            # report and no is_new_user to report it with - reading one here raised
+            # KeyError, which the endpoint's broad except turned into a 500. The
+            # prompt this response exists to render never reached the user.
+            logger.info(
+                "SSO authentication needs a manual GitHub account link",
+                extra={"category": "sso", "event": "github_manual_link_required"},
             )
         else:
             logger.info(

--- a/app/services/sso_service.py
+++ b/app/services/sso_service.py
@@ -392,7 +392,29 @@ class SSOService:
         )
 
         if is_github_no_email:
-            # For GitHub users without accessible email, show manual linking modal
+            # A previous manual link already recorded this GitHub identity, so
+            # there is nothing left to ask. Without this lookup the branch below
+            # fires on every login: the link writes external_id but nothing ever
+            # read it back, so a private-email GitHub user re-entered their local
+            # password each time - and under SSO_ONLY_MODE they have none to
+            # enter, which makes a working prompt a lockout.
+            linked_user = user_crud.get_by_external_id(
+                db,
+                external_id=user_info.sub,
+                sso_provider=settings.SSO_PROVIDER_TYPE,
+            )
+            if linked_user:
+                logger.info(
+                    f"SSO login for GitHub account linked by external_id: {linked_user.username}",
+                    extra={
+                        "category": "sso",
+                        "event": "github_external_id_login",
+                        "user_id": linked_user.id,
+                    },
+                )
+                return self._link_existing_user(linked_user, user_info, db)
+
+            # No account carries this identity yet - show the manual linking modal
             return self._return_github_manual_linking(user_info)
 
         # Check for existing user by email

--- a/app/services/sso_service.py
+++ b/app/services/sso_service.py
@@ -225,6 +225,11 @@ class SSOService:
 
         # Validate email domain if configured
         if not self._validate_email_domain(user_info.email):
+            if not user_info.email:
+                raise SSOAuthenticationError(
+                    "This provider account does not share an email address, and "
+                    "this instance only accepts specific email domains."
+                )
             raise SSOAuthenticationError(
                 f"Email domain not allowed: {user_info.email.split('@')[1]}"
             )
@@ -322,10 +327,18 @@ class SSOService:
 
         return str(exc)
 
-    def _validate_email_domain(self, email: str) -> bool:
+    def _validate_email_domain(self, email: Optional[str]) -> bool:
         """Check if email domain is allowed"""
         if not settings.SSO_ALLOWED_DOMAINS:
             return True  # No restrictions
+
+        # GitHub exposes no email for accounts with a private email setting, so
+        # there is no domain to check. Refuse rather than skip: skipping would let
+        # any GitHub user bypass the allowlist by making their email private,
+        # which is the control failing open. Reading .split() off None here also
+        # raised AttributeError outside any try, surfacing as a 500.
+        if not email:
+            return False
 
         domain = email.split("@")[1].lower()
         allowed_domains = [d.lower() for d in settings.SSO_ALLOWED_DOMAINS]

--- a/docs/SSO_SETUP_GUIDE.md
+++ b/docs/SSO_SETUP_GUIDE.md
@@ -111,7 +111,7 @@ SSO_REDIRECT_URI=http://localhost:8000/auth/sso/callback
 
 **GitHub-Specific Notes:**
 
-- **Private Emails**: If users have private email settings, they'll see a manual linking modal to connect with existing accounts
+- **Private Emails**: If users have private email settings, they'll see a manual linking modal to connect with existing accounts. This is asked **once per account** - after linking, later sign-ins are recognized by the stored GitHub account id
 - **Public Emails**: Users with public emails work like Google SSO with automatic email matching
 - **No Domain Restrictions**: GitHub doesn't enforce email domain restrictions like workplace providers
 
@@ -239,6 +239,11 @@ When GitHub users have private email settings:
 2. Shows GitHub manual linking modal
 3. User enters existing account credentials to link
 4. GitHub account gets permanently linked to local account
+5. Every later sign-in matches on the stored GitHub account id, so the credential prompt is not repeated
+
+> Earlier releases wrote the link but never read it back, so this prompt reappeared on every
+> login. That matters most with `SSO_ONLY_MODE=true`, where the user has no local password to
+> answer it with.
 
 **User Preferences:**
 

--- a/tests/api/test_sso_external_id_routing.py
+++ b/tests/api/test_sso_external_id_routing.py
@@ -1,0 +1,229 @@
+"""Tests for GitHub login routing by ``external_id`` (spec 8.13, criterion 16).
+
+Manual linking has always *written* the GitHub identity onto the account -
+``_link_existing_user`` sets ``external_id`` and ``sso_provider`` - but nothing
+ever read it back. ``_find_or_create_user`` routes on the *absence* of an email
+before any lookup runs, so a GitHub user whose email the provider does not expose
+completed the link once and was re-prompted for their local password on every
+login afterwards. Under ``SSO_ONLY_MODE`` they have no local password to answer
+with, which turns a working prompt into a lockout.
+
+Criterion 16 is "can complete manual account linking *and sign in*", so the shape
+that matters is: link once, then sign in twice. These tests drive the real service
+against real ``User`` rows - nothing here may patch the method under test, which is
+how the credential bug underneath this same flow (8.5) survived earlier coverage.
+"""
+
+from datetime import timedelta
+
+import pytest
+
+from app.auth.sso.base_provider import SSOUserInfo
+from app.core.config import settings
+from app.crud.user import user as user_crud
+from app.models.models import User
+from app.services.sso_service import SSOService, _state_storage
+from tests.api.conftest import LOCAL_PASSWORD
+from tests.utils.sso import store_github_link_token
+
+GITHUB_ID = "github-99881"
+TEMP_TOKEN = "github-routing-token"
+
+
+pytestmark = pytest.mark.usefixtures("clean_sso_state")
+
+
+@pytest.fixture
+def service():
+    return SSOService()
+
+
+@pytest.fixture
+def github_provider(monkeypatch):
+    """The GitHub-no-email branch only exists when GitHub is the configured provider."""
+    monkeypatch.setattr(settings, "SSO_PROVIDER_TYPE", "github")
+    return "github"
+
+
+@pytest.fixture
+def local_user(make_sso_user) -> User:
+    """An ordinary password account, not yet linked to any provider."""
+    return make_sso_user(
+        username="githubrouter", auth_method="local", link_sso_identity=False
+    )
+
+
+@pytest.fixture
+def linked_user(service, db_session, local_user, github_provider) -> User:
+    """``local_user`` after completing the real manual link - i.e. their first login."""
+    store_github_link_token(TEMP_TOKEN, sub=GITHUB_ID)
+    service.resolve_github_manual_link(
+        TEMP_TOKEN, local_user.username, LOCAL_PASSWORD, db_session
+    )
+    db_session.refresh(local_user)
+    return local_user
+
+
+def github_login(sub: str = GITHUB_ID) -> SSOUserInfo:
+    """What the provider hands us for an account with a private email."""
+    return SSOUserInfo(
+        sub=sub, email=None, username="githubrouter", name="GitHub Router"
+    )
+
+
+def link_identity(db_session, user: User, *, sso_provider: str, external_id=GITHUB_ID):
+    """Attach a provider identity directly, bypassing the manual-link flow."""
+    user.external_id = external_id
+    user.sso_provider = sso_provider
+    user.auth_method = "hybrid"
+    db_session.commit()
+    return user
+
+
+class TestSecondLoginAfterLinking:
+    """Criterion 16: link once, then sign in - twice."""
+
+    def test_linked_user_signs_in_without_the_manual_link_prompt(
+        self, service, db_session, linked_user
+    ):
+        result = service._find_or_create_user(github_login(), db_session)
+
+        assert "github_manual_link" not in result
+        assert result["user"].id == linked_user.id
+        assert result["is_new_user"] is False
+
+    def test_second_login_does_not_mint_a_new_link_token(
+        self, service, db_session, linked_user
+    ):
+        assert not _state_storage, "the resolved token should have been consumed"
+
+        service._find_or_create_user(github_login(), db_session)
+
+        # A manual-link prompt would have stored a fresh temp token here.
+        assert not _state_storage
+
+    def test_second_login_refreshes_last_sso_login_and_keeps_hybrid(
+        self, service, db_session, linked_user
+    ):
+        assert linked_user.auth_method == "hybrid"
+
+        backdated = linked_user.last_sso_login - timedelta(hours=1)
+        linked_user.last_sso_login = backdated
+        db_session.commit()
+
+        service._find_or_create_user(github_login(), db_session)
+        db_session.refresh(linked_user)
+
+        assert linked_user.last_sso_login > backdated
+        assert linked_user.auth_method == "hybrid"
+
+
+class TestUnlinkedUsersStillGetThePrompt:
+    def test_unknown_github_identity_reaches_the_manual_link_prompt(
+        self, service, db_session, local_user, github_provider
+    ):
+        result = service._find_or_create_user(github_login(), db_session)
+
+        assert result["github_manual_link"] is True
+        assert result["github_user_info"]["github_id"] == GITHUB_ID
+
+    def test_a_different_github_account_is_not_matched_to_the_linked_one(
+        self, service, db_session, linked_user
+    ):
+        result = service._find_or_create_user(
+            github_login(sub="github-other"), db_session
+        )
+
+        assert result["github_manual_link"] is True
+
+    def test_same_external_id_under_another_provider_does_not_match(
+        self, service, db_session, local_user, github_provider
+    ):
+        # A row left behind by a previous SSO_PROVIDER_TYPE, carrying an id that
+        # happens to collide with the GitHub one.
+        link_identity(db_session, local_user, sso_provider="google")
+
+        result = service._find_or_create_user(github_login(), db_session)
+
+        assert result["github_manual_link"] is True
+
+
+class TestUnrelatedPathsAreUnaffected:
+    def test_github_user_with_an_email_still_routes_by_email(
+        self, service, db_session, local_user, github_provider
+    ):
+        link_identity(db_session, local_user, sso_provider="github")
+
+        result = service._find_or_create_user(
+            SSOUserInfo(
+                sub=GITHUB_ID,
+                email=local_user.email,
+                username="githubrouter",
+                name="GitHub Router",
+            ),
+            db_session,
+        )
+
+        assert "github_manual_link" not in result
+        assert result["user"].id == local_user.id
+
+    def test_non_github_provider_never_enters_the_branch(
+        self, service, db_session, local_user, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "SSO_PROVIDER_TYPE", "oidc")
+        link_identity(db_session, local_user, sso_provider="oidc")
+
+        result = service._find_or_create_user(
+            SSOUserInfo(sub=GITHUB_ID, email=local_user.email, name="GitHub Router"),
+            db_session,
+        )
+
+        assert "github_manual_link" not in result
+        assert result["user"].id == local_user.id
+
+
+class TestGetByExternalId:
+    """The lookup itself - the half that did not exist at all before."""
+
+    def test_finds_a_linked_account(self, db_session, local_user):
+        link_identity(db_session, local_user, sso_provider="github")
+
+        found = user_crud.get_by_external_id(
+            db_session, external_id=GITHUB_ID, sso_provider="github"
+        )
+        assert found is not None and found.id == local_user.id
+
+    def test_provider_must_match(self, db_session, local_user):
+        link_identity(db_session, local_user, sso_provider="github")
+
+        assert (
+            user_crud.get_by_external_id(
+                db_session, external_id=GITHUB_ID, sso_provider="google"
+            )
+            is None
+        )
+
+    def test_case_is_preserved(self, db_session, local_user):
+        """query() lowercases string filters; a mixed-case sub must still match."""
+        mixed = "Abc-DEF-123"
+        link_identity(db_session, local_user, sso_provider="oidc", external_id=mixed)
+
+        found = user_crud.get_by_external_id(
+            db_session, external_id=mixed, sso_provider="oidc"
+        )
+        assert found is not None and found.id == local_user.id
+
+    @pytest.mark.parametrize(
+        "external_id,sso_provider",
+        [(None, "github"), ("", "github"), (GITHUB_ID, None), (GITHUB_ID, "")],
+    )
+    def test_missing_halves_match_nothing(
+        self, db_session, local_user, external_id, sso_provider
+    ):
+        """Both columns are nullable - a None filter must not match every unlinked row."""
+        assert (
+            user_crud.get_by_external_id(
+                db_session, external_id=external_id, sso_provider=sso_provider
+            )
+            is None
+        )

--- a/tests/api/test_sso_external_id_routing.py
+++ b/tests/api/test_sso_external_id_routing.py
@@ -22,7 +22,7 @@ from app.auth.sso.base_provider import SSOUserInfo
 from app.core.config import settings
 from app.crud.user import user as user_crud
 from app.models.models import User
-from app.services.sso_service import SSOService, _state_storage
+from app.services.sso_service import SSOService, _state_storage, _store_state_entry
 from tests.api.conftest import LOCAL_PASSWORD
 from tests.utils.sso import store_github_link_token
 
@@ -227,3 +227,91 @@ class TestGetByExternalId:
             )
             is None
         )
+
+
+class TestThroughCompleteAuthentication:
+    """The callback path, not just the routing helper underneath it.
+
+    Every other test here (and in ``test_sso_github_manual_link.py``) calls
+    ``_find_or_create_user`` or ``resolve_github_manual_link`` directly. That
+    leaves the caller unexercised, and the caller had a defect: its success log
+    read ``result["is_new_user"]``, a key the manual-link response does not carry,
+    so an unknown private-email GitHub user raised KeyError inside the endpoint's
+    broad ``except`` and got a 500 instead of the prompt. Linking could never
+    begin, which makes the second-login fix above unreachable for a new user.
+
+    The provider is stubbed because it does network I/O; the method under test is
+    not.
+    """
+
+    STATE = "state-token-routing"
+
+    @pytest.fixture
+    def stub_provider(self, monkeypatch):
+        """Stand in for the GitHub provider's two network calls."""
+
+        def install(user_info: SSOUserInfo):
+            class StubProvider:
+                async def exchange_code_for_token(self, code):
+                    return {"access_token": "stub-access-token"}
+
+                async def get_user_info(self, access_token):
+                    return user_info
+
+            monkeypatch.setattr(
+                "app.services.sso_service.create_sso_provider", lambda: StubProvider()
+            )
+
+        return install
+
+    @pytest.fixture
+    def valid_state(self):
+        _store_state_entry(self.STATE, {"return_url": "/patients/42"})
+        return self.STATE
+
+    @pytest.mark.asyncio
+    async def test_unknown_private_email_user_gets_the_prompt_not_a_keyerror(
+        self,
+        service,
+        db_session,
+        local_user,
+        github_provider,
+        stub_provider,
+        valid_state,
+    ):
+        stub_provider(github_login())
+
+        result = await service.complete_authentication("code", valid_state, db_session)
+
+        assert result["github_manual_link"] is True
+        assert result["github_user_info"]["github_id"] == GITHUB_ID
+        assert "is_new_user" not in result
+
+    @pytest.mark.asyncio
+    async def test_the_prompt_response_still_carries_the_return_url(
+        self,
+        service,
+        db_session,
+        local_user,
+        github_provider,
+        stub_provider,
+        valid_state,
+    ):
+        stub_provider(github_login())
+
+        result = await service.complete_authentication("code", valid_state, db_session)
+
+        assert result["return_url"] == "/patients/42"
+
+    @pytest.mark.asyncio
+    async def test_a_linked_user_completes_authentication_normally(
+        self, service, db_session, linked_user, stub_provider, valid_state
+    ):
+        stub_provider(github_login())
+
+        result = await service.complete_authentication("code", valid_state, db_session)
+
+        assert "github_manual_link" not in result
+        assert result["is_new_user"] is False
+        assert result["user"].id == linked_user.id
+        assert result["return_url"] == "/patients/42"

--- a/tests/api/test_sso_external_id_routing.py
+++ b/tests/api/test_sso_external_id_routing.py
@@ -19,6 +19,7 @@ from datetime import timedelta
 import pytest
 
 from app.auth.sso.base_provider import SSOUserInfo
+from app.auth.sso.exceptions import SSOAuthenticationError
 from app.core.config import settings
 from app.crud.user import user as user_crud
 from app.models.models import User
@@ -69,6 +70,29 @@ def github_login(sub: str = GITHUB_ID) -> SSOUserInfo:
     return SSOUserInfo(
         sub=sub, email=None, username="githubrouter", name="GitHub Router"
     )
+
+
+@pytest.fixture
+def stub_sso_provider(monkeypatch):
+    """Stand in for the provider's two network calls.
+
+    The collaborator is stubbed because it does real HTTP; the method under test
+    never is - that is how the credential defect in this flow (8.5) survived.
+    """
+
+    def install(user_info: SSOUserInfo):
+        class StubProvider:
+            async def exchange_code_for_token(self, code):
+                return {"access_token": "stub-access-token"}
+
+            async def get_user_info(self, access_token):
+                return user_info
+
+        monkeypatch.setattr(
+            "app.services.sso_service.create_sso_provider", lambda: StubProvider()
+        )
+
+    return install
 
 
 def link_identity(db_session, user: User, *, sso_provider: str, external_id=GITHUB_ID):
@@ -247,24 +271,6 @@ class TestThroughCompleteAuthentication:
     STATE = "state-token-routing"
 
     @pytest.fixture
-    def stub_provider(self, monkeypatch):
-        """Stand in for the GitHub provider's two network calls."""
-
-        def install(user_info: SSOUserInfo):
-            class StubProvider:
-                async def exchange_code_for_token(self, code):
-                    return {"access_token": "stub-access-token"}
-
-                async def get_user_info(self, access_token):
-                    return user_info
-
-            monkeypatch.setattr(
-                "app.services.sso_service.create_sso_provider", lambda: StubProvider()
-            )
-
-        return install
-
-    @pytest.fixture
     def valid_state(self):
         _store_state_entry(self.STATE, {"return_url": "/patients/42"})
         return self.STATE
@@ -276,10 +282,10 @@ class TestThroughCompleteAuthentication:
         db_session,
         local_user,
         github_provider,
-        stub_provider,
+        stub_sso_provider,
         valid_state,
     ):
-        stub_provider(github_login())
+        stub_sso_provider(github_login())
 
         result = await service.complete_authentication("code", valid_state, db_session)
 
@@ -294,10 +300,10 @@ class TestThroughCompleteAuthentication:
         db_session,
         local_user,
         github_provider,
-        stub_provider,
+        stub_sso_provider,
         valid_state,
     ):
-        stub_provider(github_login())
+        stub_sso_provider(github_login())
 
         result = await service.complete_authentication("code", valid_state, db_session)
 
@@ -305,9 +311,9 @@ class TestThroughCompleteAuthentication:
 
     @pytest.mark.asyncio
     async def test_a_linked_user_completes_authentication_normally(
-        self, service, db_session, linked_user, stub_provider, valid_state
+        self, service, db_session, linked_user, stub_sso_provider, valid_state
     ):
-        stub_provider(github_login())
+        stub_sso_provider(github_login())
 
         result = await service.complete_authentication("code", valid_state, db_session)
 
@@ -315,3 +321,79 @@ class TestThroughCompleteAuthentication:
         assert result["is_new_user"] is False
         assert result["user"].id == linked_user.id
         assert result["return_url"] == "/patients/42"
+
+
+class TestAllowedDomainsWithNoEmail:
+    """``SSO_ALLOWED_DOMAINS`` against a provider that exposes no email.
+
+    ``_validate_email_domain`` read ``email.split()`` off ``None``, raising
+    AttributeError outside any ``try`` in ``complete_authentication`` - a 500
+    before ``_find_or_create_user`` ran at all, so neither the manual-link prompt
+    nor the linked-user lookup was reachable on a domain-restricted instance.
+
+    The policy is now explicit: no verifiable domain means refused. Skipping the
+    check instead would let any GitHub user bypass the allowlist by making their
+    email private.
+    """
+
+    STATE = "state-token-domains"
+
+    @pytest.fixture
+    def restricted_domains(self, monkeypatch):
+        monkeypatch.setattr(settings, "SSO_ALLOWED_DOMAINS", ["example.com"])
+
+    @pytest.fixture
+    def valid_state(self):
+        _store_state_entry(self.STATE, {"return_url": None})
+        return self.STATE
+
+    @pytest.mark.asyncio
+    async def test_unlinked_user_is_refused_not_crashed(
+        self,
+        service,
+        db_session,
+        local_user,
+        github_provider,
+        stub_sso_provider,
+        valid_state,
+        restricted_domains,
+    ):
+        stub_sso_provider(github_login())
+
+        with pytest.raises(SSOAuthenticationError) as exc:
+            await service.complete_authentication("code", valid_state, db_session)
+
+        assert "email" in str(exc.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_linked_user_is_refused_too(
+        self,
+        service,
+        db_session,
+        linked_user,
+        stub_sso_provider,
+        valid_state,
+        restricted_domains,
+    ):
+        """Deliberate: an allowlist the account cannot satisfy is not waived by
+        having linked earlier. Flagged as a policy call - see the PR notes."""
+        stub_sso_provider(github_login())
+
+        with pytest.raises(SSOAuthenticationError):
+            await service.complete_authentication("code", valid_state, db_session)
+
+    @pytest.mark.asyncio
+    async def test_without_an_allowlist_the_flow_is_untouched(
+        self,
+        service,
+        db_session,
+        linked_user,
+        stub_sso_provider,
+        valid_state,
+    ):
+        """The default configuration - no allowlist - must be unaffected."""
+        stub_sso_provider(github_login())
+
+        result = await service.complete_authentication("code", valid_state, db_session)
+
+        assert result["user"].id == linked_user.id

--- a/tests/api/test_sso_github_manual_link.py
+++ b/tests/api/test_sso_github_manual_link.py
@@ -23,6 +23,7 @@ from app.crud.user import user as user_crud
 from app.models.models import User
 from app.schemas.user import UserCreate
 from app.services.sso_service import _STATE_TTL, SSOService, _state_storage
+from tests.utils.sso import store_github_link_token
 
 PASSWORD = "linkpassword123"
 TEMP_TOKEN = "github-temp-token"
@@ -51,18 +52,7 @@ def local_user(db_session) -> User:
 
 
 def store_link_token(token: str = TEMP_TOKEN, *, age: timedelta = timedelta(0)) -> str:
-    created_at = datetime.utcnow() - age
-    key = f"github_manual_link_{token}"
-    _state_storage[key] = {
-        "created_at": created_at,
-        "sso_user_info": {
-            "sub": "github-12345",
-            "email": None,
-            "name": "GitHub Linker",
-        },
-        "expires_at": created_at + _STATE_TTL,
-    }
-    return key
+    return store_github_link_token(token, sub="github-12345", age=age)
 
 
 class TestSuccessfulLink:

--- a/tests/utils/sso.py
+++ b/tests/utils/sso.py
@@ -1,0 +1,30 @@
+"""Shared helpers for SSO tests."""
+
+from datetime import datetime, timedelta
+
+from app.services.sso_service import _STATE_TTL, _state_storage
+
+
+def store_github_link_token(
+    token: str,
+    *,
+    sub: str,
+    name: str = "GitHub Linker",
+    age: timedelta = timedelta(0),
+) -> str:
+    """Seed the state store with a pending GitHub manual-link token.
+
+    Writes the entry ``_return_github_manual_linking`` would have written, so a
+    test can drive ``resolve_github_manual_link`` without standing up the whole
+    callback. Pass ``age`` to backdate it past ``_STATE_TTL`` and exercise expiry.
+
+    Returns the state-store key, for tests asserting on consumption.
+    """
+    created_at = datetime.utcnow() - age
+    key = f"github_manual_link_{token}"
+    _state_storage[key] = {
+        "created_at": created_at,
+        "sso_user_info": {"sub": sub, "email": None, "name": name},
+        "expires_at": created_at + _STATE_TTL,
+    }
+    return key


### PR DESCRIPTION
## Summary

This pull request addresses a longstanding issue with GitHub SSO login for users with private emails. Previously, users who manually linked their GitHub account would be prompted to re-link on every login, which could result in a lockout if SSO-only mode was enabled. The changes ensure that, after the initial manual link, subsequent logins correctly recognize the linked GitHub account using the stored `external_id` and `sso_provider`. The update also includes comprehensive tests to verify correct routing and prevent regressions.

**SSO login improvements:**
* Added a new method `get_by_external_id` to `user_crud` in `app/crud/user.py` to retrieve users by their SSO provider-issued identifier, ensuring that linked accounts are recognized on subsequent logins.
* Updated `SSOService._find_or_create_user` to check for an existing linked GitHub account using `external_id` before prompting for manual linking, preventing repeated prompts and potential lockouts.

**Documentation updates:**
* Clarified in `docs/SSO_SETUP_GUIDE.md` that the manual linking modal for GitHub private email users is only shown once per account, and subsequent logins are recognized by the stored GitHub account ID. Also explained the previous behavior and its impact in SSO-only mode. [[1]](diffhunk://#diff-e587822c2193de0efb5b8082075c074007e221f7e2da15c33c38860c4e911349L114-R114) [[2]](diffhunk://#diff-e587822c2193de0efb5b8082075c074007e221f7e2da15c33c38860c4e911349R242-R246)

**Testing and utilities:**
* Added a new test suite `tests/api/test_sso_external_id_routing.py` that verifies manual linking works as intended, ensures subsequent logins are routed correctly, and covers edge cases such as provider mismatches and case sensitivity.
* Refactored test helpers by introducing `store_github_link_token` in `tests/utils/sso.py` and updating existing tests to use this shared utility for seeding manual-link tokens. [[1]](diffhunk://#diff-748f5fb394e149e5e243202503205d6cf971f7280f8da79ac96afda6ec3b68bfR1-R30) [[2]](diffhunk://#diff-2560d52878f0229f2b70adbc6ac6153cd3225a1edc8c9232a1bdd7d4d618dd25R26) [[3]](diffhunk://#diff-2560d52878f0229f2b70adbc6ac6153cd3225a1edc8c9232a1bdd7d4d618dd25L54-R55)

## Related issue


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Translation / i18n
- [ ] Other

## Checklist

- [x] Tests added or updated (or N/A with reason)
- [ ] `npm run lint` and `npm run build` pass
- [ ] Backend tests pass (`pytest`) if backend code changed
- [ ] No PHI, secrets, or `console.log` left in the diff
- [ ] User-facing strings go through `t()` translations
- [ ] Documentation updated if API, schema, or service behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - GitHub accounts with private email addresses can sign in again using their previously linked account without repeating credential prompts.
  - Account matching now verifies both the identity provider and external account ID.
  - Unlinked private-email GitHub accounts receive the appropriate manual-linking prompt.

- **Bug Fixes**
  - Missing email addresses under domain restrictions now produce a clear authentication error instead of an application error.
  - Improved handling of GitHub manual-link authentication responses.

- **Documentation**
  - Updated SSO guidance for repeat sign-ins and SSO-only mode behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->