### PR TITLE
fix: enforce strict parsing for SSO_ENABLED to prevent misconfiguration

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -358,7 +358,12 @@ class Settings:  # App Info
     ADMIN_DEFAULT_PASSWORD: str = get_secret("ADMIN_DEFAULT_PASSWORD", "admin123")
 
     # SSO Configuration (Simple and Right-Sized)
-    SSO_ENABLED: bool = os.getenv("SSO_ENABLED", "False").lower() == "true"
+    #
+    # Parsed strictly, unlike the other booleans in this file, because it gates the
+    # two flags below that are parsed strictly already. Left loose, SSO_ENABLED=1
+    # reads False while SSO_ONLY_MODE=1 reads True, and the pairing check in
+    # validate_auth_mode_config() refuses the boot of an instance whose SSO works.
+    SSO_ENABLED: bool = _strict_bool("SSO_ENABLED")
     SSO_PROVIDER_TYPE: str = os.getenv("SSO_PROVIDER_TYPE", "oidc")
     SSO_CLIENT_ID: str = get_secret("SSO_CLIENT_ID", "")
     SSO_CLIENT_SECRET: str = get_secret("SSO_CLIENT_SECRET", "")

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -46,7 +46,9 @@ SSO_ALLOWED_DOMAINS=[]
 
 # SSO-only mode and IdP auto-redirect. Both default to false; both require
 # SSO_ENABLED=true. The container refuses to start if either is set without it,
-# rather than booting into an instance nobody can sign in to.
+# rather than booting into an instance nobody can sign in to. These two and
+# SSO_ENABLED accept true/false, 1/0, yes/no, on/off in any case; anything else
+# stops the container with an error naming the variable.
 #
 # SSO_ONLY_MODE=true     The server refuses password login and password
 #                        registration (403), and the login page hides the

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,8 @@
+# MediKeep. Every environment variable, Docker secrets (the _FILE pattern),
+# reverse-proxy setup and SSO configuration are documented here:
+# https://github.com/afairgiant/MediKeep/wiki/Developer-Guide
+
 services:
-  # PostgreSQL Database Service
   postgres:
     image: postgres:15.8-alpine
     container_name: medikeep-db
@@ -7,8 +10,6 @@ services:
       POSTGRES_DB: ${DB_NAME:-medical_records}
       POSTGRES_USER: ${DB_USER:-medapp}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
-      # For Docker secrets, use POSTGRES_PASSWORD_FILE instead (built-in to postgres image):
-      #POSTGRES_PASSWORD_FILE: /run/secrets/db_password
     volumes:
       - postgres_data-prod:/var/lib/postgresql/data
       - ./postgres/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
@@ -28,7 +29,6 @@ services:
     networks:
       - medikeep-network
 
-  # Combined Frontend + Backend Application Service
   medikeep-app:
     image: ghcr.io/afairgiant/medikeep:latest
     # build:
@@ -36,7 +36,7 @@ services:
     #   dockerfile: docker/Dockerfile
     container_name: medikeep-app
     ports:
-      - ${APP_PORT:-8005}:8000 # Single port serves both React app and FastAPI
+      - ${APP_PORT:-8005}:8000 # one port serves both the React app and the API
     environment:
       DB_HOST: postgres
       DB_PORT: 5432
@@ -48,13 +48,12 @@ services:
       ENABLE_API_DOCS: ${ENABLE_API_DOCS:-false}
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       TZ: ${TZ:-America/New_York}
-      # SSL Configuration - set ENABLE_SSL=true in .env to enable HTTPS
       ENABLE_SSL: ${ENABLE_SSL:-false}
-      # Integration URL SSRF control - Paperless/Papra on private LAN addresses
-      # is allowed by default; set false on internet-exposed instances to
-      # restrict to public URLs (169.254.x cloud-metadata is always blocked).
       #ALLOW_PRIVATE_INTEGRATION_URLS: ${ALLOW_PRIVATE_INTEGRATION_URLS:-true}
-      # SSO Configuration (Optional) - SSO is disabled by default
+      #ADMIN_DEFAULT_PASSWORD: ${ADMIN_DEFAULT_PASSWORD:-}
+      #PUID: ${PUID} # bind mounts only
+      #PGID: ${PGID} # bind mounts only
+
       SSO_ENABLED: ${SSO_ENABLED:-false}
       SSO_PROVIDER_TYPE: ${SSO_PROVIDER_TYPE:-oidc}
       SSO_CLIENT_ID: ${SSO_CLIENT_ID:-}
@@ -62,50 +61,21 @@ services:
       SSO_ISSUER_URL: ${SSO_ISSUER_URL:-}
       SSO_REDIRECT_URI: ${SSO_REDIRECT_URI:-}
       SSO_ALLOWED_DOMAINS: ${SSO_ALLOWED_DOMAINS:-[]}
-      # SSO-only front door. Both require SSO_ENABLED=true - the app refuses to
-      # start otherwise, rather than booting with no usable way to sign in.
+      # Both require SSO_ENABLED=true; the app refuses to start otherwise.
       SSO_ONLY_MODE: ${SSO_ONLY_MODE:-false}
       SSO_AUTO_REDIRECT: ${SSO_AUTO_REDIRECT:-false}
-      # Per-IP throttle on POST /auth/sso/initiate. Worth raising with
-      # SSO_AUTO_REDIRECT on, where every unauthenticated page load is one
-      # attempt. The defaults repeat config.py's because an empty value is not
-      # the same as an unset one here - the app parses these as integers, so
-      # `${VAR:-}` would fail the boot rather than fall back.
+      # Defaults repeated from config.py: these parse as integers, so an empty
+      # value fails the boot where an unset one would fall back.
       SSO_RATE_LIMIT_ATTEMPTS: ${SSO_RATE_LIMIT_ATTEMPTS:-30}
       SSO_RATE_LIMIT_WINDOW_MINUTES: ${SSO_RATE_LIMIT_WINDOW_MINUTES:-10}
-
-      # Peers whose X-Forwarded-For / X-Real-IP this app believes. Unset trusts the
-      # private ranges a reverse proxy connects from and ignores the header from
-      # anywhere else; 'none' trusts nothing. Pin an address to narrow it.
+      # Unset trusts the private ranges a reverse proxy connects from; 'none'
+      # trusts no forwarded header at all.
       TRUSTED_PROXY_IPS: ${TRUSTED_PROXY_IPS:-}
-
-      # Default Admin Password Configuration (optional - defaults to admin123 in app if not set)
-      #ADMIN_DEFAULT_PASSWORD: ${ADMIN_DEFAULT_PASSWORD:-}
-
-      #PUID: ${PUID} # Enable if using bind mounts
-      #PGID: ${PGID} # Enable if using bind mounts
-
-      # --- Docker Secrets (_FILE pattern) ---
-      # Instead of passing secrets as plain env vars, point to mounted files:
-      #DB_PASSWORD_FILE: /run/secrets/db_password
-      #SECRET_KEY_FILE: /run/secrets/secret_key
-      #SSO_CLIENT_ID_FILE: /run/secrets/sso_client_id
-      #SSO_CLIENT_SECRET_FILE: /run/secrets/sso_client_secret
-      #ADMIN_DEFAULT_PASSWORD_FILE: /run/secrets/admin_password
-      # When using _FILE vars, remove the corresponding plain env var above.
-    # secrets:
-    #   - db_password
-    #   - secret_key
-    #   - sso_client_id
-    #   - sso_client_secret
-    #   - admin_password
     volumes:
       - app_uploads:/app/uploads
       - app_logs:/app/logs
       - app_backups:/app/backups
-
-      # Uncomment the line below and create certificates if you want HTTPS
-      # - ./certs:/app/certs:ro
+      # - ./certs:/app/certs:ro # HTTPS, with ENABLE_SSL=true
     depends_on:
       postgres:
         condition: service_healthy
@@ -119,7 +89,6 @@ services:
     networks:
       - medikeep-network
 
-# Named volumes for data persistence
 volumes:
   postgres_data-prod:
     driver: local
@@ -130,20 +99,6 @@ volumes:
   app_backups:
     driver: local
 
-# --- Docker Secrets (uncomment to use with Docker Swarm or compose secrets) ---
-# secrets:
-#   db_password:
-#     file: ./secrets/db_password.txt
-#   secret_key:
-#     file: ./secrets/secret_key.txt
-#   sso_client_id:
-#     file: ./secrets/sso_client_id.txt
-#   sso_client_secret:
-#     file: ./secrets/sso_client_secret.txt
-#   admin_password:
-#     file: ./secrets/admin_password.txt
-
-# Network for service communication
 networks:
   medikeep-network:
     driver: bridge

--- a/docker/unraid-template.xml
+++ b/docker/unraid-template.xml
@@ -76,7 +76,7 @@
     Description="SSO Allowed Domains (JSON array)" Type="Variable" Display="advanced"
     Required="false" Mask="false">[]</Config>
   <Config Name="SSO Enabled" Target="SSO_ENABLED" Default="false" Mode=""
-    Description="Enable Single Sign-On" Type="Variable" Display="advanced" Required="false"
+    Description="Enable Single Sign-On. Accepted values are true/false, 1/0, yes/no, on/off - anything else stops the container with an error naming this variable." Type="Variable" Display="advanced" Required="false"
     Mask="false">false</Config>
   <Config Name="SSO Client ID" Target="SSO_CLIENT_ID" Default="" Mode=""
     Description="SSO Client ID (if SSO enabled)" Type="Variable" Display="advanced" Required="false"

--- a/docs/developer-guide/04-deployment.md
+++ b/docs/developer-guide/04-deployment.md
@@ -550,13 +550,16 @@ the offending variable named. This is deliberate: booting with password login re
 and no working SSO means nobody can sign in, and that is far harder to diagnose after
 the fact.
 
-**These two flags are parsed strictly.** `true`/`false`, `1`/`0`, `yes`/`no`, and
-`on`/`off` are accepted in any case; an empty value means unset. Anything else fails
-the boot with an error naming the variable and showing what it was set to, rather
-than being read as `false`. Everywhere else `false` merely means "off", but for
-`SSO_ONLY_MODE` it means password login is still open, so a misread value would leave
-an instance accepting credentials its operator believes are refused — with nothing in
-the logs to say so.
+**These two flags and `SSO_ENABLED` are parsed strictly.** `true`/`false`, `1`/`0`,
+`yes`/`no`, and `on`/`off` are accepted in any case; an empty value means unset.
+Anything else fails the boot with an error naming the variable and showing what it was
+set to, rather than being read as `false`. Everywhere else `false` merely means "off",
+but for `SSO_ONLY_MODE` it means password login is still open, so a misread value would
+leave an instance accepting credentials its operator believes are refused — with
+nothing in the logs to say so. `SSO_ENABLED` is parsed the same way because it gates
+the other two: read loosely, `SSO_ENABLED=1` would resolve to `false` while
+`SSO_ONLY_MODE=1` resolved to `true`, and that pairing refuses the boot of an instance
+whose SSO is configured and working.
 
 Compose strips `#` comments from env files when the hash is unquoted and preceded by a
 space, and trims whitespace. That holds after a quoted value too, so `true # sso only`

--- a/tests/api/test_sso_startup_validation.py
+++ b/tests/api/test_sso_startup_validation.py
@@ -14,7 +14,10 @@ so from the lifespan hook rather than as an import traceback.
 import asyncio
 import logging
 import os
+import subprocess
+import sys
 from contextlib import ExitStack, contextmanager
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -25,6 +28,8 @@ from app.core.auth_mode import no_local_password_warning
 from app.core.config import settings
 from app.main import app
 from app.models.user import User
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 STARTUP_LOGGER = "medical_records.app.core.startup"
 AUTH_MODE_LOGGER = "medical_records.app.core.auth_mode"
@@ -153,6 +158,44 @@ class TestFlagParsing:
         yield
         config._AUTH_FLAG_PARSE_ERRORS.clear()
         config._AUTH_FLAG_PARSE_ERRORS.update(original)
+
+    @pytest.mark.parametrize("raw", ["1", "yes", "on"])
+    def test_settings_reads_sso_enabled_through_the_strict_parser(self, raw):
+        """The wiring, not the helper - a test calling _strict_bool would pass either way.
+
+        SSO_ENABLED parsed loosely while SSO_ONLY_MODE parsed strictly meant
+        `SSO_ENABLED=1 SSO_ONLY_MODE=1` resolved to enabled=False, only=True, a
+        pairing validate_auth_mode_config() refuses - on an instance whose identity
+        provider was configured and working.
+
+        Run in a subprocess because the class body reads the environment once, at
+        import: reloading the module here would leave every other test in the suite
+        holding a different settings object.
+        """
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from app.core.config import settings;"
+                "print(f'PARSED={settings.SSO_ENABLED}')",
+            ],
+            env={**os.environ, "SSO_ENABLED": raw},
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+
+        assert "PARSED=True" in result.stdout, result.stdout + result.stderr
+
+    def test_an_unreadable_sso_enabled_aborts_the_boot(self):
+        with configured(AUTH_FLAG_PARSE_ERRORS={"SSO_ENABLED": "tru"}):
+            with pytest.raises(RuntimeError) as excinfo:
+                with TestClient(app):
+                    pass
+
+        message = str(excinfo.value)
+        assert "SSO_ENABLED" in message
+        assert "tru" in message
 
     @pytest.mark.parametrize(
         "raw", ["true", "TRUE", "True", "1", "yes", "on", " true "]


### PR DESCRIPTION
## Summary

This pull request strengthens and clarifies the way SSO (Single Sign-On) environment variables are parsed and documented, ensuring consistency and preventing misconfiguration that could lock out all users. It also improves related documentation, test coverage, and Docker configuration comments to match the stricter parsing logic.

**SSO Environment Variable Parsing and Validation**

* Changed `SSO_ENABLED` in `Settings` (`config.py`) to use strict boolean parsing, matching `SSO_ONLY_MODE` and `SSO_AUTO_REDIRECT`, so only recognized values (`true/false`, `1/0`, `yes/no`, `on/off`) are accepted. This prevents mismatches that could cause the app to refuse to start even with a working SSO setup.
* Updated the `.env.example`, Unraid template, and documentation to specify the accepted values for these SSO flags and clarify that anything else will halt the container with an error naming the offending variable. [[1]](diffhunk://#diff-ec10582dde9af6c0c622084d3244b29d496260613491c430ec8958565e2f31b4L49-R51) [[2]](diffhunk://#diff-67ee65eb09491b119a803fcedcb85d2e65d5f0a6ada141d85f65cf09d40b8803L79-R79) [[3]](diffhunk://#diff-077c15df273385c333c1fd4a881f7db85fc04c5a7b8e0a96edfbff20c18efd66L553-R562)

**Testing Enhancements**

* Added a test to ensure `SSO_ENABLED` is parsed strictly and that unreadable values abort the application boot, matching the stricter validation logic.
* Refactored the test setup for easier environment manipulation and subprocess testing. [[1]](diffhunk://#diff-5b15be8389743cf4da8dccf9cf84046eb74fc0b061d091ac8fb41a6dfb1282b6R17-R20) [[2]](diffhunk://#diff-5b15be8389743cf4da8dccf9cf84046eb74fc0b061d091ac8fb41a6dfb1282b6R32-R33)

**Docker Compose and Documentation Updates**

* Improved comments and documentation in `docker-compose.yml` and related files to reflect the strict parsing, clarify environment variable usage, and clean up/organize configuration examples. [[1]](diffhunk://#diff-423deb13b7c401b1a7f41ee91c77f722e11d2f317d6a66b546524e8a04cc8b03R1-L11) [[2]](diffhunk://#diff-423deb13b7c401b1a7f41ee91c77f722e11d2f317d6a66b546524e8a04cc8b03L31-R39) [[3]](diffhunk://#diff-423deb13b7c401b1a7f41ee91c77f722e11d2f317d6a66b546524e8a04cc8b03L51-R78) [[4]](diffhunk://#diff-423deb13b7c401b1a7f41ee91c77f722e11d2f317d6a66b546524e8a04cc8b03L122) [[5]](diffhunk://#diff-423deb13b7c401b1a7f41ee91c77f722e11d2f317d6a66b546524e8a04cc8b03L133-L146)

These changes help ensure that SSO configuration is robust, user error is minimized, and the deployment process is better documented and safer.


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Translation / i18n
- [ ] Other

## Testing

<!-- How did you verify this works? Manual steps, screenshots, or test names. -->

## Checklist

- [x] Tests added or updated (or N/A with reason)
- [x] `npm run lint` and `npm run build` pass
- [x] Backend tests pass (`pytest`) if backend code changed
- [ ] No PHI, secrets, or `console.log` left in the diff
- [ ] User-facing strings go through `t()` translations
- [x] Documentation updated if API, schema, or service behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - SSO configuration now consistently recognizes supported boolean values, including `1`, `yes`, and `on`.
  - Invalid `SSO_ENABLED` values now prevent startup and identify the affected setting and supplied value instead of being silently treated as disabled.

- **Documentation**
  - Updated deployment and container configuration guidance to document accepted boolean formats, defaults, validation behavior, and startup requirements for SSO-related settings.
  - Refined Docker Compose configuration comments and removed outdated commented secrets examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->