### PR TITLE
fix: make user preferences language nullable to support browser detection

### DIFF
--- a/alembic/migrations/versions/20260903_1200_e7f4a2b9c1d3_make_user_preferences_language_nullable.py
+++ b/alembic/migrations/versions/20260903_1200_e7f4a2b9c1d3_make_user_preferences_language_nullable.py
@@ -1,0 +1,43 @@
+"""Make user_preferences.language nullable
+
+Revision ID: e7f4a2b9c1d3
+Revises: add_lr_med_proc_tables
+Create Date: 2026-09-03 12:00:00.000000
+
+NULL records that the user has never chosen a language, which lets browser
+detection apply without overriding a deliberate choice of English.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e7f4a2b9c1d3"
+down_revision = "add_lr_med_proc_tables"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Batch mode keeps this migration runnable on SQLite for the round-trip test.
+    with op.batch_alter_table("user_preferences") as batch_op:
+        batch_op.alter_column(
+            "language",
+            existing_type=sa.String(10),
+            existing_nullable=False,
+            nullable=True,
+            server_default=None,
+        )
+
+
+def downgrade() -> None:
+    op.execute("UPDATE user_preferences SET language = 'en' WHERE language IS NULL")
+
+    with op.batch_alter_table("user_preferences") as batch_op:
+        batch_op.alter_column(
+            "language",
+            existing_type=sa.String(10),
+            existing_nullable=True,
+            nullable=False,
+            server_default="en",
+        )

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -130,8 +130,9 @@ class UserPreferences(Base):
     # Session timeout in minutes (default 120 minutes)
     session_timeout_minutes = Column(Integer, default=120, nullable=False)
 
-    # Language preference (ISO 639-1 code, e.g., 'en', 'es', 'fr')
-    language = Column(String(10), default="en", nullable=False)
+    # Language preference (ISO 639-1 code); NULL means the user never chose one,
+    # so browser detection applies instead of an assumed English
+    language = Column(String(10), nullable=True)
 
     # Date format preference: 'mdy' (US), 'dmy' (European), 'ymd' (ISO)
     date_format = Column(String(10), default="mdy", nullable=False)

--- a/app/schemas/user_preferences.py
+++ b/app/schemas/user_preferences.py
@@ -94,7 +94,7 @@ class UserPreferencesBase(BaseModel):
 
     unit_system: str
     session_timeout_minutes: Optional[int] = 120
-    language: Optional[str] = "en"
+    language: Optional[str] = None
     date_format: Optional[str] = "mdy"
     paperless_enabled: Optional[bool] = False
     paperless_url: Optional[str] = None

--- a/docs/developer-guide/02-api-reference.md
+++ b/docs/developer-guide/02-api-reference.md
@@ -513,6 +513,10 @@ Base path: `/api/v1/users`
 }
 ```
 
+- **Note**: `language` is `null` until the user explicitly picks one. Clients should
+  fall back to browser detection in that case and may persist the detected code with a
+  `PUT`; an explicit `"en"` is a real choice and overrides detection.
+
 ### Update User Preferences
 
 `PUT /users/me/preferences`

--- a/docs/developer-guide/03-database-schema.md
+++ b/docs/developer-guide/03-database-schema.md
@@ -245,6 +245,7 @@ JUNCTION TABLES (Many-to-Many)
 | user_id | Integer | FK(users.id), NOT NULL, UNIQUE | Associated user |
 | unit_system | String | NOT NULL, DEFAULT 'imperial' | imperial or metric |
 | session_timeout_minutes | Integer | NOT NULL, DEFAULT 30 | Session timeout duration |
+| language | String(10) | NULL | ISO 639-1 UI language; NULL means the user never chose one, so browser detection applies |
 | paperless_enabled | Boolean | NOT NULL, DEFAULT FALSE | Enable Paperless integration |
 | paperless_url | String(500) | | Paperless-ngx instance URL |
 | paperless_api_token_encrypted | Text | | Encrypted API token |

--- a/frontend/src/components/shared/LanguageSwitcher.tsx
+++ b/frontend/src/components/shared/LanguageSwitcher.tsx
@@ -4,6 +4,7 @@ import { Select } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import logger from '../../services/logger';
 import { useUserPreferences } from '../../contexts/UserPreferencesContext';
+import { LANGUAGES, normalizeLanguage } from '../../constants/languages';
 
 interface LanguageSwitcherProps {
   compact?: boolean;
@@ -11,44 +12,6 @@ interface LanguageSwitcherProps {
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
   comboboxWithinPortal?: boolean;
 }
-
-interface Language {
-  value: string;
-  label: string;
-  shortLabel: string;
-}
-
-// Available languages - defined outside component to avoid recreation
-const LANGUAGES: Language[] = [
-  { value: 'en', label: 'English', shortLabel: 'EN' },
-  { value: 'fr', label: 'Français', shortLabel: 'FR' },
-  { value: 'de', label: 'Deutsch', shortLabel: 'DE' },
-  { value: 'es', label: 'Español', shortLabel: 'ES' },
-  { value: 'it', label: 'Italiano', shortLabel: 'IT' },
-  { value: 'pt', label: 'Português', shortLabel: 'PT' },
-  { value: 'ru', label: 'Русский', shortLabel: 'RU' },
-  { value: 'sv', label: 'Svenska', shortLabel: 'SV' },
-  { value: 'nl', label: 'Nederlands', shortLabel: 'NL' },
-  { value: 'pl', label: 'Polski', shortLabel: 'PL' },
-  { value: 'zh', label: '中文', shortLabel: 'ZH' },
-  { value: 'el', label: 'Ελληνικά', shortLabel: 'EL' },
-];
-
-const SUPPORTED_LANGUAGE_CODES = LANGUAGES.map(l => l.value);
-
-/**
- * Normalizes a language code to match our supported languages.
- * Handles locale codes (e.g., 'en-US' -> 'en') and validates against supported languages.
- */
-const normalizeLanguage = (lang: string): string => {
-  if (!lang) return 'en';
-
-  // Extract primary language code (e.g., 'en-US' -> 'en')
-  const primaryLang = lang.split('-')[0].toLowerCase();
-
-  // Return the primary language if supported, otherwise fallback to 'en'
-  return SUPPORTED_LANGUAGE_CODES.includes(primaryLang) ? primaryLang : 'en';
-};
 
 /**
  * LanguageSwitcher - Component for switching application language

--- a/frontend/src/constants/languages.ts
+++ b/frontend/src/constants/languages.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared language configuration for the UI language switcher and preference sync.
+ * Keep in sync with SUPPORTED_LANGUAGES in app/schemas/user_preferences.py, which
+ * validates the API, and in app/services/report_translations.py, which renders PDFs.
+ */
+
+export interface Language {
+  value: string;
+  label: string;
+  shortLabel: string;
+}
+
+export const LANGUAGES: readonly Language[] = [
+  { value: 'en', label: 'English', shortLabel: 'EN' },
+  { value: 'fr', label: 'Français', shortLabel: 'FR' },
+  { value: 'de', label: 'Deutsch', shortLabel: 'DE' },
+  { value: 'es', label: 'Español', shortLabel: 'ES' },
+  { value: 'it', label: 'Italiano', shortLabel: 'IT' },
+  { value: 'pt', label: 'Português', shortLabel: 'PT' },
+  { value: 'ru', label: 'Русский', shortLabel: 'RU' },
+  { value: 'sv', label: 'Svenska', shortLabel: 'SV' },
+  { value: 'nl', label: 'Nederlands', shortLabel: 'NL' },
+  { value: 'pl', label: 'Polski', shortLabel: 'PL' },
+  { value: 'zh', label: '中文', shortLabel: 'ZH' },
+  { value: 'el', label: 'Ελληνικά', shortLabel: 'EL' },
+];
+
+export const SUPPORTED_LANGUAGE_CODES: readonly string[] = LANGUAGES.map(
+  l => l.value
+);
+
+export const DEFAULT_LANGUAGE = 'en';
+
+/** Reduces a locale code to its primary subtag, e.g. 'de-AT' to 'de'. */
+export const extractPrimaryLanguage = (lang: string): string =>
+  (lang || DEFAULT_LANGUAGE).split('-')[0].toLowerCase();
+
+/**
+ * Reduces a locale code to a supported language code.
+ *
+ * Falls back to DEFAULT_LANGUAGE for empty or unsupported input, so callers that
+ * need to tell "unsupported" apart from "English" must compare the raw code too.
+ */
+export const normalizeLanguage = (lang: string): string => {
+  const primaryLang = extractPrimaryLanguage(lang);
+
+  return SUPPORTED_LANGUAGE_CODES.includes(primaryLang)
+    ? primaryLang
+    : DEFAULT_LANGUAGE;
+};

--- a/frontend/src/contexts/UserPreferencesContext.jsx
+++ b/frontend/src/contexts/UserPreferencesContext.jsx
@@ -4,6 +4,7 @@ import {
   useState,
   useEffect,
   useCallback,
+  useRef,
 } from 'react';
 import {
   getUserPreferences,
@@ -85,6 +86,9 @@ export const UserPreferencesProvider = ({ children }) => {
   const [preferences, setPreferences] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  // The auto-detect write is not awaited on the load path, so an explicit choice
+  // made moments later must queue behind it or the server keeps whichever landed last.
+  const pendingDetectedLanguageWrite = useRef(null);
 
   // Load user preferences when authenticated user changes
   useEffect(() => {
@@ -108,7 +112,9 @@ export const UserPreferencesProvider = ({ children }) => {
           : detectedLanguageToPersist(user?.id);
 
         if (detected) {
-          updateUserPreferences({ language: detected })
+          pendingDetectedLanguageWrite.current = updateUserPreferences({
+            language: detected,
+          })
             .then(saved => {
               setPreferences(prev => (prev ? { ...prev, ...saved } : prev));
               frontendLogger.logInfo('Auto-detected language saved to backend', {
@@ -124,6 +130,9 @@ export const UserPreferencesProvider = ({ children }) => {
                 userId: user?.id,
                 component: 'UserPreferencesContext',
               });
+            })
+            .finally(() => {
+              pendingDetectedLanguageWrite.current = null;
             });
         }
 
@@ -181,6 +190,9 @@ export const UserPreferencesProvider = ({ children }) => {
   // Function to update preferences and save to server
   const updatePreferences = useCallback(async newPreferences => {
     try {
+      // Let an in-flight auto-detect write land first; it never rejects
+      await pendingDetectedLanguageWrite.current;
+
       // Save to server first
       const updatedPreferences = await updateUserPreferences(newPreferences);
 

--- a/frontend/src/contexts/UserPreferencesContext.jsx
+++ b/frontend/src/contexts/UserPreferencesContext.jsx
@@ -99,11 +99,16 @@ export const UserPreferencesProvider = ({ children }) => {
 
   // Load user preferences when authenticated user changes
   useEffect(() => {
+    // A logout or user switch mid-request must not let the old response apply its
+    // language or write its preferences over whoever is signed in now.
+    let cancelled = false;
+
     const loadPreferences = async () => {
       try {
         setLoading(true);
         setError(null);
         const userPrefs = await getUserPreferences();
+        if (cancelled) return;
 
         // A stored choice outranks browser detection on every device; with no
         // stored choice the browser decides.
@@ -114,6 +119,7 @@ export const UserPreferencesProvider = ({ children }) => {
 
         if (activeLanguage) {
           await applyLanguage(activeLanguage);
+          if (cancelled) return;
         }
 
         setPreferences(userPrefs);
@@ -126,6 +132,7 @@ export const UserPreferencesProvider = ({ children }) => {
             language: detected,
           })
             .then(saved => {
+              if (cancelled) return;
               setPreferences(prev => (prev ? { ...prev, ...saved } : prev));
               frontendLogger.logInfo('Auto-detected language saved to backend', {
                 language: detected,
@@ -157,6 +164,8 @@ export const UserPreferencesProvider = ({ children }) => {
           component: 'UserPreferencesContext',
         });
       } catch (err) {
+        if (cancelled) return;
+
         const errorMessage = err.message || 'Failed to load user preferences';
         setError(errorMessage);
 
@@ -181,7 +190,9 @@ export const UserPreferencesProvider = ({ children }) => {
           }
         );
       } finally {
-        setLoading(false);
+        if (!cancelled) {
+          setLoading(false);
+        }
       }
     };
 
@@ -198,6 +209,10 @@ export const UserPreferencesProvider = ({ children }) => {
         component: 'UserPreferencesContext',
       });
     }
+
+    return () => {
+      cancelled = true;
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only re-load on auth state or user ID change; full user object would re-trigger on every refresh
   }, [isAuthenticated, user?.id, authLoading]);
 

--- a/frontend/src/contexts/UserPreferencesContext.jsx
+++ b/frontend/src/contexts/UserPreferencesContext.jsx
@@ -15,27 +15,58 @@ import { PAPERLESS_SETTING_DEFAULTS } from '../constants/paperlessSettings';
 import { timezoneService } from '../services/timezoneService';
 import { DATE_FORMAT_OPTIONS, DEFAULT_DATE_FORMAT } from '../utils/constants';
 import i18n from '../i18n';
-
-// Supported languages - must match backend validation
-const SUPPORTED_LANGUAGES = [
-  'en',
-  'fr',
-  'de',
-  'es',
-  'it',
-  'pt',
-  'ru',
-  'sv',
-  'nl',
-  'pl',
-  'zh',
-  'el',
-];
+import {
+  DEFAULT_LANGUAGE,
+  SUPPORTED_LANGUAGE_CODES,
+  extractPrimaryLanguage,
+  normalizeLanguage,
+} from '../constants/languages';
 
 /**
  * User Preferences Context
  * Provides user preferences (including unit system) throughout the app
  */
+
+/** Applies a stored language choice to i18next, which outranks browser detection. */
+const applyStoredLanguage = async language => {
+  if (
+    !SUPPORTED_LANGUAGE_CODES.includes(language) ||
+    language === i18n.language
+  ) {
+    return;
+  }
+
+  try {
+    await i18n.changeLanguage(language);
+  } catch (langErr) {
+    frontendLogger.logError('Failed to apply saved language preference', {
+      language,
+      error: langErr.message,
+      component: 'UserPreferencesContext',
+    });
+  }
+};
+
+/** The detected language worth recording, or null when there is nothing to record. */
+const detectedLanguageToPersist = userId => {
+  const detectedRaw = extractPrimaryLanguage(i18n.language);
+  const detected = normalizeLanguage(detectedRaw);
+
+  if (detected !== DEFAULT_LANGUAGE) {
+    return detected;
+  }
+
+  if (detectedRaw !== DEFAULT_LANGUAGE) {
+    frontendLogger.logInfo('Browser language not supported, keeping default', {
+      browserLanguage: detectedRaw,
+      supportedLanguages: SUPPORTED_LANGUAGE_CODES,
+      userId,
+      component: 'UserPreferencesContext',
+    });
+  }
+
+  return null;
+};
 
 const UserPreferencesContext = createContext();
 
@@ -63,29 +94,38 @@ export const UserPreferencesProvider = ({ children }) => {
         setError(null);
         const userPrefs = await getUserPreferences();
 
-        // Apply the backend-stored language to i18next BEFORE updating React state.
-        // This ensures syncAutoDetectedLanguage never reads a stale i18n.language
-        // in the window between setPreferences and changeLanguage completing.
-        if (
-          userPrefs.language &&
-          SUPPORTED_LANGUAGES.includes(userPrefs.language) &&
-          userPrefs.language !== i18n.language
-        ) {
-          try {
-            await i18n.changeLanguage(userPrefs.language);
-          } catch (langErr) {
-            frontendLogger.logError(
-              'Failed to apply saved language preference',
-              {
-                language: userPrefs.language,
-                error: langErr.message,
-                component: 'UserPreferencesContext',
-              }
-            );
-          }
+        if (userPrefs.language) {
+          await applyStoredLanguage(userPrefs.language);
         }
 
         setPreferences(userPrefs);
+
+        // Record the detected language off the loading path, so a first login in a
+        // non-English browser is not delayed by a round trip. It matters only to
+        // server-rendered output (PDF reports, exports); i18next already has it.
+        const detected = userPrefs.language
+          ? null
+          : detectedLanguageToPersist(user?.id);
+
+        if (detected) {
+          updateUserPreferences({ language: detected })
+            .then(saved => {
+              setPreferences(prev => (prev ? { ...prev, ...saved } : prev));
+              frontendLogger.logInfo('Auto-detected language saved to backend', {
+                language: detected,
+                userId: user?.id,
+                component: 'UserPreferencesContext',
+              });
+            })
+            .catch(langErr => {
+              frontendLogger.logError('Failed to save auto-detected language', {
+                language: detected,
+                error: langErr.message,
+                userId: user?.id,
+                component: 'UserPreferencesContext',
+              });
+            });
+        }
 
         frontendLogger.logInfo('User preferences loaded', {
           unitSystem: userPrefs.unit_system,
@@ -169,55 +209,6 @@ export const UserPreferencesProvider = ({ children }) => {
       throw err;
     }
   }, []);
-
-  // Sync auto-detected language to backend on first login
-  useEffect(() => {
-    const syncAutoDetectedLanguage = async () => {
-      if (isAuthenticated && user && preferences && !loading) {
-        const currentLanguage = (i18n.language || 'en')
-          .split('-')[0]
-          .toLowerCase();
-        const savedLanguage = preferences.language;
-
-        // Only save if user has no language preference yet (still on default 'en')
-        // and their browser/system language is different AND supported
-        if (
-          savedLanguage === 'en' &&
-          currentLanguage !== 'en' &&
-          SUPPORTED_LANGUAGES.includes(currentLanguage)
-        ) {
-          try {
-            await updatePreferences({ language: currentLanguage });
-            frontendLogger.logInfo('Auto-detected language saved to backend', {
-              language: currentLanguage,
-              userId: user.id,
-              component: 'UserPreferencesContext',
-            });
-          } catch (error) {
-            frontendLogger.logError('Failed to save auto-detected language', {
-              error: error.message,
-              language: currentLanguage,
-              userId: user.id,
-              component: 'UserPreferencesContext',
-            });
-          }
-        } else if (savedLanguage === 'en' && currentLanguage !== 'en') {
-          // Log when browser language is not supported
-          frontendLogger.logInfo(
-            'Browser language not supported, keeping default',
-            {
-              browserLanguage: currentLanguage,
-              supportedLanguages: SUPPORTED_LANGUAGES,
-              userId: user.id,
-              component: 'UserPreferencesContext',
-            }
-          );
-        }
-      }
-    };
-
-    syncAutoDetectedLanguage();
-  }, [isAuthenticated, user, preferences, loading, updatePreferences]);
 
   // Sync date format locale to timezoneService when preferences change
   useEffect(() => {

--- a/frontend/src/contexts/UserPreferencesContext.jsx
+++ b/frontend/src/contexts/UserPreferencesContext.jsx
@@ -28,8 +28,8 @@ import {
  * Provides user preferences (including unit system) throughout the app
  */
 
-/** Applies a stored language choice to i18next, which outranks browser detection. */
-const applyStoredLanguage = async language => {
+/** Applies a language to i18next, tolerating a failed translation load. */
+const applyLanguage = async language => {
   if (
     !SUPPORTED_LANGUAGE_CODES.includes(language) ||
     language === i18n.language
@@ -48,9 +48,16 @@ const applyStoredLanguage = async language => {
   }
 };
 
-/** The detected language worth recording, or null when there is nothing to record. */
-const detectedLanguageToPersist = userId => {
-  const detectedRaw = extractPrimaryLanguage(i18n.language);
+/**
+ * The browser's language when it is worth recording, otherwise null.
+ *
+ * Reads navigator rather than i18n.language, which on a shared browser may still
+ * hold the language a previously signed-in user chose.
+ */
+const detectBrowserLanguage = userId => {
+  const detectedRaw = extractPrimaryLanguage(
+    navigator.languages?.[0] || navigator.language
+  );
   const detected = normalizeLanguage(detectedRaw);
 
   if (detected !== DEFAULT_LANGUAGE) {
@@ -98,8 +105,15 @@ export const UserPreferencesProvider = ({ children }) => {
         setError(null);
         const userPrefs = await getUserPreferences();
 
-        if (userPrefs.language) {
-          await applyStoredLanguage(userPrefs.language);
+        // A stored choice outranks browser detection on every device; with no
+        // stored choice the browser decides.
+        const detected = userPrefs.language
+          ? null
+          : detectBrowserLanguage(user?.id);
+        const activeLanguage = userPrefs.language || detected;
+
+        if (activeLanguage) {
+          await applyLanguage(activeLanguage);
         }
 
         setPreferences(userPrefs);
@@ -107,12 +121,8 @@ export const UserPreferencesProvider = ({ children }) => {
         // Record the detected language off the loading path, so a first login in a
         // non-English browser is not delayed by a round trip. It matters only to
         // server-rendered output (PDF reports, exports); i18next already has it.
-        const detected = userPrefs.language
-          ? null
-          : detectedLanguageToPersist(user?.id);
-
         if (detected) {
-          pendingDetectedLanguageWrite.current = updateUserPreferences({
+          const write = updateUserPreferences({
             language: detected,
           })
             .then(saved => {
@@ -132,8 +142,12 @@ export const UserPreferencesProvider = ({ children }) => {
               });
             })
             .finally(() => {
-              pendingDetectedLanguageWrite.current = null;
+              // A later login may already have queued its own write
+              if (pendingDetectedLanguageWrite.current === write) {
+                pendingDetectedLanguageWrite.current = null;
+              }
             });
+          pendingDetectedLanguageWrite.current = write;
         }
 
         frontendLogger.logInfo('User preferences loaded', {

--- a/frontend/src/contexts/UserPreferencesContext.test.jsx
+++ b/frontend/src/contexts/UserPreferencesContext.test.jsx
@@ -428,3 +428,49 @@ describe('UserPreferencesContext — one browser, successive users', () => {
     });
   });
 });
+
+describe('UserPreferencesContext — obsolete session responses', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    i18n.language = 'en';
+    setAuthUser(1);
+    setBrowserLanguage('en');
+  });
+
+  // The first user's request completes after the second user has already loaded
+  test('ignores a preferences response from a signed-out user', async () => {
+    let resolveFirstLoad;
+    vi.mocked(userPrefsApi.getUserPreferences)
+      .mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            resolveFirstLoad = () => resolve(makePrefs({ language: 'de' }));
+          })
+      )
+      .mockResolvedValueOnce(makePrefs({ language: 'fr' }));
+
+    const { result, rerender } = renderHook(() => useUserPreferences(), {
+      wrapper: UserPreferencesProvider,
+    });
+
+    await waitFor(() => {
+      expect(userPrefsApi.getUserPreferences).toHaveBeenCalledTimes(1);
+    });
+
+    setAuthUser(2);
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.preferences.language).toBe('fr');
+    });
+
+    await act(async () => {
+      resolveFirstLoad();
+    });
+
+    expect(result.current.preferences.language).toBe('fr');
+    expect(i18n.changeLanguage).not.toHaveBeenCalledWith('de');
+    expect(userPrefsApi.updateUserPreferences).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/contexts/UserPreferencesContext.test.jsx
+++ b/frontend/src/contexts/UserPreferencesContext.test.jsx
@@ -46,10 +46,12 @@ const makePrefs = (overrides = {}) => ({
   ...overrides,
 });
 
-// Renders the provider and returns a consumer that exposes the loaded language
+// Renders the provider and returns a consumer that exposes the loaded language.
+// 'unset' distinguishes a loaded-but-null language from a still-loading provider.
 const Consumer = () => {
-  const { preferences } = useUserPreferences();
-  return <div data-testid="lang">{preferences?.language ?? 'loading'}</div>;
+  const { preferences, loading } = useUserPreferences();
+  if (loading) return <div data-testid="lang">loading</div>;
+  return <div data-testid="lang">{preferences?.language ?? 'unset'}</div>;
 };
 
 const renderProvider = () =>
@@ -126,11 +128,72 @@ describe('UserPreferencesContext — language sync on load', () => {
       expect(userPrefsApi.getUserPreferences).toHaveBeenCalled();
     });
     expect(i18n.changeLanguage).not.toHaveBeenCalled();
+    expect(userPrefsApi.updateUserPreferences).not.toHaveBeenCalled();
   });
 
-  test('does not call i18n.changeLanguage when backend language is absent', async () => {
+  test('applies an explicit English choice over a non-English browser language', async () => {
+    i18n.language = 'de';
     vi.mocked(userPrefsApi.getUserPreferences).mockResolvedValue(
-      makePrefs({ language: undefined })
+      makePrefs({ language: 'en' })
+    );
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lang').textContent).toBe('en');
+    });
+    expect(i18n.changeLanguage).toHaveBeenCalledWith('en');
+    expect(userPrefsApi.updateUserPreferences).not.toHaveBeenCalled();
+  });
+});
+
+describe('UserPreferencesContext — auto-detect when no language is stored', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    i18n.language = 'en';
+  });
+
+  test('saves the detected language and keeps it in the UI', async () => {
+    i18n.language = 'de';
+    vi.mocked(userPrefsApi.getUserPreferences).mockResolvedValue(
+      makePrefs({ language: null })
+    );
+    vi.mocked(userPrefsApi.updateUserPreferences).mockResolvedValue(
+      makePrefs({ language: 'de' })
+    );
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lang').textContent).toBe('de');
+    });
+    expect(userPrefsApi.updateUserPreferences).toHaveBeenCalledWith({
+      language: 'de',
+    });
+    expect(i18n.changeLanguage).not.toHaveBeenCalled();
+  });
+
+  test('normalizes a regional browser locale before saving', async () => {
+    i18n.language = 'de-AT';
+    vi.mocked(userPrefsApi.getUserPreferences).mockResolvedValue(
+      makePrefs({ language: null })
+    );
+    vi.mocked(userPrefsApi.updateUserPreferences).mockResolvedValue(
+      makePrefs({ language: 'de' })
+    );
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(userPrefsApi.updateUserPreferences).toHaveBeenCalledWith({
+        language: 'de',
+      });
+    });
+  });
+
+  test('does not save when the detected language is English', async () => {
+    vi.mocked(userPrefsApi.getUserPreferences).mockResolvedValue(
+      makePrefs({ language: null })
     );
 
     renderProvider();
@@ -138,6 +201,51 @@ describe('UserPreferencesContext — language sync on load', () => {
     await waitFor(() => {
       expect(userPrefsApi.getUserPreferences).toHaveBeenCalled();
     });
+    expect(userPrefsApi.updateUserPreferences).not.toHaveBeenCalled();
     expect(i18n.changeLanguage).not.toHaveBeenCalled();
+  });
+
+  test('does not save an unsupported browser language and logs it', async () => {
+    i18n.language = 'xx';
+    vi.mocked(userPrefsApi.getUserPreferences).mockResolvedValue(
+      makePrefs({ language: null })
+    );
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(frontendLogger.logInfo).toHaveBeenCalledWith(
+        'Browser language not supported, keeping default',
+        expect.objectContaining({
+          browserLanguage: 'xx',
+          component: 'UserPreferencesContext',
+        })
+      );
+    });
+    expect(userPrefsApi.updateUserPreferences).not.toHaveBeenCalled();
+  });
+
+  test('still loads preferences when saving the detected language fails', async () => {
+    i18n.language = 'fr';
+    vi.mocked(userPrefsApi.getUserPreferences).mockResolvedValue(
+      makePrefs({ language: null })
+    );
+    vi.mocked(userPrefsApi.updateUserPreferences).mockRejectedValueOnce(
+      new Error('network down')
+    );
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(frontendLogger.logError).toHaveBeenCalledWith(
+        'Failed to save auto-detected language',
+        expect.objectContaining({
+          language: 'fr',
+          error: 'network down',
+          component: 'UserPreferencesContext',
+        })
+      );
+    });
+    expect(screen.getByTestId('lang').textContent).toBe('unset');
   });
 });

--- a/frontend/src/contexts/UserPreferencesContext.test.jsx
+++ b/frontend/src/contexts/UserPreferencesContext.test.jsx
@@ -1,5 +1,11 @@
 import { vi, describe, test, expect, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import {
+  act,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import {
   UserPreferencesProvider,
   useUserPreferences,
@@ -247,5 +253,62 @@ describe('UserPreferencesContext — auto-detect when no language is stored', ()
       );
     });
     expect(screen.getByTestId('lang').textContent).toBe('unset');
+  });
+});
+
+describe('UserPreferencesContext — auto-detect vs. manual write ordering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    i18n.language = 'en';
+  });
+
+  // A manual choice made while the auto-detect write is still in flight must be
+  // the last write the server sees, whatever order the responses would resolve in.
+  test('queues a manual language change behind the in-flight auto-detect write', async () => {
+    i18n.language = 'de';
+    vi.mocked(userPrefsApi.getUserPreferences).mockResolvedValue(
+      makePrefs({ language: null })
+    );
+
+    let resolveAutoWrite;
+    vi.mocked(userPrefsApi.updateUserPreferences)
+      .mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            resolveAutoWrite = () => resolve(makePrefs({ language: 'de' }));
+          })
+      )
+      .mockResolvedValueOnce(makePrefs({ language: 'fr' }));
+
+    const { result } = renderHook(() => useUserPreferences(), {
+      wrapper: UserPreferencesProvider,
+    });
+
+    await waitFor(() => {
+      expect(userPrefsApi.updateUserPreferences).toHaveBeenCalledWith({
+        language: 'de',
+      });
+    });
+
+    const manualWrite = result.current.updatePreferences({ language: 'fr' });
+
+    // The manual PUT must not be issued while the auto-detect write is pending
+    await Promise.resolve();
+    expect(userPrefsApi.updateUserPreferences).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveAutoWrite();
+      await manualWrite;
+    });
+
+    expect(userPrefsApi.updateUserPreferences).toHaveBeenNthCalledWith(1, {
+      language: 'de',
+    });
+    expect(userPrefsApi.updateUserPreferences).toHaveBeenNthCalledWith(2, {
+      language: 'fr',
+    });
+    await waitFor(() => {
+      expect(result.current.preferences.language).toBe('fr');
+    });
   });
 });

--- a/frontend/src/contexts/UserPreferencesContext.test.jsx
+++ b/frontend/src/contexts/UserPreferencesContext.test.jsx
@@ -30,13 +30,26 @@ vi.mock('../i18n', () => ({
   },
 }));
 
+// Mutable so a test can simulate one user signing out and another signing in
+const authState = {
+  isAuthenticated: true,
+  user: { id: 1, username: 'testuser' },
+  isLoading: false,
+};
+
 vi.mock('./AuthContext', () => ({
-  useAuth: () => ({
-    isAuthenticated: true,
-    user: { id: 1, username: 'testuser' },
-    isLoading: false,
-  }),
+  useAuth: () => authState,
 }));
+
+const setAuthUser = id => {
+  authState.user = { id, username: `testuser${id}` };
+};
+
+// The browser's language, which detection reads instead of i18next's current one
+const setBrowserLanguage = lang => {
+  vi.spyOn(navigator, 'languages', 'get').mockReturnValue([lang]);
+  vi.spyOn(navigator, 'language', 'get').mockReturnValue(lang);
+};
 
 // Minimal preferences response covering all fields read by the context
 const makePrefs = (overrides = {}) => ({
@@ -155,12 +168,15 @@ describe('UserPreferencesContext — language sync on load', () => {
 
 describe('UserPreferencesContext — auto-detect when no language is stored', () => {
   beforeEach(() => {
+    vi.restoreAllMocks();
     vi.clearAllMocks();
     i18n.language = 'en';
+    setAuthUser(1);
+    setBrowserLanguage('en');
   });
 
   test('saves the detected language and keeps it in the UI', async () => {
-    i18n.language = 'de';
+    setBrowserLanguage('de');
     vi.mocked(userPrefsApi.getUserPreferences).mockResolvedValue(
       makePrefs({ language: null })
     );
@@ -176,11 +192,11 @@ describe('UserPreferencesContext — auto-detect when no language is stored', ()
     expect(userPrefsApi.updateUserPreferences).toHaveBeenCalledWith({
       language: 'de',
     });
-    expect(i18n.changeLanguage).not.toHaveBeenCalled();
+    expect(i18n.changeLanguage).toHaveBeenCalledWith('de');
   });
 
   test('normalizes a regional browser locale before saving', async () => {
-    i18n.language = 'de-AT';
+    setBrowserLanguage('de-AT');
     vi.mocked(userPrefsApi.getUserPreferences).mockResolvedValue(
       makePrefs({ language: null })
     );
@@ -212,7 +228,7 @@ describe('UserPreferencesContext — auto-detect when no language is stored', ()
   });
 
   test('does not save an unsupported browser language and logs it', async () => {
-    i18n.language = 'xx';
+    setBrowserLanguage('xx');
     vi.mocked(userPrefsApi.getUserPreferences).mockResolvedValue(
       makePrefs({ language: null })
     );
@@ -232,7 +248,7 @@ describe('UserPreferencesContext — auto-detect when no language is stored', ()
   });
 
   test('still loads preferences when saving the detected language fails', async () => {
-    i18n.language = 'fr';
+    setBrowserLanguage('fr');
     vi.mocked(userPrefsApi.getUserPreferences).mockResolvedValue(
       makePrefs({ language: null })
     );
@@ -258,14 +274,17 @@ describe('UserPreferencesContext — auto-detect when no language is stored', ()
 
 describe('UserPreferencesContext — auto-detect vs. manual write ordering', () => {
   beforeEach(() => {
+    vi.restoreAllMocks();
     vi.clearAllMocks();
     i18n.language = 'en';
+    setAuthUser(1);
+    setBrowserLanguage('en');
   });
 
   // A manual choice made while the auto-detect write is still in flight must be
   // the last write the server sees, whatever order the responses would resolve in.
   test('queues a manual language change behind the in-flight auto-detect write', async () => {
-    i18n.language = 'de';
+    setBrowserLanguage('de');
     vi.mocked(userPrefsApi.getUserPreferences).mockResolvedValue(
       makePrefs({ language: null })
     );
@@ -309,6 +328,103 @@ describe('UserPreferencesContext — auto-detect vs. manual write ordering', () 
     });
     await waitFor(() => {
       expect(result.current.preferences.language).toBe('fr');
+    });
+  });
+});
+
+describe('UserPreferencesContext — one browser, successive users', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    i18n.language = 'en';
+    setAuthUser(1);
+    setBrowserLanguage('en');
+  });
+
+  // i18next still holds the first user's German after they sign out; the second
+  // user's own browser must decide, not the leftover state.
+  test('does not inherit the language of the previous user', async () => {
+    vi.mocked(userPrefsApi.getUserPreferences).mockResolvedValue(
+      makePrefs({ language: 'de' })
+    );
+
+    const { rerender } = renderHook(() => useUserPreferences(), {
+      wrapper: UserPreferencesProvider,
+    });
+
+    await waitFor(() => {
+      expect(i18n.changeLanguage).toHaveBeenCalledWith('de');
+    });
+
+    i18n.language = 'de';
+    vi.mocked(userPrefsApi.getUserPreferences).mockResolvedValue(
+      makePrefs({ language: null })
+    );
+    vi.mocked(userPrefsApi.updateUserPreferences).mockResolvedValue(
+      makePrefs({ language: 'en' })
+    );
+
+    setAuthUser(2);
+    rerender();
+
+    await waitFor(() => {
+      expect(userPrefsApi.getUserPreferences).toHaveBeenCalledTimes(2);
+    });
+    expect(userPrefsApi.updateUserPreferences).not.toHaveBeenCalled();
+    expect(i18n.changeLanguage).not.toHaveBeenCalledWith('de-DE');
+  });
+
+  // Each login queues its own write; the first to settle must not clear a newer one
+  test('keeps the newer auto-detect write pending when an older one settles', async () => {
+    setBrowserLanguage('de');
+    vi.mocked(userPrefsApi.getUserPreferences).mockResolvedValue(
+      makePrefs({ language: null })
+    );
+
+    const resolvers = [];
+    vi.mocked(userPrefsApi.updateUserPreferences).mockImplementation(
+      () => new Promise(resolve => resolvers.push(resolve))
+    );
+
+    const { result, rerender } = renderHook(() => useUserPreferences(), {
+      wrapper: UserPreferencesProvider,
+    });
+
+    await waitFor(() => {
+      expect(userPrefsApi.updateUserPreferences).toHaveBeenCalledTimes(1);
+    });
+
+    setAuthUser(2);
+    rerender();
+
+    await waitFor(() => {
+      expect(userPrefsApi.updateUserPreferences).toHaveBeenCalledTimes(2);
+    });
+
+    // The older write settles first
+    await act(async () => {
+      resolvers[0](makePrefs({ language: 'de' }));
+    });
+
+    const manualWrite = result.current.updatePreferences({ language: 'fr' });
+    await act(async () => {});
+
+    // The newer write is still pending, so the manual one must not have gone out
+    expect(userPrefsApi.updateUserPreferences).toHaveBeenCalledTimes(2);
+
+    // Once it settles, the manual write is released
+    resolvers[1](makePrefs({ language: 'de' }));
+    await waitFor(() => {
+      expect(userPrefsApi.updateUserPreferences).toHaveBeenCalledTimes(3);
+    });
+
+    await act(async () => {
+      resolvers[2](makePrefs({ language: 'fr' }));
+      await manualWrite;
+    });
+
+    expect(userPrefsApi.updateUserPreferences).toHaveBeenNthCalledWith(3, {
+      language: 'fr',
     });
   });
 });

--- a/frontend/src/i18n/config.ts
+++ b/frontend/src/i18n/config.ts
@@ -103,6 +103,8 @@ i18n
       loadPath: '/locales/{{lng}}/{{ns}}.json',
     },
 
+    // Provisional until login: UserPreferencesContext overrides this with the
+    // user's stored choice, or records what was detected here when there is none.
     detection: {
       order: ['localStorage', 'navigator'],
       caches: ['localStorage'],

--- a/tests/api/test_user_preferences_language.py
+++ b/tests/api/test_user_preferences_language.py
@@ -15,8 +15,10 @@ from tests.utils.user import create_random_user, create_user_authentication_head
 class TestUserPreferencesLanguage:
     """Test language preference management."""
 
-    def test_default_language_is_english(self, client: TestClient, db_session: Session):
-        """Test that new users get English as default language."""
+    def test_language_is_unset_for_new_users(
+        self, client: TestClient, db_session: Session
+    ):
+        """New users have no stored language, so the client can auto-detect one."""
         # Create a test user
         user_data = create_random_user(db_session)
         headers = create_user_authentication_headers(
@@ -30,7 +32,7 @@ class TestUserPreferencesLanguage:
 
         assert response.status_code == 200
         data = response.json()
-        assert data["language"] == "en"
+        assert data["language"] is None
 
     def test_update_language_to_french(self, client: TestClient, db_session: Session):
         """Test updating user language preference to French."""
@@ -256,9 +258,30 @@ class TestUserPreferencesLanguage:
 
         assert response.status_code == 200
         data = response.json()
-        # Language should still be default (en)
-        assert data["language"] == "en"
+        # Language stays unset - updating other fields must not imply a choice
+        assert data["language"] is None
         assert data["unit_system"] == "metric"
+
+    def test_explicit_english_is_stored(self, client: TestClient, db_session: Session):
+        """A deliberate choice of English must be distinguishable from no choice."""
+        user_data = create_random_user(db_session)
+        headers = create_user_authentication_headers(
+            client=client,
+            username=user_data["username"],
+            password=user_data["password"],
+        )
+
+        response = client.put(
+            "/api/v1/users/me/preferences",
+            headers=headers,
+            json={"language": "en"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["language"] == "en"
+
+        response = client.get("/api/v1/users/me/preferences", headers=headers)
+        assert response.json()["language"] == "en"
 
     def test_supported_languages_list(self, client: TestClient, db_session: Session):
         """Test that all supported languages can be set successfully."""
@@ -322,12 +345,12 @@ class TestLanguageValidation:
         with pytest.raises(ValueError, match="Language must be one of"):
             UserPreferencesUpdate(language="xx")
 
-    def test_language_defaults_to_en(self):
-        """Test that language defaults to 'en' when not specified."""
+    def test_language_defaults_to_unset(self):
+        """Test that language is None when not specified."""
         from app.schemas.user_preferences import UserPreferencesBase
 
         prefs = UserPreferencesBase(unit_system="imperial")
-        assert prefs.language == "en"
+        assert prefs.language is None
 
     def test_language_normalization_to_lowercase(self):
         """Test that language codes are normalized to lowercase."""
@@ -388,7 +411,7 @@ class TestLanguageCRUD:
         prefs = user_preferences.get_or_create_by_user_id(
             db_session, user_id=user_obj.id
         )
-        assert prefs.language == "en"
+        assert prefs.language is None
 
         # Update to German
         updated_prefs = user_preferences.update_by_user_id(

--- a/tests/unit/test_language_nullable_migration.py
+++ b/tests/unit/test_language_nullable_migration.py
@@ -1,0 +1,114 @@
+"""
+Round-trip test for the nullable-language Alembic migration.
+
+Spins up a minimal SQLite schema with a ``user_preferences`` table that mirrors the
+original NOT NULL DEFAULT 'en' column, runs ``upgrade`` then ``downgrade``, and
+asserts the nullability change is applied and reversed cleanly.
+"""
+
+import pytest
+from sqlalchemy import (
+    Column,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    create_engine,
+    inspect,
+)
+
+from tests.utils.migrations import run_migration
+
+MIGRATION_FILE = "20260903_1200_e7f4a2b9c1d3_make_user_preferences_language_nullable.py"
+
+
+@pytest.fixture
+def engine_with_baseline_preferences():
+    """In-memory SQLite engine with the pre-migration user_preferences shape."""
+    engine = create_engine("sqlite:///:memory:")
+    metadata = MetaData()
+    Table(
+        "user_preferences",
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("user_id", Integer, nullable=False, unique=True),
+        Column("unit_system", String, nullable=False, server_default="imperial"),
+        Column("language", String(10), nullable=False, server_default="en"),
+    )
+    metadata.create_all(engine)
+
+    with engine.begin() as conn:
+        conn.exec_driver_sql(
+            "INSERT INTO user_preferences (user_id, language) VALUES (1, 'en')"
+        )
+
+    yield engine
+    engine.dispose()
+
+
+def _language_column(engine):
+    return next(
+        c
+        for c in inspect(engine).get_columns("user_preferences")
+        if c["name"] == "language"
+    )
+
+
+class TestLanguageNullableMigration:
+    """Upgrade makes language nullable and default-free; downgrade restores it."""
+
+    def test_upgrade_makes_language_nullable(self, engine_with_baseline_preferences):
+        engine = engine_with_baseline_preferences
+
+        run_migration(engine, MIGRATION_FILE, "upgrade")
+
+        column = _language_column(engine)
+        assert column["nullable"] is True
+        assert column["default"] is None
+
+    def test_upgrade_preserves_existing_values(self, engine_with_baseline_preferences):
+        engine = engine_with_baseline_preferences
+
+        run_migration(engine, MIGRATION_FILE, "upgrade")
+
+        with engine.connect() as conn:
+            value = conn.exec_driver_sql(
+                "SELECT language FROM user_preferences WHERE user_id = 1"
+            ).scalar()
+        assert value == "en"
+
+    def test_upgrade_accepts_null_language(self, engine_with_baseline_preferences):
+        engine = engine_with_baseline_preferences
+
+        run_migration(engine, MIGRATION_FILE, "upgrade")
+
+        with engine.begin() as conn:
+            conn.exec_driver_sql(
+                "INSERT INTO user_preferences (user_id, language) VALUES (2, NULL)"
+            )
+            value = conn.exec_driver_sql(
+                "SELECT language FROM user_preferences WHERE user_id = 2"
+            ).scalar()
+        assert value is None
+
+    def test_downgrade_restores_not_null_and_backfills(
+        self, engine_with_baseline_preferences
+    ):
+        engine = engine_with_baseline_preferences
+
+        run_migration(engine, MIGRATION_FILE, "upgrade")
+        with engine.begin() as conn:
+            conn.exec_driver_sql(
+                "INSERT INTO user_preferences (user_id, language) VALUES (2, NULL)"
+            )
+
+        run_migration(engine, MIGRATION_FILE, "downgrade")
+
+        column = _language_column(engine)
+        assert column["nullable"] is False
+
+        with engine.connect() as conn:
+            value = conn.exec_driver_sql(
+                "SELECT language FROM user_preferences WHERE user_id = 2"
+            ).scalar()
+        assert value == "en"

--- a/tests/unit/test_medication_reminder_migration.py
+++ b/tests/unit/test_medication_reminder_migration.py
@@ -6,12 +6,7 @@ columns referenced by the migration, runs ``upgrade`` then ``downgrade``, and
 asserts the schema changes are applied and reversed cleanly.
 """
 
-import importlib.util
-from pathlib import Path
-
 import pytest
-from alembic.migration import MigrationContext
-from alembic.operations import Operations
 from sqlalchemy import (
     Column,
     Date,
@@ -23,25 +18,9 @@ from sqlalchemy import (
     inspect,
 )
 
+from tests.utils.migrations import run_migration
 
-# Loaded by file path — the repo's alembic/ directory is shadowed by the
-# installed alembic package, so a dotted import cannot reach it.
-MIGRATION_FILE = (
-    Path(__file__).resolve().parents[2]
-    / "alembic"
-    / "migrations"
-    / "versions"
-    / "20260609_1000_b3f7c1d9e2a4_add_reminders_to_medications.py"
-)
-
-
-def _load_migration_module():
-    spec = importlib.util.spec_from_file_location(
-        "reminder_migration_under_test", MIGRATION_FILE
-    )
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+MIGRATION_FILE = "20260609_1000_b3f7c1d9e2a4_add_reminders_to_medications.py"
 
 
 @pytest.fixture
@@ -71,30 +50,13 @@ def engine_with_baseline_medications():
     engine.dispose()
 
 
-def _run_migration(engine, direction: str) -> None:
-    """Run upgrade() or downgrade() in a proper Alembic operations context."""
-    module = _load_migration_module()
-    with engine.begin() as conn:
-        ctx = MigrationContext.configure(conn)
-        ops = Operations(ctx)
-        # The migration module reads ``from alembic import op`` at import time;
-        # rebinding that module-level name to our scoped Operations instance is
-        # the standard pattern for testing migrations in isolation.
-        original_op = module.op
-        module.op = ops
-        try:
-            getattr(module, direction)()
-        finally:
-            module.op = original_op
-
-
 class TestReminderColumnsMigration:
     """Upgrade adds the columns + index; downgrade removes them."""
 
     def test_upgrade_adds_columns_and_index(self, engine_with_baseline_medications):
         engine = engine_with_baseline_medications
 
-        _run_migration(engine, "upgrade")
+        run_migration(engine, MIGRATION_FILE, "upgrade")
 
         inspector = inspect(engine)
         column_names = {c["name"] for c in inspector.get_columns("medications")}
@@ -107,7 +69,7 @@ class TestReminderColumnsMigration:
     def test_existing_row_gets_default_false(self, engine_with_baseline_medications):
         engine = engine_with_baseline_medications
 
-        _run_migration(engine, "upgrade")
+        run_migration(engine, MIGRATION_FILE, "upgrade")
 
         with engine.connect() as conn:
             value = conn.exec_driver_sql(
@@ -120,8 +82,8 @@ class TestReminderColumnsMigration:
     ):
         engine = engine_with_baseline_medications
 
-        _run_migration(engine, "upgrade")
-        _run_migration(engine, "downgrade")
+        run_migration(engine, MIGRATION_FILE, "upgrade")
+        run_migration(engine, MIGRATION_FILE, "downgrade")
 
         inspector = inspect(engine)
         column_names = {c["name"] for c in inspector.get_columns("medications")}

--- a/tests/utils/migrations.py
+++ b/tests/utils/migrations.py
@@ -1,0 +1,34 @@
+"""Helpers for running a single Alembic migration against a throwaway engine."""
+
+import importlib.util
+from pathlib import Path
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+VERSIONS_DIR = (
+    Path(__file__).resolve().parents[2] / "alembic" / "migrations" / "versions"
+)
+
+
+def load_migration_module(filename: str):
+    """Import a migration by file name; a dotted import cannot reach alembic/."""
+    path = VERSIONS_DIR / filename
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def run_migration(engine, filename: str, direction: str) -> None:
+    """Run a migration's upgrade() or downgrade() in an Alembic operations context."""
+    module = load_migration_module(filename)
+    with engine.begin() as conn:
+        ops = Operations(MigrationContext.configure(conn))
+        # the module bound `op` at import time, so tests must rebind it
+        original_op = module.op
+        module.op = ops
+        try:
+            getattr(module, direction)()
+        finally:
+            module.op = original_op


### PR DESCRIPTION
## Summary

This pull request updates how user language preferences are handled and synced between the backend and frontend. The main improvement is that the `language` field in user preferences is now nullable, meaning new users have no default language set until they explicitly choose one. This allows the UI to auto-detect the language from the browser and persist it only if the user hasn't made a choice, improving the user experience for non-English speakers. The frontend and backend logic, as well as documentation and tests, have been updated to reflect this behavior.

**Backend changes:**

* The `language` field in the `user_preferences` table is now nullable; no default language is set for new users, allowing browser detection to apply if the user hasn’t chosen a language. [[1]](diffhunk://#diff-794ae773edd25975063df317aff91f679a7bbaa235ed2156c291fe6a008cad9bR1-R43) [[2]](diffhunk://#diff-d84bd67ad2b2725d57973696072a8912dacbc4592f364ec163a81a681ef1df44L133-R135) [[3]](diffhunk://#diff-b448b0cdd9571e72517c5253a26776ba2da704873639dd2f08d5e3f39547bfecL97-R97)
* API and database documentation updated to clarify that `language` is `null` until the user picks one, and to describe fallback behavior. [[1]](diffhunk://#diff-1a9fb546cf7d8e7fe373361c585bc639db88fcedb5c4939f6ce42b1cb8196f15R516-R519) [[2]](diffhunk://#diff-1ed4ba78cede8552f355229a24c22e10a0cd7e7c9aedfb072684e3457d26f30bR248)
* Tests updated to expect `language` to be `null` for new users rather than defaulting to `"en"`. [[1]](diffhunk://#diff-181ee167af060deec7fc5719979479249765710981171bae42f0dc3ed6593331L18-R21) [[2]](diffhunk://#diff-181ee167af060deec7fc5719979479249765710981171bae42f0dc3ed6593331L33-R35)

**Frontend changes:**

* Language constants and normalization logic moved to a shared module (`constants/languages.ts`) for consistency across the app. [[1]](diffhunk://#diff-2e1894ba7ca4dc48421f9a43118637be82ccaefa755e37b90a94045389e552e8R7) [[2]](diffhunk://#diff-2e1894ba7ca4dc48421f9a43118637be82ccaefa755e37b90a94045389e552e8L15-L52) [[3]](diffhunk://#diff-d74c9e8e91a39ddf6c2214564333548c27061f16ddb39b2aaa240f5d2a53ce5fR1-R50) [[4]](diffhunk://#diff-2a6ed226e1ba43eb965757dce729ace2aeca04a192834b8c881f6e09bb692458L18-R70)
* On first login, if no language is stored, the frontend auto-detects the browser language, normalizes it, and saves it to the backend if supported and not English; this avoids assuming English for users whose browser is set to another supported language. [[1]](diffhunk://#diff-2a6ed226e1ba43eb965757dce729ace2aeca04a192834b8c881f6e09bb692458L66-R129) [[2]](diffhunk://#diff-2a6ed226e1ba43eb965757dce729ace2aeca04a192834b8c881f6e09bb692458L173-L221)
* The context and tests for user preferences have been updated to handle the new nullable and auto-detection logic, including robust error handling and logging. [[1]](diffhunk://#diff-f0893f390120431ae6068fb74959844ed9bb6d830e1730c8f5562d959d06c39bL49-R54) [[2]](diffhunk://#diff-f0893f390120431ae6068fb74959844ed9bb6d830e1730c8f5562d959d06c39bR131-R250)
* i18n configuration and comments clarified to explain the provisional nature of detected language before login.

These changes ensure that language preference is only set by explicit user choice or by persisting a detected, supported, non-English language, improving internationalization support and user experience.

## Related issue

#988 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Translation / i18n
- [ ] Other



## Checklist

- [x] Tests added or updated (or N/A with reason)
- [ ] `npm run lint` and `npm run build` pass
- [x] Backend tests pass (`pytest`) if backend code changed
- [ ] No PHI, secrets, or `console.log` left in the diff
- [ ] User-facing strings go through `t()` translations
- [x] Documentation updated if API, schema, or service behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Language preferences are now optional. Until a user selects a language, the app detects the browser’s preferred language.
  - Detected languages are normalized to supported options and saved for future visits.
  - Explicitly selecting English remains distinct from having no language preference.

- **Bug Fixes**
  - Regional and unsupported browser locales are handled more consistently.
  - Preferences from a previous or signed-out session no longer override the active user’s settings.

- **Documentation**
  - Updated API and database documentation to explain language detection, persistence, and preference behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->