### PR TITLE
fix: wire SSO settings into deployment files, correct break-glass docs

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -134,10 +134,14 @@ def _strict_bool(name: str, default: bool = False) -> bool:
     survived its transport. Docker Compose strips unquoted ` #` comments from env
     files and trims whitespace - measured on Compose v5, both the project `.env`
     and a service `env_file:` - so a plain `SSO_ONLY_MODE=true # sso only` arrives
-    as `true`. It survives when quoted (`"true # sso only"`), when there is no
-    space before the hash (`true# sso only`), or when it comes from a vehicle that
-    does no such parsing: `docker run -e`, an Unraid template field, or a literal
-    in the compose `environment:` block.
+    as `true`. The strip happens after a quoted value too, so
+    `SSO_ONLY_MODE="true" # sso only` also arrives as `true` - measured on the
+    python-dotenv parser this module loads for the host path, not re-measured on
+    Compose. It survives when the hash is inside the quotes
+    (`"true # sso only"`), when there is no space before the hash (`true# sso only`),
+    or when it comes from a vehicle that does no such parsing: an Unraid template
+    field, a literal in the compose `environment:` block, or a `docker run -e`
+    argument quoted to keep the hash (unquoted at a shell, the shell strips it).
 
     Deliberately not applied to the other booleans in this file. Changing what
     `DEBUG=1` means is unrelated behavior with its own blast radius; this is scoped

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -124,12 +124,20 @@ def _strict_bool(name: str, default: bool = False) -> bool:
     The `.lower() == "true"` idiom used elsewhere in this file silently reads every
     other value as False. For a flag that only relaxes behavior that is merely
     annoying; for a flag that *is* a security control it is a failure to fail
-    closed. `SSO_ONLY_MODE=1`, a trailing space, or `SSO_ONLY_MODE=true # sso only`
-    in a compose env file (Compose does not strip inline comments) would each leave
-    password login accepting credentials while the operator believed it was off,
-    with nothing logged to say so - and the pairing check in
-    validate_auth_mode_config() cannot catch it either, because that only fires
-    when the flag parses True.
+    closed. A value this cannot read would otherwise leave password login accepting
+    credentials while the operator believed it was off, with nothing logged to say
+    so - and the pairing check in validate_auth_mode_config() cannot catch it
+    either, because that only fires when the flag parses True.
+
+    `1`, `yes`, `on` and a trailing space are all accepted, so the values that
+    actually reach here unreadable are a typo (`fasle`) or a stray `#` note that
+    survived its transport. Docker Compose strips unquoted ` #` comments from env
+    files and trims whitespace - measured on Compose v5, both the project `.env`
+    and a service `env_file:` - so a plain `SSO_ONLY_MODE=true # sso only` arrives
+    as `true`. It survives when quoted (`"true # sso only"`), when there is no
+    space before the hash (`true# sso only`), or when it comes from a vehicle that
+    does no such parsing: `docker run -e`, an Unraid template field, or a literal
+    in the compose `environment:` block.
 
     Deliberately not applied to the other booleans in this file. Changing what
     `DEBUG=1` means is unrelated behavior with its own blast radius; this is scoped
@@ -528,9 +536,11 @@ class Settings:  # App Info
                 for name, raw in sorted(self.AUTH_FLAG_PARSE_ERRORS.items())
             )
             raise ValueError(
-                f"Unrecognized boolean value for {details}. Use true or false. "
-                "Note that a compose env file does not strip inline comments, so "
-                "'true # my note' is read as the whole string, not as true. "
+                f"Unrecognized boolean value for {details}. Accepted: "
+                "true/false, 1/0, yes/no, on/off, in any case. If the value above "
+                "carries a trailing '# note', quoting it or omitting the space "
+                "before the hash is what preserved it - and 'docker run -e' and "
+                "Unraid template fields never strip one. "
                 "Refusing to start rather than guess: guessing wrong here leaves "
                 "password login open on an instance meant to be SSO-only."
             )

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -61,9 +61,10 @@ SSO_ALLOWED_DOMAINS=[]
 #
 # Accepted values are true/false (also 1/0, yes/no, on/off), and these two are
 # checked strictly: anything else fails the boot with an error naming the
-# variable, rather than being read as false. Note that a compose env file does
-# NOT strip inline comments, so `SSO_ONLY_MODE=true # my note` is the whole
-# string - put comments on their own line.
+# variable, rather than being read as false. Compose does strip an unquoted
+# ' #' comment here, so `SSO_ONLY_MODE=true # my note` works - but it does not
+# when quoted, when no space precedes the hash, or when the value comes from
+# `docker run -e` or an Unraid field. Put comments on their own line.
 #
 # To recover if the identity provider is unreachable: set SSO_ONLY_MODE=false,
 # restart, and sign in locally. There is deliberately no in-app toggle for these.
@@ -79,7 +80,8 @@ SSO_ALLOWED_DOMAINS=[]
 # no way in at all until the window rolls off, since there is no password login
 # to fall back on.
 #
-# Raise further if legitimate users report being turned away.
+# Raise further if anyone is turned away in ordinary use - on a self-hosted
+# instance that person may well be you, with no second account to check from.
 #SSO_RATE_LIMIT_ATTEMPTS=30
 #SSO_RATE_LIMIT_WINDOW_MINUTES=10
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -39,6 +39,10 @@ SSO_CLIENT_ID=your-github-client-id
 SSO_CLIENT_SECRET=your-github-client-secret
 SSO_REDIRECT_URI=http://localhost:8005/auth/sso/callback
 SSO_ALLOWED_DOMAINS=[]
+# Required for every OIDC-family provider type - oidc, keycloak, authentik,
+# authelia - and unused by github and google. The container will not start
+# without it on those types, so it is left commented rather than blank.
+#SSO_ISSUER_URL=https://idp.example.com/realms/your-realm
 
 # SSO-only mode and IdP auto-redirect. Both default to false; both require
 # SSO_ENABLED=true. The container refuses to start if either is set without it,

--- a/docker/README_SSO.md
+++ b/docker/README_SSO.md
@@ -125,26 +125,19 @@ it** — that is deliberate. Booting into an instance that refuses password logi
 has no working SSO means nobody can sign in, and the error is much harder to
 diagnose after the fact than at startup.
 
-> **This release ships the server-side half only.** Nothing in the web UI reads
-> these two settings yet. Under `SSO_ONLY_MODE` the login page still draws the
-> password form and every submission is refused with 403, and `SSO_AUTO_REDIRECT`
-> does nothing at all — no visitor is redirected anywhere. The table below is the
-> configuration contract; the rows marked *(UI half pending)* describe behavior that
-> arrives with the frontend half of this feature in a following release.
-
 | `SSO_ENABLED` | `SSO_ONLY_MODE` | `SSO_AUTO_REDIRECT` | Result |
 |---|---|---|---|
 | `false` | `false` | `false` | Current behavior, unchanged |
 | `false` | either flag set | either flag set | **Startup failure** with an explicit error |
 | `true` | `false` | `false` | Standard SSO — login form plus an SSO button |
 | `true` | `true` | `false` | `/auth/login` and `/auth/register` return 403; sign in with SSO |
-| `true` | `false` | `true` | Password login still works; visitors are sent to the IdP, and `/login?local=1` reaches the login page directly *(UI half pending)* |
-| `true` | `true` | `true` | Pure SSO front door *(UI half pending)* |
+| `true` | `false` | `true` | Password login still works; visitors are sent to the IdP, and `/login?local=1` reaches the login page directly |
+| `true` | `true` | `true` | Pure SSO front door — no password form, no button to click |
 
 `SSO_ONLY_MODE` is enforced server-side: `POST /auth/login` and `POST /auth/register`
 return 403 before any credential check, and each refusal is recorded in the security
-log. That enforcement is the security boundary and it is already complete — hiding
-the form is only cosmetic, since anyone can POST to the API directly.
+log. That enforcement is the security boundary — hiding the form is only cosmetic,
+since anyone can POST to the API directly.
 
 Still available under `SSO_ONLY_MODE`, by design:
 
@@ -160,24 +153,33 @@ Still available under `SSO_ONLY_MODE`, by design:
 There is deliberately no in-app toggle for these settings, precisely so a broken IdP
 cannot make itself unfixable:
 
-1. **Set `SSO_ONLY_MODE=false` and restart, then sign in locally.** This is the
+1. **Set `SSO_ONLY_MODE=false`, recreate the container, then sign in locally.** The
    primary path, and the only one that restores access when the IdP is unreachable.
-2. **If SSO still works but no account has admin rights**, run
-   `app/scripts/create_emergency_admin.py --username <name> --promote` against an
-   account that can sign in through your IdP. Promotion writes directly to the
-   database and preserves the existing password, so the user signs in via SSO as
-   usual and is now an admin.
+   `docker compose up -d` — a plain `docker restart` reuses the old environment. If
+   `SSO_AUTO_REDIRECT` is also on, clear it too or use `/login?local=1`, otherwise you
+   are bounced to the provider that is down before you see the password form.
 
-   Note what this does **not** do: creating a *new* password admin with this script
-   does not get you in while `SSO_ONLY_MODE=true`, because password login is refused
-   for every account, including that one. Pair it with step 1.
+   This assumes some account **has** a local password. Accounts created through the
+   IdP (`auth_method='sso'`) have none; see step 2.
+2. **Run `create_emergency_admin.py` inside the container**, e.g.
+   `docker compose exec -it medikeep-app python app/scripts/create_emergency_admin.py …`
+   - No admin rights but SSO works: `--username <existing> --promote`. Preserves the
+     existing password and grants admin.
+   - No account has a password at all: `--username <new> --force`. `--force` is needed
+     because admin accounts do exist, they just cannot answer a password prompt.
+   - **Omit `--password`** — the script prompts twice, hidden, keeping it out of shell
+     history.
+
+   Creating a password admin does not get you in while `SSO_ONLY_MODE=true`, because
+   password login is refused for every account including that one. Pair it with step 1.
 3. Startup validation refuses the most likely misconfiguration before it takes
    effect, so a typo in these variables surfaces as a logged startup failure rather
    than a login page nobody can get past. That includes a value it cannot parse:
    `SSO_ONLY_MODE` and `SSO_AUTO_REDIRECT` accept `true`/`false` (also `1`/`0`,
    `yes`/`no`, `on`/`off`, any case), and anything else fails the boot instead of
-   being read as `false`. Watch for inline comments — a compose env file does not
-   strip them, so `SSO_ONLY_MODE=true # sso only` is the whole string.
+   being read as `false`. Compose strips an unquoted ` #` comment from this file, so
+   `SSO_ONLY_MODE=true # sso only` works here — but not when quoted, when no space
+   precedes the hash, or via `docker run -e` or an Unraid field.
 
 If registration is also disabled (`ALLOW_USER_REGISTRATION=false`, or the admin
 setting), no new user can enter by any self-service route. That is a legitimate

--- a/docker/README_SSO.md
+++ b/docker/README_SSO.md
@@ -52,6 +52,11 @@ environment:
   # SSO_ENABLED=true; the container refuses to start otherwise.
   SSO_ONLY_MODE: ${SSO_ONLY_MODE:-false}
   SSO_AUTO_REDIRECT: ${SSO_AUTO_REDIRECT:-false}
+
+  # Optional - per-IP throttle on sign-in attempts. Worth raising with
+  # SSO_AUTO_REDIRECT on, where every unauthenticated page load is one attempt.
+  SSO_RATE_LIMIT_ATTEMPTS: ${SSO_RATE_LIMIT_ATTEMPTS:-30}
+  SSO_RATE_LIMIT_WINDOW_MINUTES: ${SSO_RATE_LIMIT_WINDOW_MINUTES:-10}
 ```
 
 ### 3. Restart the containers
@@ -104,6 +109,8 @@ SSO_ISSUER_URL=https://homelab.local/auth/realms/family
 | `SSO_ALLOWED_DOMAINS` | No | `[]` | JSON array of allowed email domains |
 | `SSO_ONLY_MODE` | No | `false` | Refuse password login and password registration |
 | `SSO_AUTO_REDIRECT` | No | `false` | Send unauthenticated visitors straight to the IdP |
+| `SSO_RATE_LIMIT_ATTEMPTS` | No | `30` | Sign-in attempts allowed per IP per window |
+| `SSO_RATE_LIMIT_WINDOW_MINUTES` | No | `10` | Length of the rate limit window |
 
 ## SSO-Only Mode and Auto-Redirect
 

--- a/docker/README_SSO.md
+++ b/docker/README_SSO.md
@@ -178,9 +178,13 @@ cannot make itself unfixable:
    `SSO_ONLY_MODE` and `SSO_AUTO_REDIRECT` accept `true`/`false` (also `1`/`0`,
    `yes`/`no`, `on`/`off`, any case), and anything else fails the boot instead of
    being read as `false`. Compose strips a `#` comment from this file when the hash is
-   unquoted and preceded by a space, so `SSO_ONLY_MODE=true # sso only` works here — but
-   not when quoted, when no space precedes the hash, or via `docker run -e` or an Unraid
-   field.
+   unquoted and preceded by a space — including after a quoted value, so both
+   `SSO_ONLY_MODE=true # sso only` and `SSO_ONLY_MODE="true" # sso only` work here. What
+   survives into the value is a hash *inside* the quotes (`"true # sso only"`), a hash
+   with no space before it (`true# sso only`), or a value from something that does no
+   such parsing: an Unraid template field, a compose `environment:` literal, or a
+   `docker run -e` argument quoted to keep the hash (typed unquoted at a shell, the
+   shell removes the comment before Docker sees it).
 
 If registration is also disabled (`ALLOW_USER_REGISTRATION=false`, or the admin
 setting), no new user can enter by any self-service route. That is a legitimate

--- a/docker/README_SSO.md
+++ b/docker/README_SSO.md
@@ -177,9 +177,10 @@ cannot make itself unfixable:
    than a login page nobody can get past. That includes a value it cannot parse:
    `SSO_ONLY_MODE` and `SSO_AUTO_REDIRECT` accept `true`/`false` (also `1`/`0`,
    `yes`/`no`, `on`/`off`, any case), and anything else fails the boot instead of
-   being read as `false`. Compose strips an unquoted ` #` comment from this file, so
-   `SSO_ONLY_MODE=true # sso only` works here — but not when quoted, when no space
-   precedes the hash, or via `docker run -e` or an Unraid field.
+   being read as `false`. Compose strips a `#` comment from this file when the hash is
+   unquoted and preceded by a space, so `SSO_ONLY_MODE=true # sso only` works here — but
+   not when quoted, when no space precedes the hash, or via `docker run -e` or an Unraid
+   field.
 
 If registration is also disabled (`ALLOW_USER_REGISTRATION=false`, or the admin
 setting), no new user can enter by any self-service route. That is a legitimate

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -66,6 +66,13 @@ services:
       # start otherwise, rather than booting with no usable way to sign in.
       SSO_ONLY_MODE: ${SSO_ONLY_MODE:-false}
       SSO_AUTO_REDIRECT: ${SSO_AUTO_REDIRECT:-false}
+      # Per-IP throttle on POST /auth/sso/initiate. Worth raising with
+      # SSO_AUTO_REDIRECT on, where every unauthenticated page load is one
+      # attempt. The defaults repeat config.py's because an empty value is not
+      # the same as an unset one here - the app parses these as integers, so
+      # `${VAR:-}` would fail the boot rather than fall back.
+      SSO_RATE_LIMIT_ATTEMPTS: ${SSO_RATE_LIMIT_ATTEMPTS:-30}
+      SSO_RATE_LIMIT_WINDOW_MINUTES: ${SSO_RATE_LIMIT_WINDOW_MINUTES:-10}
 
       # Default Admin Password Configuration (optional - defaults to admin123 in app if not set)
       #ADMIN_DEFAULT_PASSWORD: ${ADMIN_DEFAULT_PASSWORD:-}

--- a/docker/unraid-template.xml
+++ b/docker/unraid-template.xml
@@ -85,11 +85,17 @@
     Description="SSO Client Secret (if SSO enabled)" Type="Variable" Display="advanced"
     Required="false" Mask="true" />
   <Config Name="SSO Only Mode" Target="SSO_ONLY_MODE" Default="false" Mode=""
-    Description="Refuse password login and registration (403); sign in with SSO only. Requires SSO Enabled - the container will not start without it. Set back to false to recover if the identity provider is unreachable. Note: the login page still shows the password form in this release; the server refuses it."
+    Description="Refuse password login and registration (403); sign in with SSO only. Requires SSO Enabled - the container will not start without it. Set back to false to recover if the identity provider is unreachable. Accepted values are true/false, 1/0, yes/no, on/off - anything else stops the container with an error naming this variable, rather than leaving password login open."
     Type="Variable" Display="advanced" Required="false" Mask="false">false</Config>
   <Config Name="SSO Auto Redirect" Target="SSO_AUTO_REDIRECT" Default="false" Mode=""
-    Description="Send unauthenticated visitors straight to the identity provider, with /login?local=1 to reach the login page directly. Requires SSO Enabled - the container will not start without it. Note: not yet active in this release; it takes effect with the web UI half of this feature."
+    Description="Send unauthenticated visitors straight to the identity provider, with /login?local=1 to reach the login page directly. Requires SSO Enabled - the container will not start without it. Same accepted values as SSO Only Mode."
     Type="Variable" Display="advanced" Required="false" Mask="false">false</Config>
+  <Config Name="SSO Rate Limit Attempts" Target="SSO_RATE_LIMIT_ATTEMPTS" Default="30" Mode=""
+    Description="Sign-in attempts allowed per IP address per window. Worth raising with SSO Auto Redirect on, where every unauthenticated page load counts as one attempt."
+    Type="Variable" Display="advanced" Required="false" Mask="false">30</Config>
+  <Config Name="SSO Rate Limit Window Minutes" Target="SSO_RATE_LIMIT_WINDOW_MINUTES" Default="10"
+    Mode="" Description="Length of the rate limit window in minutes." Type="Variable"
+    Display="advanced" Required="false" Mask="false">10</Config>
   <Config Name="PUID" Target="PUID" Default="99" Mode="" Description="User ID" Type="Variable"
     Display="advanced" Required="false" Mask="false">99</Config>
   <Config Name="PGID" Target="PGID" Default="100" Mode="" Description="Group ID" Type="Variable"

--- a/docs/SSO_QUICK_START.md
+++ b/docs/SSO_QUICK_START.md
@@ -116,6 +116,13 @@ otherwise, rather than hiding the login form with no SSO behind it.
 redirect but does **not** re-enable password login. Full recovery steps are in the
 [Setup Guide](SSO_SETUP_GUIDE.md#break-glass-getting-back-in-when-sso-is-broken).
 
+> **Keep one account with a local password.** Turning the flag back off only helps if some
+> account can answer a password prompt, and an account created through SSO has no password to
+> answer with. Signing into an existing local account through your provider makes it *hybrid*
+> and keeps its password, so it stays usable — an account that started life at the provider does
+> not. Check this before you need it; there is a way back without it, but it involves a shell on
+> the host.
+
 
 ### Restrict to Family Domains (Optional)
 ```bash

--- a/docs/SSO_SETUP_GUIDE.md
+++ b/docs/SSO_SETUP_GUIDE.md
@@ -189,12 +189,18 @@ variables are parsed strictly: anything else fails the boot with an error naming
 and echoing what you set.
 
 Docker Compose strips `#` comments from env files when the hash is unquoted and preceded by a
-space, and trims whitespace, so a plain `SSO_ONLY_MODE=true # my note` reaches the app as
-`true` and works. It reaches the app *broken*
-when the quoting hides the comment from Compose, or when the value never passes through Compose
-at all: `SSO_ONLY_MODE="true # my note"`, `SSO_ONLY_MODE=true# my note` (no space before the
-hash), a `-e` argument to `docker run`, or an Unraid template field. Simplest to put comments on
-their own line and not think about which case you are in.
+space, and trims whitespace. That applies after a quoted value as well, so both
+`SSO_ONLY_MODE=true # my note` and `SSO_ONLY_MODE="true" # my note` reach the app as `true`
+and work. It reaches the app *broken* when the hash is inside the quotes and so is part of the
+value, when nothing separates it from the value, or when the value never passes through a parser
+that strips comments: `SSO_ONLY_MODE="true # my note"`, `SSO_ONLY_MODE=true# my note` (no space
+before the hash), or an Unraid template field.
+
+A `-e` argument to `docker run` depends on how you quote it. Typed unquoted at a shell,
+`-e SSO_ONLY_MODE=true # my note` is fine — the shell treats the hash as the start of a comment
+and Docker never sees it. Quote it into the value (`-e "SSO_ONLY_MODE=true # my note"`) and the
+hash reaches the app and fails the boot. Simplest to put comments on their own line and not
+think about which case you are in.
 
 **Built-in for Google/GitHub:**
 
@@ -358,9 +364,16 @@ still refuses your password, and nothing in the log contradicts you. If you are 
 container actually received, ask it directly:
 
 ```bash
-# Container deployments
+# Docker Compose (service name from your compose file)
 docker compose exec medikeep-app printenv SSO_ONLY_MODE
+
+# docker run (container name, not a compose service name)
+docker exec medikeep-app printenv SSO_ONLY_MODE
 ```
+
+On Unraid, the container has no compose service to address: open the container's context menu in
+the Docker tab, choose **Console**, and run `printenv SSO_ONLY_MODE` inside it — or use the
+`docker exec` form above with the name from the template.
 
 On a host install, check the environment of the running process rather than the file you edited —
 `.env` and what the process actually loaded can disagree after an incomplete restart.

--- a/docs/SSO_SETUP_GUIDE.md
+++ b/docs/SSO_SETUP_GUIDE.md
@@ -186,8 +186,14 @@ guard is server-side and is not reachable from a query string.
 
 Accepted values are `true`/`false`, `1`/`0`, `yes`/`no`, `on`/`off`, in any case. These two
 variables are parsed strictly: anything else fails the boot with an error naming the variable
-and echoing what you set. A compose env file does **not** strip inline comments, so
-`SSO_ONLY_MODE=true # my note` is the entire value — put comments on their own line.
+and echoing what you set.
+
+Docker Compose strips unquoted ` #` comments from env files and trims whitespace, so a plain
+`SSO_ONLY_MODE=true # my note` reaches the app as `true` and works. It reaches the app *broken*
+when the quoting hides the comment from Compose, or when the value never passes through Compose
+at all: `SSO_ONLY_MODE="true # my note"`, `SSO_ONLY_MODE=true# my note` (no space before the
+hash), a `-e` argument to `docker run`, or an Unraid template field. Simplest to put comments on
+their own line and not think about which case you are in.
 
 **Built-in for Google/GitHub:**
 
@@ -296,19 +302,42 @@ one.
 
 If every account on the instance is pure SSO, this step is still required but is not enough on
 its own — turn the flag off here, then use step 2's *create* form to make an account that has a
-password:
+password. Run it wherever the application lives:
 
 ```bash
-python app/scripts/create_emergency_admin.py --username emergency --password "..."
+# Docker Compose
+docker compose exec -it medikeep-app python app/scripts/create_emergency_admin.py --username emergency --force
+
+# Docker / Unraid (container name from your template; medikeep-app by default)
+docker exec -it medikeep-app python app/scripts/create_emergency_admin.py --username emergency --force
+
+# Directly on the host, from the repo root
+python app/scripts/create_emergency_admin.py --username emergency --force
 ```
+
+**Omit `--password`** — the script prompts for it twice, hidden, so the password does not land in
+your shell history or in `ps` output on a shared box.
+
+**`--force` is required here**, and this is the case that needs it: an all-SSO instance still has
+admin *accounts*, they simply have no passwords, so the script refuses to create another admin
+unless you say you mean it. Use a username that does not already exist; if it does, the script
+takes the promote path instead and promotion preserves the password that is not there.
 
 Order matters. That account cannot sign in while `SSO_ONLY_MODE=true`, because `/auth/login`
 returns 403 before looking at any credential. It is created with `must_change_password=True`, so
 expect a forced password change on first sign-in.
 
 ```bash
-SSO_ONLY_MODE=false   # then restart the container
+SSO_ONLY_MODE=false
 ```
+
+**Then recreate the container** — `docker compose up -d`, or the equivalent for your setup.
+A plain `docker restart` reuses the old environment and will not pick the change up, which looks
+exactly like the setting having no effect.
+
+If `SSO_AUTO_REDIRECT` is also on, either set it to `false` in the same edit or reach the login
+page at `/login?local=1`. With it left on, visiting the app still bounces you to the identity
+provider that is down — the password form is back, and you never get to see it.
 
 **Change it where the container actually reads it from**, which is not always where you set it
 originally:

--- a/docs/SSO_SETUP_GUIDE.md
+++ b/docs/SSO_SETUP_GUIDE.md
@@ -188,8 +188,9 @@ Accepted values are `true`/`false`, `1`/`0`, `yes`/`no`, `on`/`off`, in any case
 variables are parsed strictly: anything else fails the boot with an error naming the variable
 and echoing what you set.
 
-Docker Compose strips unquoted ` #` comments from env files and trims whitespace, so a plain
-`SSO_ONLY_MODE=true # my note` reaches the app as `true` and works. It reaches the app *broken*
+Docker Compose strips `#` comments from env files when the hash is unquoted and preceded by a
+space, and trims whitespace, so a plain `SSO_ONLY_MODE=true # my note` reaches the app as
+`true` and works. It reaches the app *broken*
 when the quoting hides the comment from Compose, or when the value never passes through Compose
 at all: `SSO_ONLY_MODE="true # my note"`, `SSO_ONLY_MODE=true# my note` (no space before the
 hash), a `-e` argument to `docker run`, or an Unraid template field. Simplest to put comments on
@@ -331,9 +332,12 @@ expect a forced password change on first sign-in.
 SSO_ONLY_MODE=false
 ```
 
-**Then recreate the container** — `docker compose up -d`, or the equivalent for your setup.
-A plain `docker restart` reuses the old environment and will not pick the change up, which looks
-exactly like the setting having no effect.
+**Then restart the application so it reads the new value.** Under Docker that means recreating
+the container — `docker compose up -d`, or the equivalent for your setup; a plain `docker restart`
+reuses the old environment and will not pick the change up, which looks exactly like the setting
+having no effect. Running directly on a host, stop and start the process itself (your service unit,
+or the `python run.py` you launched): the environment is read once at startup, so editing `.env`
+under a running process changes nothing until it restarts.
 
 If `SSO_AUTO_REDIRECT` is also on, either set it to `false` in the same edit or reach the login
 page at `/login?local=1`. With it left on, visiting the app still bounces you to the identity
@@ -347,14 +351,19 @@ originally:
 | Docker Compose | the `.env` file next to `docker-compose.yml`, or the `environment:` block in the file itself if you set it there — the block wins |
 | Unraid | the template variable in the container's edit screen, not any `.env` on the array |
 | `docker run` | the `-e SSO_ONLY_MODE=...` argument; recreate the container, restarting is not enough |
+| Directly on a host | the `.env` file in the repo root, or whatever your service unit exports — an exported variable wins over `.env`; restart the process |
 
 Setting it in the wrong one of these is a common way to spend an hour: the app comes up healthy,
 still refuses your password, and nothing in the log contradicts you. If you are unsure what the
 container actually received, ask it directly:
 
 ```bash
+# Container deployments
 docker compose exec medikeep-app printenv SSO_ONLY_MODE
 ```
+
+On a host install, check the environment of the running process rather than the file you edited —
+`.env` and what the process actually loaded can disagree after an incomplete restart.
 
 Watch the startup logs. A typo in the recovery value now fails the boot with a message naming
 the variable and echoing what you set — that is deliberate. Without it, `SSO_ONLY_MODE=fasle`

--- a/docs/SSO_SETUP_GUIDE.md
+++ b/docs/SSO_SETUP_GUIDE.md
@@ -287,8 +287,44 @@ flag, not after.
 **1. Turn the flag off and sign in locally.** This is the primary path, and the only one that
 works when the provider itself is down.
 
+This step assumes something worth checking *before* you enable the flag: **that at least one
+account still has a local password.** `auth_method='sso'` accounts — the ones created by signing
+in through the provider — have no password at all, so turning the flag off gives them a login
+form they cannot answer. An account that existed locally first and later linked a provider
+identity becomes `hybrid` and keeps its password; one that was born at the provider never had
+one.
+
+If every account on the instance is pure SSO, this step is still required but is not enough on
+its own — turn the flag off here, then use step 2's *create* form to make an account that has a
+password:
+
+```bash
+python app/scripts/create_emergency_admin.py --username emergency --password "..."
+```
+
+Order matters. That account cannot sign in while `SSO_ONLY_MODE=true`, because `/auth/login`
+returns 403 before looking at any credential. It is created with `must_change_password=True`, so
+expect a forced password change on first sign-in.
+
 ```bash
 SSO_ONLY_MODE=false   # then restart the container
+```
+
+**Change it where the container actually reads it from**, which is not always where you set it
+originally:
+
+| How you deploy | Where the value lives |
+|---|---|
+| Docker Compose | the `.env` file next to `docker-compose.yml`, or the `environment:` block in the file itself if you set it there — the block wins |
+| Unraid | the template variable in the container's edit screen, not any `.env` on the array |
+| `docker run` | the `-e SSO_ONLY_MODE=...` argument; recreate the container, restarting is not enough |
+
+Setting it in the wrong one of these is a common way to spend an hour: the app comes up healthy,
+still refuses your password, and nothing in the log contradicts you. If you are unsure what the
+container actually received, ask it directly:
+
+```bash
+docker compose exec medikeep-app printenv SSO_ONLY_MODE
 ```
 
 Watch the startup logs. A typo in the recovery value now fails the boot with a message naming

--- a/docs/developer-guide/04-deployment.md
+++ b/docs/developer-guide/04-deployment.md
@@ -512,9 +512,12 @@ Two consequences worth knowing before tuning these:
   household or CGNAT range sharing one address can plausibly reach the limit. The
   default was raised from 10 to
   30 per 10 minutes for exactly that reason; raise `SSO_RATE_LIMIT_ATTEMPTS` further if
-  legitimate users still report being turned away. Under `SSO_ONLY_MODE` there is no
+  anyone is turned away in ordinary use. Under `SSO_ONLY_MODE` there is no
   password login to fall back on, so being throttled means no way in until the window
-  rolls off.
+  rolls off — and on a self-hosted instance the person that happens to may well be you,
+  with no second account to check from. The limit is there to bound the sign-in state
+  store, not to stop a determined attacker, so tune it for the household and not for the
+  worst case.
 
 **SSO-only mode and auto-redirect:** `SSO_ONLY_MODE` makes the identity provider the
 only way in — `POST /auth/login` and `POST /auth/register` return `403` before any
@@ -561,7 +564,11 @@ warning rather than a failure.
 these settings, so a broken IdP cannot make itself unfixable:
 
 1. Set `SSO_ONLY_MODE=false`, restart, sign in locally — the primary path, and the
-   only one that works when the IdP itself is unreachable.
+   only one that works when the IdP itself is unreachable. It assumes some account has
+   a local password: accounts created through the IdP (`auth_method='sso'`) have none,
+   while a local account that later linked an identity is `hybrid` and keeps its own.
+   If every account is pure SSO, turn the flag off and then create a password admin
+   with step 2's create form — `--promote` preserves a password that is not there.
 2. If SSO still works but no account has admin rights, run
    `app/scripts/create_emergency_admin.py --username <name> --promote` against an
    account that can sign in through the IdP; promotion preserves the existing

--- a/docs/developer-guide/04-deployment.md
+++ b/docs/developer-guide/04-deployment.md
@@ -555,11 +555,12 @@ than being read as `false`. Everywhere else `false` merely means "off", but for
 an instance accepting credentials its operator believes are refused — with nothing in
 the logs to say so.
 
-Compose strips unquoted ` #` comments from env files and trims whitespace, so the plain
-inline-comment case works. The values that actually arrive unreadable are a typo (`fasle`),
-a quoted comment (`"true # sso only"`), a hash with no space before it (`true# sso only`),
-or anything set through a vehicle that does no parsing — `docker run -e`, an Unraid template
-field, a literal in the compose `environment:` block.
+Compose strips `#` comments from env files when the hash is unquoted and preceded by a
+space, and trims whitespace, so the plain inline-comment case works. The values that
+actually arrive unreadable are a typo (`fasle`), a quoted comment (`"true # sso only"`),
+a hash with no space before it (`true# sso only`), or anything set through a vehicle that
+does no parsing — `docker run -e`, an Unraid template field, a literal in the compose
+`environment:` block.
 
 If `SSO_ONLY_MODE` is combined with registration disabled, no new user can enter by
 any self-service route. That is valid for a sealed instance and is logged as a startup

--- a/docs/developer-guide/04-deployment.md
+++ b/docs/developer-guide/04-deployment.md
@@ -514,8 +514,8 @@ Two consequences worth knowing before tuning these:
   30 per 10 minutes for exactly that reason; raise `SSO_RATE_LIMIT_ATTEMPTS` further if
   anyone is turned away in ordinary use. Under `SSO_ONLY_MODE` there is no
   password login to fall back on, so being throttled means no way in until the window
-  rolls off — and on a self-hosted instance the person that happens to may well be you,
-  with no second account to check from. The limit is there to bound the sign-in state
+  rolls off — and on a self-hosted instance the person who happens to be throttled may
+  well be you, with no second account to check from. The limit is there to bound the sign-in state
   store, not to stop a determined attacker, so tune it for the household and not for the
   worst case.
 
@@ -553,8 +553,13 @@ the boot with an error naming the variable and showing what it was set to, rathe
 than being read as `false`. Everywhere else `false` merely means "off", but for
 `SSO_ONLY_MODE` it means password login is still open, so a misread value would leave
 an instance accepting credentials its operator believes are refused — with nothing in
-the logs to say so. The most common cause is an inline comment: a compose env file
-does not strip them, so `SSO_ONLY_MODE=true # sso only` is read as the entire string.
+the logs to say so.
+
+Compose strips unquoted ` #` comments from env files and trims whitespace, so the plain
+inline-comment case works. The values that actually arrive unreadable are a typo (`fasle`),
+a quoted comment (`"true # sso only"`), a hash with no space before it (`true# sso only`),
+or anything set through a vehicle that does no parsing — `docker run -e`, an Unraid template
+field, a literal in the compose `environment:` block.
 
 If `SSO_ONLY_MODE` is combined with registration disabled, no new user can enter by
 any self-service route. That is valid for a sealed instance and is logged as a startup
@@ -563,18 +568,28 @@ warning rather than a failure.
 **Recovering from a locked-out instance.** There is deliberately no in-app toggle for
 these settings, so a broken IdP cannot make itself unfixable:
 
-1. Set `SSO_ONLY_MODE=false`, restart, sign in locally — the primary path, and the
-   only one that works when the IdP itself is unreachable. It assumes some account has
-   a local password: accounts created through the IdP (`auth_method='sso'`) have none,
-   while a local account that later linked an identity is `hybrid` and keeps its own.
-   If every account is pure SSO, turn the flag off and then create a password admin
-   with step 2's create form — `--promote` preserves a password that is not there.
-2. If SSO still works but no account has admin rights, run
-   `app/scripts/create_emergency_admin.py --username <name> --promote` against an
-   account that can sign in through the IdP; promotion preserves the existing
-   password and grants admin. Creating a *new* password admin does not help while
-   `SSO_ONLY_MODE=true` — password login is refused for that account too — so pair it
-   with step 1.
+1. Set `SSO_ONLY_MODE=false` and recreate the container (`docker compose up -d`, or
+   your equivalent — a plain `docker restart` reuses the old environment). Then sign in
+   locally. This is the primary path and the only one that works when the IdP itself is
+   unreachable. Two conditions on it:
+   - **Clear `SSO_AUTO_REDIRECT` too, or use `/login?local=1`.** Left on, it bounces
+     you to the provider that is down before you ever see the password form.
+   - **Some account must have a local password.** Accounts created through the IdP
+     (`auth_method='sso'`) have none; a local account that later linked an identity is
+     `hybrid` and keeps its own. If every account is pure SSO, turn the flag off and
+     then create a password admin per step 2 — `--promote` preserves a password that is
+     not there.
+2. Run `create_emergency_admin.py` inside the container
+   (`docker compose exec -it medikeep-app python app/scripts/create_emergency_admin.py …`),
+   or directly from the repo root on a host install.
+   - **No admin rights, SSO working:** `--username <existing> --promote`. Promotion
+     grants admin and preserves the existing password.
+   - **No account with a password:** `--username <new-name> --force`. `--force` is
+     required because admin accounts do exist, they simply cannot answer a password
+     prompt. Creating one does not help while `SSO_ONLY_MODE=true` — password login is
+     refused for it too — so pair it with step 1.
+   - **Omit `--password`** in both cases; the script prompts twice, hidden, keeping the
+     credential out of shell history and `ps`.
 3. Startup validation catches the most likely misconfiguration before it takes effect.
 
 **Example (Google):**

--- a/docs/developer-guide/04-deployment.md
+++ b/docs/developer-guide/04-deployment.md
@@ -515,9 +515,12 @@ Two consequences worth knowing before tuning these:
   anyone is turned away in ordinary use. Under `SSO_ONLY_MODE` there is no
   password login to fall back on, so being throttled means no way in until the window
   rolls off — and on a self-hosted instance the person who happens to be throttled may
-  well be you, with no second account to check from. The limit is there to bound the sign-in state
-  store, not to stop a determined attacker, so tune it for the household and not for the
-  worst case.
+  well be you, with no second account to check from. What the limit actually bounds is how
+  much sign-in state any *one* client address can mint; it is not a global ceiling, since
+  enough distinct live addresses still grow the store. That global bound is a separate
+  10,000-entry cap on the SSO state store, which evicts the oldest entries rather than
+  growing without limit. So tune this limit for the household, not for the worst case —
+  the worst case is held elsewhere.
 
 **SSO-only mode and auto-redirect:** `SSO_ONLY_MODE` makes the identity provider the
 only way in — `POST /auth/login` and `POST /auth/register` return `403` before any
@@ -556,11 +559,13 @@ an instance accepting credentials its operator believes are refused — with not
 the logs to say so.
 
 Compose strips `#` comments from env files when the hash is unquoted and preceded by a
-space, and trims whitespace, so the plain inline-comment case works. The values that
-actually arrive unreadable are a typo (`fasle`), a quoted comment (`"true # sso only"`),
-a hash with no space before it (`true# sso only`), or anything set through a vehicle that
-does no parsing — `docker run -e`, an Unraid template field, a literal in the compose
-`environment:` block.
+space, and trims whitespace. That holds after a quoted value too, so `true # sso only`
+and `"true" # sso only` both arrive as `true`. The values that actually arrive unreadable
+are a typo (`fasle`), a hash *inside* the quotes (`"true # sso only"`), a hash with no
+space before it (`true# sso only`), or anything set through a vehicle that does no such
+parsing — an Unraid template field, a literal in the compose `environment:` block, or a
+`docker run -e` argument quoted to keep the hash. An unquoted `-e VAR=true # note` typed
+at a shell is fine: the shell strips the comment before Docker is invoked.
 
 If `SSO_ONLY_MODE` is combined with registration disabled, no new user can enter by
 any self-service route. That is valid for a sealed instance and is logged as a startup

--- a/tests/api/test_session_timeout.py
+++ b/tests/api/test_session_timeout.py
@@ -1,11 +1,25 @@
 """
 Test session timeout and JWT token expiration functionality.
 
-Tests verify that:
-1. JWT tokens are created with user's session_timeout_minutes preference
-2. Tokens are regenerated when user changes their timeout
-3. Default timeout is used when no preference is set
-4. All authentication flows (login, SSO) respect user preferences
+`session_timeout_minutes` drives the *frontend inactivity timer*. It is not the JWT
+lifetime, and these tests previously asserted that it was -- the contract changed in
+4c4bb995 (cookie auth, #722) and they were left behind, failing for every timeout
+below ACCESS_TOKEN_EXPIRE_MINUTES while passing for every value above it.
+
+The contract they assert now, from `auth.py:401-403` and `users.py:213-216`:
+
+1. The JWT must *outlive* the inactivity timer, so its lifetime is
+   `max(ACCESS_TOKEN_EXPIRE_MINUTES, session_timeout_minutes)`. If the cookie expired
+   first the user would get a hard 401 before the timer ever fired.
+2. Login returns the preference so the frontend can arm its timer.
+3. Changing the preference does **not** reissue the token -- JWT expiry is fixed at
+   server config. See the DEFERRED note below for the one case where that shows.
+4. A user with no explicit preference gets the column default.
+
+**Deferred, filed in TECHNICAL_DEBT.md:** raising the preference above
+ACCESS_TOKEN_EXPIRE_MINUTES mid-session leaves the old, shorter JWT in place until the
+next login, which is the exact "cookie expires before the timer fires" case point 1
+exists to prevent. Not exercised here; the tests below assert the behavior as built.
 """
 
 from datetime import datetime, timedelta, timezone
@@ -15,8 +29,15 @@ from sqlalchemy.orm import Session
 
 from app.core.config import settings
 from app.crud.user_preferences import user_preferences
+from app.models.user import UserPreferences
 from app.schemas.user_preferences import UserPreferencesUpdate
 from tests.utils.user import create_random_user
+
+# The column default, so a change to it fails one assertion here rather than being
+# restated as a literal in four places.
+DEFAULT_SESSION_TIMEOUT_MINUTES = (
+    UserPreferences.__table__.c.session_timeout_minutes.default.arg
+)
 
 
 class TestSessionTimeout:
@@ -40,11 +61,9 @@ class TestSessionTimeout:
         data = response.json()
         assert "access_token" in data
         assert "session_timeout_minutes" in data
-        # Should have default timeout (30 minutes or config default)
-        assert data["session_timeout_minutes"] in [
-            30,
-            settings.ACCESS_TOKEN_EXPIRE_MINUTES,
-        ]
+        # The column default, read from the model so this test does not have to be
+        # edited again when the default moves.
+        assert data["session_timeout_minutes"] == DEFAULT_SESSION_TIMEOUT_MINUTES
 
     def test_login_jwt_token_uses_user_preference(
         self, client: TestClient, db_session: Session
@@ -78,10 +97,12 @@ class TestSessionTimeout:
             token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM]
         )
 
-        # Calculate expected expiration time (current time + custom_timeout minutes)
-        # Both times should be in UTC for comparison
+        # The JWT outlives the inactivity timer: max(config, preference). 1440 is
+        # above ACCESS_TOKEN_EXPIRE_MINUTES, so the preference wins here -- which is
+        # why this one test kept passing while its siblings failed.
         now_timestamp = datetime.now(timezone.utc).timestamp()
-        expected_exp_timestamp = now_timestamp + (custom_timeout * 60)
+        expected_lifetime = max(settings.ACCESS_TOKEN_EXPIRE_MINUTES, custom_timeout)
+        expected_exp_timestamp = now_timestamp + (expected_lifetime * 60)
         token_exp_timestamp = decoded["exp"]
 
         # Allow 5 second tolerance for test execution time
@@ -133,18 +154,33 @@ class TestSessionTimeout:
                 algorithms=[settings.ALGORITHM],
             )
 
+            # Below ACCESS_TOKEN_EXPIRE_MINUTES the config floor applies; above it the
+            # preference does. test_timeouts deliberately straddles the boundary.
             now_timestamp = datetime.now(timezone.utc).timestamp()
-            expected_exp_timestamp = now_timestamp + (timeout_minutes * 60)
+            expected_lifetime = max(
+                settings.ACCESS_TOKEN_EXPIRE_MINUTES, timeout_minutes
+            )
+            expected_exp_timestamp = now_timestamp + (expected_lifetime * 60)
             token_exp_timestamp = decoded["exp"]
             time_diff = abs(token_exp_timestamp - expected_exp_timestamp)
 
-            assert time_diff < 5, f"Timeout {timeout_minutes}min: Token exp mismatch"
+            assert time_diff < 5, (
+                f"Timeout {timeout_minutes}min: expected a "
+                f"{expected_lifetime}min JWT, got exp {token_exp_timestamp}"
+            )
 
-    def test_update_preferences_regenerates_token(
+    def test_update_timeout_does_not_reissue_token(
         self, authenticated_client: TestClient
     ):
-        """Test that updating session timeout generates a new token."""
-        # Update session timeout to a new value
+        """Changing the timeout persists it and leaves the token alone.
+
+        Was `test_update_preferences_regenerates_token`, asserting the reverse. The
+        endpoint stopped reissuing when JWT lifetime stopped tracking this preference
+        (`users.py:213-216`); the test kept asserting a `new_token` key that no
+        response carries any more.
+        """
+        # 720 is above ACCESS_TOKEN_EXPIRE_MINUTES deliberately: this is the case
+        # where a reissue would change the JWT if one happened.
         new_timeout = 720  # 12 hours
 
         response = authenticated_client.put(
@@ -155,29 +191,18 @@ class TestSessionTimeout:
         assert response.status_code == 200
         data = response.json()
 
-        # Should include new token
-        assert "new_token" in data
-        assert "token_type" in data
-        assert data["token_type"] == "bearer"
         assert data["session_timeout_minutes"] == new_timeout
+        assert "new_token" not in data
+        assert "token_type" not in data
 
-        # Decode the new token and verify expiration using timestamps
-        new_token = data["new_token"]
-        decoded = jwt.decode(
-            new_token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM]
-        )
-
-        now_timestamp = datetime.now(timezone.utc).timestamp()
-        expected_exp_timestamp = now_timestamp + (new_timeout * 60)
-        token_exp_timestamp = decoded["exp"]
-        time_diff = abs(token_exp_timestamp - expected_exp_timestamp)
-
-        assert time_diff < 5, "New token expiration doesn't match updated timeout"
-
-    def test_update_preferences_only_regenerates_on_timeout_change(
+    def test_update_non_timeout_preference_does_not_reissue_token(
         self, authenticated_client: TestClient
     ):
-        """Test that updating non-timeout preferences doesn't regenerate token."""
+        """A non-timeout preference update carries no token either.
+
+        Renamed: "only_regenerates_on_timeout_change" described a rule that no longer
+        holds in either direction -- nothing reissues now.
+        """
         # Update a different preference (not session_timeout_minutes)
         response = authenticated_client.put(
             "/api/v1/users/me/preferences", json={"unit_system": "metric"}
@@ -186,14 +211,13 @@ class TestSessionTimeout:
         assert response.status_code == 200
         data = response.json()
 
-        # Should NOT include new token
         assert "new_token" not in data
         assert data["unit_system"] == "metric"
 
-    def test_update_timeout_to_same_value_no_regeneration(
+    def test_update_timeout_to_same_value_carries_no_token(
         self, authenticated_client: TestClient
     ):
-        """Test that setting timeout to current value doesn't regenerate token."""
+        """Setting the timeout to its current value is still a plain update."""
         # Get current timeout
         prefs_response = authenticated_client.get("/api/v1/users/me/preferences")
         current_timeout = prefs_response.json()["session_timeout_minutes"]
@@ -207,7 +231,6 @@ class TestSessionTimeout:
         assert response.status_code == 200
         data = response.json()
 
-        # Should NOT regenerate token (value unchanged)
         assert "new_token" not in data
 
     def test_default_timeout_when_no_preference(
@@ -227,18 +250,21 @@ class TestSessionTimeout:
         assert response.status_code == 200
         data = response.json()
 
-        # Should use database default (30 minutes) for new users
-        # Database default is defined in models.py: session_timeout_minutes = Column(Integer, default=30)
-        expected_default = 30
-        assert data["session_timeout_minutes"] == expected_default
+        # Should use the column default for new users
+        assert data["session_timeout_minutes"] == DEFAULT_SESSION_TIMEOUT_MINUTES
 
         # Verify token expiration using timestamps
         decoded = jwt.decode(
             data["access_token"], settings.SECRET_KEY, algorithms=[settings.ALGORITHM]
         )
 
+        # The default is below ACCESS_TOKEN_EXPIRE_MINUTES, so the config floor sets
+        # the JWT lifetime here, not the preference.
         now_timestamp = datetime.now(timezone.utc).timestamp()
-        expected_exp_timestamp = now_timestamp + (expected_default * 60)
+        expected_lifetime = max(
+            settings.ACCESS_TOKEN_EXPIRE_MINUTES, DEFAULT_SESSION_TIMEOUT_MINUTES
+        )
+        expected_exp_timestamp = now_timestamp + (expected_lifetime * 60)
         token_exp_timestamp = decoded["exp"]
         time_diff = abs(token_exp_timestamp - expected_exp_timestamp)
 

--- a/tests/api/test_sso_startup_validation.py
+++ b/tests/api/test_sso_startup_validation.py
@@ -119,11 +119,16 @@ class TestFlagParsing:
     """An unrecognized value fails the boot rather than reading as False.
 
     `.lower() == "true"` - the idiom every other boolean in config.py uses - reads
-    `SSO_ONLY_MODE=1`, a trailing space, or `SSO_ONLY_MODE=true # sso only` (a
-    compose env file does not strip inline comments) as False. Here False means
-    password login is still accepted, so a silent misparse is a security control
-    failing open, and the pairing check above cannot catch it: that only fires when
-    the flag parses True.
+    every value other than "true" as False. Here False means password login is still
+    accepted, so a silent misparse is a security control failing open, and the
+    pairing check above cannot catch it: that only fires when the flag parses True.
+
+    `1`, `yes`, `on` and surrounding whitespace are accepted rather than refused, so
+    the cases below are the ones that genuinely cannot be read: a typo, and a `#`
+    note that survived its transport. Docker Compose strips unquoted ` #` comments
+    and trims whitespace (measured on Compose v5, PR 6), so the note survives only
+    when quoted, when no space precedes the hash, or when it arrives by a vehicle
+    that does no parsing at all - `docker run -e`, an Unraid field.
     """
 
     @pytest.fixture(autouse=True)

--- a/tests/api/test_users_api.py
+++ b/tests/api/test_users_api.py
@@ -185,7 +185,9 @@ class TestUserPreferencesAPI:
         assert response.status_code == 200
         data = response.json()
         assert data["session_timeout_minutes"] == 60
-        assert "new_token" in data
+        # No reissue: this preference drives the frontend inactivity timer, not JWT
+        # expiry (`users.py:213-216`). See tests/api/test_session_timeout.py.
+        assert "new_token" not in data
 
     def test_update_session_timeout_bounds_validation(
         self, client: TestClient, user_with_patient, authenticated_headers

--- a/tests/core/test_deployment_env_coverage.py
+++ b/tests/core/test_deployment_env_coverage.py
@@ -1,0 +1,96 @@
+"""Every SSO setting the app reads must be reachable from a deployment artifact.
+
+`SSO_RATE_LIMIT_ATTEMPTS` and `SSO_RATE_LIMIT_WINDOW_MINUTES` were read by
+config.py, listed in `.env.example`, and documented in the deployment guide --
+which then advised raising the limit under `SSO_AUTO_REDIRECT`, where every
+unauthenticated page load is one attempt. No compose file and no Unraid template
+passed either variable into the container, so an operator following that advice
+changed nothing, silently, on the one setting they had been told to change.
+`SSO_ISSUER_URL` had the mirror-image gap: passed by compose, required by every
+OIDC-family provider, and absent from the example file operators copy.
+
+A unit test cannot catch either: the settings parse correctly, and the code that
+reads them works. What was missing was the wiring, which lives in files no test
+had ever opened. Hence this one, which reads them.
+
+Scoped to the three tracked artifacts. `dev_docker/` and `docker/dev/` are
+gitignored working files -- asserting on those would pass locally and error in
+CI, which is its own version of this bug.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG_PY = REPO_ROOT / "app" / "core" / "config.py"
+COMPOSE = REPO_ROOT / "docker" / "docker-compose.yml"
+UNRAID_TEMPLATE = REPO_ROOT / "docker" / "unraid-template.xml"
+ENV_EXAMPLE = REPO_ROOT / "docker" / ".env.example"
+
+# The three ways config.py reads an environment variable. `get_secret` also
+# accepts a `<NAME>_FILE` companion, which is a separate mechanism with its own
+# commented-out block in the compose file; the plain name is what this checks.
+ENV_READ = re.compile(
+    r"""(?:os\.getenv|get_secret|_strict_bool)\(\s*["'](SSO_[A-Z0-9_]+)["']"""
+)
+
+
+@pytest.fixture(scope="module")
+def sso_settings():
+    """Every SSO_* variable config.py reads from the environment."""
+    names = set(ENV_READ.findall(CONFIG_PY.read_text(encoding="utf-8")))
+    # A guard on the guard: if the extraction breaks, every assertion below
+    # would pass vacuously against an empty set.
+    assert "SSO_ENABLED" in names, "env-var extraction found nothing recognizable"
+    return names
+
+
+def test_compose_passes_every_sso_setting(sso_settings):
+    """Union across services, so renaming one does not quietly turn this off."""
+    compose = yaml.safe_load(COMPOSE.read_text(encoding="utf-8"))
+    passed = set()
+    for service in (compose.get("services") or {}).values():
+        environment = service.get("environment")
+        if isinstance(environment, dict):
+            passed.update(environment)
+        elif isinstance(environment, list):
+            # `- NAME=value` and bare `- NAME` are both legal.
+            passed.update(entry.split("=", 1)[0] for entry in environment)
+
+    missing = sorted(sso_settings - passed)
+    assert not missing, (
+        f"docker/docker-compose.yml does not pass {missing}. The app reads "
+        "these, so an operator setting one would see no effect."
+    )
+
+
+def test_unraid_template_offers_every_sso_setting(sso_settings):
+    targets = set(
+        re.findall(
+            r'Target="(SSO_[A-Z0-9_]+)"', UNRAID_TEMPLATE.read_text(encoding="utf-8")
+        )
+    )
+    missing = sorted(sso_settings - targets)
+    assert not missing, (
+        f"unraid-template.xml has no Config entry for {missing}. Unraid users "
+        "configure the container through this file only."
+    )
+
+
+def test_env_example_names_every_sso_setting(sso_settings):
+    """Commented-out counts -- the point is that the name is discoverable."""
+    documented = set(
+        re.findall(
+            r"^#*\s*(SSO_[A-Z0-9_]+)=",
+            ENV_EXAMPLE.read_text(encoding="utf-8"),
+            re.MULTILINE,
+        )
+    )
+    missing = sorted(sso_settings - documented)
+    assert not missing, (
+        f".env.example never mentions {missing}. It is the file operators copy, "
+        "so a setting absent from it is a setting most of them never learn about."
+    )

--- a/tests/core/test_deployment_env_coverage.py
+++ b/tests/core/test_deployment_env_coverage.py
@@ -27,6 +27,9 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CONFIG_PY = REPO_ROOT / "app" / "core" / "config.py"
 COMPOSE = REPO_ROOT / "docker" / "docker-compose.yml"
+# The service the application runs in. Asserted to exist before its environment is
+# read, so a rename surfaces here rather than silently skipping the check.
+APP_SERVICE = "medikeep-app"
 UNRAID_TEMPLATE = REPO_ROOT / "docker" / "unraid-template.xml"
 ENV_EXAMPLE = REPO_ROOT / "docker" / ".env.example"
 
@@ -49,21 +52,33 @@ def sso_settings():
 
 
 def test_compose_passes_every_sso_setting(sso_settings):
-    """Union across services, so renaming one does not quietly turn this off."""
+    """Checked against the application service specifically.
+
+    Not a union across services: the database service passing `SSO_ONLY_MODE` would
+    satisfy a union while the application still never saw it. Naming the service means
+    a rename fails this test loudly, which is the outcome a union was reaching for and
+    did not achieve.
+    """
     compose = yaml.safe_load(COMPOSE.read_text(encoding="utf-8"))
-    passed = set()
-    for service in (compose.get("services") or {}).values():
-        environment = service.get("environment")
-        if isinstance(environment, dict):
-            passed.update(environment)
-        elif isinstance(environment, list):
-            # `- NAME=value` and bare `- NAME` are both legal.
-            passed.update(entry.split("=", 1)[0] for entry in environment)
+    services = compose.get("services") or {}
+    assert APP_SERVICE in services, (
+        f"docker-compose.yml has no '{APP_SERVICE}' service. If it was renamed, "
+        "update APP_SERVICE here — this test cannot check a service it cannot find."
+    )
+
+    environment = services[APP_SERVICE].get("environment")
+    if isinstance(environment, dict):
+        passed = set(environment)
+    elif isinstance(environment, list):
+        # `- NAME=value` and bare `- NAME` are both legal.
+        passed = {entry.split("=", 1)[0] for entry in environment}
+    else:
+        passed = set()
 
     missing = sorted(sso_settings - passed)
     assert not missing, (
-        f"docker/docker-compose.yml does not pass {missing}. The app reads "
-        "these, so an operator setting one would see no effect."
+        f"docker/docker-compose.yml does not pass {missing} to '{APP_SERVICE}'. "
+        "The app reads these, so an operator setting one would see no effect."
     )
 
 


### PR DESCRIPTION
## Summary

This pull request updates documentation and tests related to SSO (Single Sign-On) and session timeout behavior. The most important changes clarify how SSO recovery works, add new SSO rate-limiting environment variables to all deployment configs, and revise the session timeout tests to match the current authentication contract.

**SSO Configuration and Documentation Updates:**

* Added `SSO_RATE_LIMIT_ATTEMPTS` and `SSO_RATE_LIMIT_WINDOW_MINUTES` environment variables to all SSO deployment configs (`docker-compose.yml`, `README_SSO.md`, `.env.example`, and Unraid template), allowing per-IP throttling of sign-in attempts. These are now documented for users and administrators. [[1]](diffhunk://#diff-a2df2446358b8b090462bbfff458e3324b5bc3c85a4f3fe43d4c6497b17e248dR55-R59) [[2]](diffhunk://#diff-a2df2446358b8b090462bbfff458e3324b5bc3c85a4f3fe43d4c6497b17e248dR112-R113) [[3]](diffhunk://#diff-423deb13b7c401b1a7f41ee91c77f722e11d2f317d6a66b546524e8a04cc8b03R69-R75) [[4]](diffhunk://#diff-67ee65eb09491b119a803fcedcb85d2e65d5f0a6ada141d85f65cf09d40b8803L88-R98)
* Improved SSO recovery instructions in user and developer guides, emphasizing the need to keep at least one account with a local password and providing steps for emergency admin creation if all accounts are SSO-only. [[1]](diffhunk://#diff-7ffe80fc4f823fee03b21a379869e91fc7f2fb980e5a4110ddf5fb250039a297R119-R125) [[2]](diffhunk://#diff-e587822c2193de0efb5b8082075c074007e221f7e2da15c33c38860c4e911349R290-R329) [[3]](diffhunk://#diff-077c15df273385c333c1fd4a881f7db85fc04c5a7b8e0a96edfbff20c18efd66L564-R571)
* Clarified accepted values and error handling for `SSO_ONLY_MODE` and `SSO_AUTO_REDIRECT` in the Unraid template.
* Added explanation for the required but provider-specific `SSO_ISSUER_URL` variable in `.env.example`.

**Session Timeout Test Refactor:**

* Rewrote `tests/api/test_session_timeout.py` to reflect the updated contract: JWT lifetime is now the maximum of `ACCESS_TOKEN_EXPIRE_MINUTES` and the user's `session_timeout_minutes` preference, not always equal to the preference. Tests now check for the correct behavior and no longer expect JWTs to be reissued on preference change. [[1]](diffhunk://#diff-50cb0ab5b40fb6ee6cd4ec708eb703dbce39d5544bdb4e4561e46c8b6de8bdd8L4-R22) [[2]](diffhunk://#diff-50cb0ab5b40fb6ee6cd4ec708eb703dbce39d5544bdb4e4561e46c8b6de8bdd8R32-R41) [[3]](diffhunk://#diff-50cb0ab5b40fb6ee6cd4ec708eb703dbce39d5544bdb4e4561e46c8b6de8bdd8L43-R66) [[4]](diffhunk://#diff-50cb0ab5b40fb6ee6cd4ec708eb703dbce39d5544bdb4e4561e46c8b6de8bdd8L81-R105) [[5]](diffhunk://#diff-50cb0ab5b40fb6ee6cd4ec708eb703dbce39d5544bdb4e4561e46c8b6de8bdd8R157-R183) [[6]](diffhunk://#diff-50cb0ab5b40fb6ee6cd4ec708eb703dbce39d5544bdb4e4561e46c8b6de8bdd8L158-R205) [[7]](diffhunk://#diff-50cb0ab5b40fb6ee6cd4ec708eb703dbce39d5544bdb4e4561e46c8b6de8bdd8L189-R220) [[8]](diffhunk://#diff-50cb0ab5b40fb6ee6cd4ec708eb703dbce39d5544bdb4e4561e46c8b6de8bdd8L210) [[9]](diffhunk://#diff-50cb0ab5b40fb6ee6cd4ec708eb703dbce39d5544bdb4e4561e46c8b6de8bdd8L230-R267)

**Developer Documentation:**

* Updated deployment documentation to clarify the purpose and tuning of SSO rate limits, and to explain the implications of SSO-only mode for self-hosted instances.

These changes improve clarity for both users and developers, ensure configuration is consistent across deployment methods, and bring tests in line with the current authentication logic.

## Related issue

<!-- e.g. "Closes #123" or "N/A" -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Translation / i18n
- [ ] Other

## Testing


## Checklist

- [ ] Tests added or updated (or N/A with reason)
- [ ] `npm run lint` and `npm run build` pass
- [ ] Backend tests pass (`pytest`) if backend code changed
- [ ] No PHI, secrets, or `console.log` left in the diff
- [ ] User-facing strings go through `t()` translations
- [ ] Documentation updated if API, schema, or service behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable per-IP SSO sign-in rate limits, defaulting to 30 attempts per 10 minutes.
  * Added SSO rate-limit settings for Docker Compose, Unraid, and environment examples.

* **Documentation**
  * Expanded SSO setup, deployment, recovery, and quick-start guidance.
  * Clarified configuration values, inline-comment behavior, auto-redirect bypasses, and SSO-only account recovery.

* **Bug Fixes**
  * Clarified session-timeout behavior so preference updates do not unnecessarily issue new tokens.

* **Tests**
  * Added checks ensuring SSO settings are exposed across supported deployment configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->