### PR TITLE
fix: allow removing a patient's assigned practitioner (#995)

### DIFF
--- a/app/api/v1/endpoints/patient_management.py
+++ b/app/api/v1/endpoints/patient_management.py
@@ -43,7 +43,9 @@ class PatientCreateRequest(BaseModel):
     height: Optional[float] = Field(None, gt=0, description="Height in inches")
     weight: Optional[float] = Field(None, gt=0, description="Weight in pounds")
     address: Optional[str] = Field(None, max_length=500)
-    physician_id: Optional[int] = Field(None, description="Primary care physician ID")
+    physician_id: Optional[int] = Field(
+        None, gt=0, description="Primary care physician ID"
+    )
     is_self_record: bool = Field(
         False, description="Whether this is the user's own medical record"
     )
@@ -64,6 +66,12 @@ class PatientCreateRequest(BaseModel):
     def validate_relationship_to_self(cls, v):
         """Convert empty string to None, consistent with PatientUpdateRequest."""
         return None if v == "" else v
+
+
+# An explicit null for one of these is dropped rather than applied, since the column rejects it
+_NON_NULLABLE_UPDATE_FIELDS = frozenset(
+    c.name for c in Patient.__table__.columns if not c.nullable
+)
 
 
 class PatientUpdateRequest(BaseModel):
@@ -241,11 +249,14 @@ def create_patient(
                     request=request,
                 )
 
-        patient = service.create_patient(
-            user=current_user,
-            patient_data=patient_in.model_dump(),
-            is_self_record=patient_in.is_self_record,
-        )
+        try:
+            patient = service.create_patient(
+                user=current_user,
+                patient_data=patient_in.model_dump(),
+                is_self_record=patient_in.is_self_record,
+            )
+        except ValueError as e:
+            raise BusinessLogicException(message=str(e), request=request) from e
 
         log_data_access(
             logger,
@@ -528,9 +539,11 @@ def update_patient(
                 request=request,
             )
 
-        # Filter out None values
+        # exclude_unset keeps an explicit null (clear the field) distinct from an omitted field
         patient_data = {
-            k: v for k, v in patient_in.model_dump().items() if v is not None
+            k: v
+            for k, v in patient_in.model_dump(exclude_unset=True).items()
+            if not (v is None and k in _NON_NULLABLE_UPDATE_FIELDS)
         }
 
         # Log fields being updated without sensitive values
@@ -544,7 +557,11 @@ def update_patient(
                 fields_updated=list(patient_data.keys()),
             )
 
-        patient = service.update_patient(current_user, patient_id, patient_data)
+        try:
+            patient = service.update_patient(current_user, patient_id, patient_data)
+        except ValueError as e:
+            # Existence and edit permission are checked above, so what is left is bad request data
+            raise BusinessLogicException(message=str(e), request=request) from e
 
         log_data_access(
             logger,

--- a/app/services/patient_management.py
+++ b/app/services/patient_management.py
@@ -12,11 +12,15 @@ from app.core.logging.config import get_logger, log_security_event
 from app.core.logging.constants import LogFields
 from app.core.utils.activity_tracker import activity_tracking_disabled_var
 from app.models.models import Patient, PatientShare, User
+from app.models.practice import Practitioner
 from app.services.patient_access import PatientAccessService
 
 security_logger = get_logger(__name__, "security")
 
 logger = get_logger(__name__, "app")
+
+# Shared so the pre-flush check and the IntegrityError backstop cannot drift apart
+PHYSICIAN_NOT_FOUND_ERROR = "The specified physician does not exist"
 
 
 class PatientManagementService:
@@ -25,6 +29,19 @@ class PatientManagementService:
     def __init__(self, db: Session):
         self.db = db
         self.access_service = PatientAccessService(db)
+
+    def _validate_physician(self, physician_id: Optional[int]) -> None:
+        """Raise ValueError unless physician_id is None or names an existing practitioner."""
+        if physician_id is None:
+            return
+
+        exists = (
+            self.db.query(Practitioner.id)
+            .filter(Practitioner.id == physician_id)
+            .first()
+        )
+        if not exists:
+            raise ValueError(PHYSICIAN_NOT_FOUND_ERROR)
 
     def create_patient(
         self, user: User, patient_data: dict, is_self_record: bool = False
@@ -64,6 +81,8 @@ class PatientManagementService:
         # Validate birth_date is not in the future
         if patient_data["birth_date"] > date.today():
             raise ValueError("Birth date cannot be in the future")
+
+        self._validate_physician(patient_data.get("physician_id"))
 
         # If user is creating their own record, check if they already have one
         if is_self_record:
@@ -186,6 +205,8 @@ class PatientManagementService:
             if patient_data["birth_date"] > date.today():
                 raise ValueError("Birth date cannot be in the future")
 
+        self._validate_physician(patient_data.get("physician_id"))
+
         # Update allowed fields
         updatable_fields = [
             "first_name",
@@ -218,7 +239,7 @@ class PatientManagementService:
 
             if "foreign key" in error_msg.lower():
                 if "physician" in error_msg.lower():
-                    raise ValueError("The specified physician does not exist")
+                    raise ValueError(PHYSICIAN_NOT_FOUND_ERROR)
                 raise ValueError("Invalid reference in patient update")
             if "unique" in error_msg.lower() or "duplicate" in error_msg.lower():
                 raise ValueError("This update would create a duplicate patient record")

--- a/docs/developer-guide/02-api-reference.md
+++ b/docs/developer-guide/02-api-reference.md
@@ -817,6 +817,8 @@ Base path: `/api/v1/patient-management`
 ```
 
 - **Success Response** (201): Created patient object
+- **Error Responses**: 400 if `physician_id` refers to a practitioner that does not exist; 422 if
+  `physician_id` is not a positive integer
 
 #### List All Patients
 
@@ -851,7 +853,13 @@ Base path: `/api/v1/patient-management`
 
 - **Purpose**: Update patient information
 - **Request Body**: Same as create (all fields optional)
+- **Partial update semantics**: An omitted field is left unchanged. An explicit `null` clears the field, which
+  is how a nullable field such as `physician_id`, `address`, `blood_type`, `gender`, `height`, `weight`, or
+  `relationship_to_self` is unset. `null` for `first_name`, `last_name`, or `birth_date` is ignored, since
+  those columns are NOT NULL.
 - **Success Response** (200): Updated patient object
+- **Error Responses**: 400 if `physician_id` refers to a practitioner that does not exist; 422 if
+  `physician_id` is not a positive integer (use `null`, not `0`, to unassign)
 
 #### Delete Patient
 

--- a/frontend/src/pages/medical/__tests__/PatientInfo.physician.test.jsx
+++ b/frontend/src/pages/medical/__tests__/PatientInfo.physician.test.jsx
@@ -1,0 +1,196 @@
+/**
+ * Regression test for #995: clearing the assigned practitioner must reach the
+ * API as an explicit `physician_id: null`.
+ *
+ * The practitioner Select emits an empty string when cleared (see
+ * useFormHandlers.handleSelectChange), and this page is the only place that
+ * empty string is translated into the null the backend needs to unassign the
+ * physician. That mapping had no test, so a refactor here could silently
+ * reintroduce the bug even with the backend fixed.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key, fallback) => (typeof fallback === 'string' ? fallback : key),
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
+  Trans: ({ i18nKey, children }) => i18nKey || children,
+  initReactI18next: { type: '3rdParty', init: vi.fn() },
+}));
+
+import { createMockPatient, createMockPractitioner } from '../../../test-utils/test-data';
+
+const assignedPhysician = createMockPractitioner({ id: 2, name: 'Dr. Assigned' });
+const existingPatient = createMockPatient({
+  id: 4,
+  physician_id: assignedPhysician.id,
+  relationship_to_self: 'self',
+});
+
+const { mockUpdatePatient } = vi.hoisted(() => ({
+  mockUpdatePatient: vi.fn(() => Promise.resolve({})),
+}));
+
+vi.mock('../../../services/api/patientApi', () => ({
+  default: {
+    updatePatient: mockUpdatePatient,
+    createPatient: vi.fn(() => Promise.resolve({})),
+    getPhotoInfo: vi.fn(() => Promise.resolve(null)),
+    getPhotoUrl: vi.fn(() => Promise.resolve(null)),
+  },
+}));
+
+vi.mock('../../../hooks/useGlobalData', () => ({
+  useCurrentPatient: () => ({
+    patient: existingPatient,
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  }),
+  usePractitioners: () => ({
+    practitioners: [assignedPhysician],
+    loading: false,
+  }),
+  useCacheManager: () => ({
+    invalidatePatientList: vi.fn(() => Promise.resolve()),
+    invalidatePatient: vi.fn(() => Promise.resolve()),
+  }),
+}));
+
+vi.mock('../../../contexts/UserPreferencesContext', () => ({
+  useUserPreferences: () => ({ unitSystem: 'imperial' }),
+}));
+
+vi.mock('../../../hooks/useFormSubmissionWithUploads', () => ({
+  useFormSubmissionWithUploads: () => ({
+    isBlocking: false,
+    canSubmit: true,
+    statusMessage: '',
+    resetSubmission: vi.fn(),
+    startSubmission: vi.fn(),
+    completeFormSubmission: vi.fn(() => true),
+    completeFileUpload: vi.fn(),
+    handleSubmissionFailure: vi.fn(),
+  }),
+}));
+
+vi.mock('../../../hooks/useDateFormat', () => ({
+  useDateFormat: () => ({ formatLongDate: d => d || '' }),
+}));
+
+vi.mock('../../../hooks/useViewport', () => ({
+  useViewport: () => ({ isMobile: false, isTablet: false }),
+}));
+
+vi.mock('../../../services/logger', () => ({
+  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@mantine/core', () => ({
+  Container: ({ children }) => <div>{children}</div>,
+  Stack: ({ children }) => <div>{children}</div>,
+  Text: ({ children }) => <span>{children}</span>,
+  Alert: ({ children }) => <div>{children}</div>,
+  Card: ({ children }) => <div>{children}</div>,
+  SimpleGrid: ({ children }) => <div>{children}</div>,
+  ThemeIcon: ({ children }) => <span>{children}</span>,
+  Button: ({ children, onClick, disabled }) => (
+    <button onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@tabler/icons-react', () => ({
+  IconUser: props => <span {...props} />,
+  IconStethoscope: props => <span {...props} />,
+  IconPencil: props => <span {...props} />,
+}));
+
+vi.mock('../../../components', () => ({
+  PageHeader: () => <div />,
+}));
+
+vi.mock('../../../components/shared/PatientAvatar', () => ({
+  default: () => <div />,
+}));
+
+vi.mock('../../../components/shared/MedicalPageLoading', () => ({
+  default: () => <div />,
+}));
+
+/**
+ * Stands in for the real form, driving onInputChange exactly as the practitioner
+ * Select does: an empty string when the selection is cleared.
+ */
+vi.mock('../../../components/medical/patient-info/PatientFormWrapper', () => ({
+  default: ({ isOpen, formData, onInputChange, onSubmit }) => {
+    if (!isOpen) return null;
+    return (
+      <div data-testid="patient-form">
+        <span data-testid="physician-value">{String(formData.physician_id)}</span>
+        <button
+          data-testid="clear-physician"
+          onClick={() =>
+            onInputChange({ target: { name: 'physician_id', value: '' } })
+          }
+        />
+        <button data-testid="submit-form" onClick={() => onSubmit()} />
+      </div>
+    );
+  },
+}));
+
+import PatientInfo from '../Patient-Info';
+
+const renderInEditMode = () =>
+  render(
+    <MemoryRouter initialEntries={['/patients/me?edit=true']}>
+      <PatientInfo />
+    </MemoryRouter>
+  );
+
+describe('Patient-Info physician assignment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('populates the form with the currently assigned physician', async () => {
+    renderInEditMode();
+
+    expect(await screen.findByTestId('patient-form')).toBeInTheDocument();
+    expect(screen.getByTestId('physician-value')).toHaveTextContent('2');
+  });
+
+  it('sends physician_id as null after the practitioner is cleared', async () => {
+    renderInEditMode();
+
+    await screen.findByTestId('patient-form');
+    fireEvent.click(screen.getByTestId('clear-physician'));
+    fireEvent.click(screen.getByTestId('submit-form'));
+
+    await waitFor(() => expect(mockUpdatePatient).toHaveBeenCalled());
+
+    const [patientId, payload] = mockUpdatePatient.mock.calls[0];
+    expect(patientId).toBe(existingPatient.id);
+    expect(payload).toHaveProperty('physician_id', null);
+  });
+
+  it('keeps the assignment when the practitioner is left untouched', async () => {
+    renderInEditMode();
+
+    await screen.findByTestId('patient-form');
+    fireEvent.click(screen.getByTestId('submit-form'));
+
+    await waitFor(() => expect(mockUpdatePatient).toHaveBeenCalled());
+
+    expect(mockUpdatePatient.mock.calls[0][1]).toHaveProperty(
+      'physician_id',
+      existingPatient.physician_id
+    );
+  });
+});

--- a/tests/api/test_patient_management.py
+++ b/tests/api/test_patient_management.py
@@ -6,7 +6,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from app.models.models import User, Patient
+from app.models.models import Patient, Practitioner, User
 
 
 class TestPatientManagementAPI:
@@ -440,3 +440,196 @@ class TestPatientManagementAPI:
         )
 
         assert response.status_code == 422
+
+
+@pytest.fixture
+def patient_with_physician(
+    db_session: Session, test_patient: Patient, test_practitioner: Practitioner
+) -> Patient:
+    """A patient that already has a physician assigned."""
+    test_patient.physician_id = test_practitioner.id
+    db_session.commit()
+    db_session.refresh(test_patient)
+    return test_patient
+
+
+class TestPatientPhysicianAssignment:
+    """Regression tests for #995: removing a patient's assigned practitioner."""
+
+    def test_update_clears_physician_with_explicit_null(
+        self,
+        authenticated_client: TestClient,
+        db_session: Session,
+        patient_with_physician: Patient,
+    ):
+        """Regression test for #995: an explicit null must unassign the physician."""
+        response = authenticated_client.put(
+            f"/api/v1/patient-management/{patient_with_physician.id}",
+            json={"physician_id": None},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["physician_id"] is None
+
+        db_session.refresh(patient_with_physician)
+        assert patient_with_physician.physician_id is None
+
+    def test_update_without_physician_field_preserves_assignment(
+        self,
+        authenticated_client: TestClient,
+        db_session: Session,
+        patient_with_physician: Patient,
+        test_practitioner: Practitioner,
+    ):
+        """An omitted field must not be treated as a request to clear it."""
+        response = authenticated_client.put(
+            f"/api/v1/patient-management/{patient_with_physician.id}",
+            json={"address": "456 Unrelated Ave"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["physician_id"] == test_practitioner.id
+
+        db_session.refresh(patient_with_physician)
+        assert patient_with_physician.physician_id == test_practitioner.id
+
+    def test_update_assigns_physician(
+        self,
+        authenticated_client: TestClient,
+        db_session: Session,
+        test_patient: Patient,
+        test_practitioner: Practitioner,
+    ):
+        """Assigning a valid physician still works."""
+        response = authenticated_client.put(
+            f"/api/v1/patient-management/{test_patient.id}",
+            json={"physician_id": test_practitioner.id},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["physician_id"] == test_practitioner.id
+
+        db_session.refresh(test_patient)
+        assert test_patient.physician_id == test_practitioner.id
+
+    def test_update_unknown_physician_returns_400_not_500(
+        self, authenticated_client: TestClient, test_patient: Patient
+    ):
+        """Regression test for #995: an unknown physician must not surface as ISE-500."""
+        response = authenticated_client.put(
+            f"/api/v1/patient-management/{test_patient.id}",
+            json={"physician_id": 999999},
+        )
+
+        assert response.status_code == 400
+        assert "physician" in response.json()["message"].lower()
+
+    def test_create_unknown_physician_returns_400_not_500(
+        self, authenticated_client: TestClient
+    ):
+        """Create must reject an unknown physician the same way update does."""
+        response = authenticated_client.post(
+            "/api/v1/patient-management/",
+            json={
+                "first_name": "Unknown",
+                "last_name": "Physician",
+                "birth_date": "1990-01-01",
+                "physician_id": 999999,
+                "is_self_record": False,
+            },
+        )
+
+        assert response.status_code == 400
+        assert "physician" in response.json()["message"].lower()
+
+    def test_update_rejects_zero_physician_id(
+        self, authenticated_client: TestClient, test_patient: Patient
+    ):
+        """Zero is not a valid ID; null is the way to clear the assignment."""
+        response = authenticated_client.put(
+            f"/api/v1/patient-management/{test_patient.id}",
+            json={"physician_id": 0},
+        )
+
+        assert response.status_code == 422
+
+    def test_create_rejects_zero_physician_id(self, authenticated_client: TestClient):
+        """Create and update must agree that zero is invalid."""
+        response = authenticated_client.post(
+            "/api/v1/patient-management/",
+            json={
+                "first_name": "Zero",
+                "last_name": "Physician",
+                "birth_date": "1990-01-01",
+                "physician_id": 0,
+                "is_self_record": False,
+            },
+        )
+
+        assert response.status_code == 422
+
+
+class TestPatientNullableFieldClearing:
+    """Every nullable field was unclearable through this endpoint before #995."""
+
+    @pytest.mark.parametrize(
+        "field,initial_value",
+        [
+            ("address", "123 Clearable St"),
+            ("blood_type", "A+"),
+            ("gender", "F"),
+            ("height", 70.5),
+            ("weight", 180.25),
+            ("relationship_to_self", "child"),
+        ],
+    )
+    def test_explicit_null_clears_nullable_field(
+        self,
+        authenticated_client: TestClient,
+        db_session: Session,
+        test_patient: Patient,
+        field,
+        initial_value,
+    ):
+        """An explicit null must clear any nullable field, not just physician_id."""
+        setattr(test_patient, field, initial_value)
+        db_session.commit()
+
+        response = authenticated_client.put(
+            f"/api/v1/patient-management/{test_patient.id}",
+            json={field: None},
+        )
+
+        assert response.status_code == 200
+        assert response.json()[field] is None
+
+        db_session.refresh(test_patient)
+        assert getattr(test_patient, field) is None
+
+    @pytest.mark.parametrize(
+        "field,expected_value",
+        [
+            ("first_name", "Test"),
+            ("last_name", "User"),
+            ("birth_date", "1990-01-01"),
+        ],
+    )
+    def test_explicit_null_does_not_clear_required_field(
+        self,
+        authenticated_client: TestClient,
+        db_session: Session,
+        test_patient: Patient,
+        field,
+        expected_value,
+    ):
+        """Columns that are NOT NULL keep their value rather than failing the request."""
+        response = authenticated_client.put(
+            f"/api/v1/patient-management/{test_patient.id}",
+            json={field: None},
+        )
+
+        assert response.status_code == 200
+        assert response.json()[field] == expected_value
+
+        db_session.refresh(test_patient)
+        assert getattr(test_patient, field) is not None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -321,6 +321,21 @@ def default_specialty(db_session: Session):
 
 
 @pytest.fixture
+def test_practitioner(db_session: Session, default_specialty):
+    """Provide a persisted Practitioner row tests can assign as a physician."""
+    from app.models.practice import Practitioner
+
+    practitioner = Practitioner(
+        name="Dr. Test Practitioner",
+        specialty_id=default_specialty.id,
+    )
+    db_session.add(practitioner)
+    db_session.commit()
+    db_session.refresh(practitioner)
+    return practitioner
+
+
+@pytest.fixture
 def sample_practitioner_data(default_specialty):
     """Sample practitioner data for testing."""
     return {

--- a/tests/services/test_patient_physician_validation.py
+++ b/tests/services/test_patient_physician_validation.py
@@ -1,0 +1,87 @@
+"""
+Unit tests for physician validation in PatientManagementService.
+"""
+
+import pytest
+
+from app.models.models import Patient, Practitioner, User
+from app.services.patient_management import PatientManagementService
+
+
+class TestValidatePhysician:
+    """Regression tests for #995: an unknown physician must fail before the flush."""
+
+    @pytest.fixture
+    def service(self, db_session):
+        return PatientManagementService(db_session)
+
+    def test_update_rejects_unknown_physician(
+        self,
+        service: PatientManagementService,
+        test_user: User,
+        test_patient: Patient,
+    ):
+        with pytest.raises(ValueError, match="physician does not exist"):
+            service.update_patient(test_user, test_patient.id, {"physician_id": 999999})
+
+    def test_update_accepts_existing_physician(
+        self,
+        service: PatientManagementService,
+        test_user: User,
+        test_patient: Patient,
+        test_practitioner: Practitioner,
+    ):
+        updated = service.update_patient(
+            test_user, test_patient.id, {"physician_id": test_practitioner.id}
+        )
+
+        assert updated.physician_id == test_practitioner.id
+
+    def test_update_accepts_null_physician(
+        self,
+        service: PatientManagementService,
+        db_session,
+        test_user: User,
+        test_patient: Patient,
+        test_practitioner: Practitioner,
+    ):
+        test_patient.physician_id = test_practitioner.id
+        db_session.commit()
+
+        updated = service.update_patient(
+            test_user, test_patient.id, {"physician_id": None}
+        )
+
+        assert updated.physician_id is None
+
+    def test_create_rejects_unknown_physician(
+        self, service: PatientManagementService, test_user: User
+    ):
+        with pytest.raises(ValueError, match="physician does not exist"):
+            service.create_patient(
+                test_user,
+                {
+                    "first_name": "Unknown",
+                    "last_name": "Physician",
+                    "birth_date": "1990-01-01",
+                    "physician_id": 999999,
+                },
+            )
+
+    def test_create_accepts_existing_physician(
+        self,
+        service: PatientManagementService,
+        test_user: User,
+        test_practitioner: Practitioner,
+    ):
+        patient = service.create_patient(
+            test_user,
+            {
+                "first_name": "Known",
+                "last_name": "Physician",
+                "birth_date": "1990-01-01",
+                "physician_id": test_practitioner.id,
+            },
+        )
+
+        assert patient.physician_id == test_practitioner.id


### PR DESCRIPTION
Fixes #995

## Problem

Clearing a patient's assigned physician and saving silently did nothing — the record kept its old `physician_id`. Reproduced against the API directly:

| Payload to `PUT /api/v1/patient-management/{id}` | Before | After |
|---|---|---|
| `{"physician_id": null}` | 200, response still `physician_id: 2` | 200, `physician_id: null` |
| `{"physician_id": 0}` | 422 (correct) | 422 (unchanged) |
| `{"physician_id": <unknown id>}` | 500 `ISE-500` | 400 with a usable message |

## Root causes

Both backend. The frontend was already correct — the practitioner select emits `''` on clear, and `Patient-Info.jsx` already converted that to `null` before the request.

**1. The endpoint discarded every `null` before it reached the service.**

```python
patient_data = {k: v for k, v in patient_in.model_dump().items() if v is not None}
```

`model_dump()` without `exclude_unset` materialises every optional field as `None`, so the filter existed to stop unsent fields clobbering stored values — but it could not tell an unsent field from an explicit `null`. This made **every nullable field unclearable** through this endpoint, not just `physician_id`: `address`, `blood_type`, `gender`, `height`, `weight`, and `relationship_to_self` were all affected.

`app/crud/base.py` already did this correctly with `exclude_unset=True`, which is why the older `PUT /patients/me` path never had the bug. This endpoint had diverged from that convention.

**2. An unknown `physician_id` surfaced as an opaque 500.**

The service caught the FK `IntegrityError` and re-raised a bare `ValueError`. Nothing caught it — `handle_database_errors` only handles SQLAlchemy errors — so it fell through to the global `Exception` fallback handler and was reported as `ISE-500`.

## Changes

- `update_patient` now builds its payload from `model_dump(exclude_unset=True)`, with a guard that drops explicit nulls for NOT NULL columns. The guard set is **derived from the model** (`Patient.__table__.columns`) rather than hand-maintained, so it cannot go stale when a column is added.
- Both `create_patient` and `update_patient` map service `ValueError` to `BusinessLogicException` (400).
- New `PatientManagementService._validate_physician()` checks the practitioner exists *before* the flush, called from create and update. This keeps the error message deterministic across drivers: on SQLite the FK error text is `FOREIGN KEY constraint failed` (no `"physician"` substring), while Postgres yields `patients_physician_id_fkey` — relying on the existing string-matching backstop alone made the user-facing message database-dependent. The `IntegrityError` handling stays as defense-in-depth.
- `PatientCreateRequest.physician_id` gained `gt=0`, matching the update model.

## Semantics (now documented in the API reference)

- Omitted field: left unchanged
- Explicit `null`: clears the field
- Explicit `null` on `first_name` / `last_name` / `birth_date`: ignored, since those columns are NOT NULL. This is deliberate — the schema's `convert_empty_strings_to_none` already turns `first_name: ""` into `None`, so a 422 here would turn a silent no-op into a hard failure for existing clients.
- `0` is not a clear sentinel; use `null`.

## Tests

18 new backend tests, 3 new frontend tests. Verified as genuine regression tests: stashing only the `app/` changes makes 10 of them fail.

- `tests/api/test_patient_management.py` — physician clear/preserve/assign, unknown physician → 400 on both verbs, `0` → 422 on both verbs, parametrized clearing of all six nullable fields, and non-clearing of the three required ones
- `tests/services/test_patient_physician_validation.py` (new) — unit coverage for the pre-check
- `frontend/src/pages/medical/__tests__/PatientInfo.physician.test.jsx` (new) — pins the page's `'' → null` mapping, the one untested link in the frontend chain
- Shared `test_practitioner` fixture added to `tests/conftest.py`

## Verification

`pytest` (full suite), `black`, `bandit`, `npm run lint`, `npm run build`, and the frontend suite all pass. The 35 pre-existing failures in the full run (27 translation-key tests plus 8 others) reproduce identically on a clean tree and are unrelated.

**Not yet manually verified against a running instance** — the end-to-end walkthrough of the issue's reproduction steps still needs doing before release.

## Noted separately

- `PUT /patients/me` has the *same* unhandled-FK → ISE-500 problem via the CRUD path. `tests/api/test_patients.py::test_patient_physician_assignment` and `::test_patient_physician_invalid_assignment` already fail on `main` for this reason, and the latter's docstring still claims a non-existent ID "is accepted (200)" — untrue since FK enforcement was enabled in `conftest.py`. Out of scope here.
- Logged as tech debt: services raise bare `ValueError` at 111 sites across 19 services, but only 13 of 46 endpoint modules catch it. Every uncaught one is a latent ISE-500. Also logged: the two divergent patient write paths that made this bug possible.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to ensure physician IDs are positive and reference an existing practitioner.
  * Added support for clearing physician assignments and other nullable patient fields.
  * Improved partial patient updates, preserving omitted values and handling required fields safely.

* **Bug Fixes**
  * Invalid physician references now return clear client errors instead of server errors.

* **Documentation**
  * Expanded API guidance for validation errors, partial updates, and clearing fields.

* **Tests**
  * Added coverage for physician assignment, removal, validation, and nullable-field behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->