### PR TITLE
feat: add Meningococcal B and ABCWY vaccines to library 

### DIFF
--- a/frontend/src/constants/__tests__/vaccineLibrary.test.ts
+++ b/frontend/src/constants/__tests__/vaccineLibrary.test.ts
@@ -65,6 +65,21 @@ describe('searchVaccines', () => {
   test('returns empty array for nonsense query', () => {
     expect(searchVaccines('zzzz_no_such_vaccine')).toEqual([]);
   });
+
+  // Regression for issue #993: typing "Meningococcal B" only surfaced the
+  // ACWY entries, so the form showed "not linked to library" on save.
+  test.each([
+    ['Meningococcal B', 'MenB'],
+    ['MenB', 'MenB'],
+    ['Bexsero', 'MenB'],
+    ['Trumenba', 'MenB'],
+    ['Meningococcal ABCWY', 'MenABCWY'],
+    ['MenABCWY', 'MenABCWY'],
+    ['Penbraya', 'MenABCWY'],
+    ['Penmenvy', 'MenABCWY'],
+  ])('%s surfaces %s', (query, expected) => {
+    expect(searchVaccines(query).map(v => v.short_name)).toContain(expected);
+  });
 });
 
 describe('lookups', () => {

--- a/shared/data/vaccine_library.json
+++ b/shared/data/vaccine_library.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.4.0",
-  "lastUpdated": "2026-06-09",
+  "version": "1.5.0",
+  "lastUpdated": "2026-09-11",
   "_source": "WHO PreQualVaccineType FHIR CodeSystem (https://smart.who.int/pcmt-vaxprequal/CodeSystem-PreQualVaccineType.html) plus curated entries for common US/Western vaccines not in WHO PCMT (Tdap booster, Shingles, MMRV, Twinrix, etc.).",
   "vaccines": [
     {
@@ -1068,6 +1068,32 @@
       "default_manufacturer": null,
       "is_common": false,
       "display_order": null
+    },
+    {
+      "who_code": null,
+      "vaccine_name": "Meningococcal B",
+      "short_name": "MenB",
+      "category": "Bacterial",
+      "common_names": ["MenB", "Meningococcal B", "Meningococcal group B", "Bexsero", "Trumenba", "4CMenB", "MenB-4C", "MenB-FHbp"],
+      "is_combined": false,
+      "components": null,
+      "disease_keys": ["Meningococcal"],
+      "default_manufacturer": null,
+      "is_common": true,
+      "display_order": 46
+    },
+    {
+      "who_code": null,
+      "vaccine_name": "Meningococcal ABCWY",
+      "short_name": "MenABCWY",
+      "category": "Bacterial",
+      "common_names": ["MenABCWY", "Meningococcal ABCWY", "Penbraya", "Penmenvy", "Pentavalent meningococcal ABCWY"],
+      "is_combined": true,
+      "components": ["Meningococcal A", "Meningococcal B", "Meningococcal C", "Meningococcal Y", "Meningococcal W-135"],
+      "disease_keys": ["Meningococcal"],
+      "default_manufacturer": null,
+      "is_common": true,
+      "display_order": 47
     }
   ]
 }

--- a/tests/data/test_vaccine_library.py
+++ b/tests/data/test_vaccine_library.py
@@ -86,6 +86,7 @@ def test_combined_vaccines_have_at_least_two_disease_keys(library):
         "Meningococcal ACYW-135 (conjugate vaccine)",
         "Meningococcal ACYW-135 Tetanus Toxoid (conjugate vaccine)",
         "Meningococcal A+C (Polysaccharide)",
+        "Meningococcal ABCWY",
         "Polio Vaccine - Oral (OPV) Bivalent Types 1 and 3",
         "Polio Vaccine - Oral (OPV) Trivalent",
     }
@@ -93,6 +94,29 @@ def test_combined_vaccines_have_at_least_two_disease_keys(library):
     assert not bad, (
         "Combined vaccines (is_combined=True) should cover ≥2 diseases:\n" f"{bad}"
     )
+
+
+@pytest.mark.parametrize(
+    "vaccine_name,brands",
+    [
+        ("Meningococcal B", ("bexsero", "trumenba", "menb")),
+        ("Meningococcal ABCWY", ("penbraya", "penmenvy", "menabcwy")),
+    ],
+)
+def test_serogroup_b_vaccines_are_present_and_findable(library, vaccine_name, brands):
+    """Regression for issue #993: the library covered the ACWY serogroups but
+    nothing containing B, so these names and their brands resolved to nothing
+    and the immunization form reported the record as unlinked."""
+    entry = next(
+        (v for v in library["vaccines"] if v["vaccine_name"] == vaccine_name), None
+    )
+    assert entry is not None, f"{vaccine_name} missing from the vaccine library"
+    assert entry["disease_keys"] == ["Meningococcal"]
+    searchable = {n.lower() for n in entry.get("common_names") or []}
+    for brand in brands:
+        assert (
+            brand in searchable
+        ), f"{brand!r} missing from {vaccine_name} common_names"
 
 
 def test_polio_vaccines_share_one_disease_key(library):


### PR DESCRIPTION
## Summary

This pull request adds support for Meningococcal B and Meningococcal ABCWY vaccines to the vaccine library, addressing a regression where searches for these vaccines or their brand names did not surface any results. The update includes new entries in the vaccine library data, expanded test coverage to ensure these vaccines and their aliases are findable, and updates to regression tests to prevent similar issues in the future.

**Vaccine library updates:**

* Added new entries for `Meningococcal B` (`MenB`) and `Meningococcal ABCWY` (`MenABCWY`) to `vaccine_library.json`, including their common names and brands (e.g., Bexsero, Trumenba, Penbraya, Penmenvy) and marked them as common vaccines.
* Bumped the vaccine library version to `1.5.0` and updated the `lastUpdated` date.

**Test coverage and regression prevention:**

* Added parameterized tests in `test_vaccine_library.py` to verify that the new vaccines and their brand names are present and searchable in the library, preventing regressions like issue #993.
* Updated combined vaccine tests to include `Meningococcal ABCWY` in the set of combined vaccines.
* Added regression tests in `vaccineLibrary.test.ts` to ensure that searching for Meningococcal B/ABCWY and their brands surfaces the correct vaccine entries.

## Related issue

#993 
 
## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Translation / i18n
- [ ] Other


## Checklist

- [x] Tests added or updated (or N/A with reason)
- [x] `npm run lint` and `npm run build` pass
- [x] Backend tests pass (`pytest`) if backend code changed
- [ ] No PHI, secrets, or `console.log` left in the diff
- [ ] User-facing strings go through `t()` translations
- [ ] Documentation updated if API, schema, or service behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Meningococcal B and combined Meningococcal ABCWY vaccines to the vaccine library.
  * Added support for searching these vaccines by common names and brand names, including MenB, Bexsero, Trumenba, MenABCWY, Penbraya, and Penmenvy.

* **Bug Fixes**
  * Improved vaccine search results so relevant Meningococcal B and ABCWY entries appear for supported search terms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->